### PR TITLE
docs: Add alternatives for Linux setup using capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,25 @@ All data is kept locally (on disk and in RAM) until you choose to upload your pr
 
 samply is a sampling profiler and collects stack traces, per thread, at some sampling interval (the default 1000Hz, i.e. 1ms). On macOS, both on- and off-cpu samples are collected (so you can see under which stack you were blocking on a lock, for example). On Linux, only on-cpu samples are collected at the moment.
 
-On Linux, as samply needs access to performance events system by unprivileged users, run:
+On Linux, samply needs access to performance events system for unprivileged users. For this, you can either:
 
-```
-sudo sysctl kernel.perf_event_paranoid=1 
-```
+ - if using Linux 5.8 or later, set the `CAP_PERFMON` capability as effective and permitted for samply (recommended):
+
+   ```
+   sudo setcap 'cap_perfmon+ep' `which samply`
+   ```
+
+ - set the `CAP_SYS_ADMIN` capability as effective and permitted for samply:
+
+   ```
+   sudo setcap 'cap_sys_admin+ep' `which samply`
+   ```
+
+ - allow use of (almost) all events by changing the `perf_event_paranoid` kernel variable (not recommended):
+
+   ```
+   sudo sysctl kernel.perf_event_paranoid=-1 
+   ```
 
 If you still get a `mmap failed` error (an `EPERM`), you might also need to increase the `mlock` limit, e.g.:
 


### PR DESCRIPTION
Hi,

First, thank you for developing samply! :handshake:

I think the setup on Linux can be adapted so that one can use [capabilities](https://man7.org/linux/man-pages/man7/capabilities.7.html) instead of removing all checks by modifying `kernel.perf_event_paranoid`.

Also, there was a typo, and according to [this piece of documentation in the source of the kernel](https://www.kernel.org/doc/Documentation/sysctl/kernel.txt), `kernel.perf_event_paranoid` must be set to `-1` so that all users can inspect events.


What do you think?