### PR TITLE
Decompress section data prior to use

### DIFF
--- a/samply/src/linux_shared/mod.rs
+++ b/samply/src/linux_shared/mod.rs
@@ -992,7 +992,7 @@ where
         };
 
         fn section_data<'a>(section: &impl ObjectSection<'a>) -> Option<Vec<u8>> {
-            section.data().ok().map(|data| data.to_owned())
+            section.uncompressed_data().ok().map(|data| data.to_vec())
         }
 
         let file = match object::File::parse(&mmap[..]) {


### PR DESCRIPTION
This doesn't matter for `.eh_frame`, but it does matter to dwarf data, which is often compressed. Accessing uncompressed data will result in a silent failure in `framehop`:

* https://github.com/mstange/framehop/blob/v0.7.2/src/unwinder.rs#L575