### PR TITLE
Add support for attaching profiler to a PID (Linux only). 

### DIFF
--- a/samply/src/main.rs
+++ b/samply/src/main.rs
@@ -102,7 +102,7 @@ struct ServerArgs {
     no_open: bool,
 
     /// The port to use for the local web server
-    #[arg(short, long, default_value = "3000+")]
+    #[arg(short = 'P', long, default_value = "3000+")]
     port: String,
 
     /// Print debugging output.


### PR DESCRIPTION
This adds support for attaching to a PID by `samply record -p 12345`.

I only implemented (and feature flagged) this for Linux, since the attaching story seems more complicated on the macOS side.