### PR TITLE
Use the path of the original file to find the debuglink destination

### DIFF
--- a/samply-symbols/src/elf.rs
+++ b/samply-symbols/src/elf.rs
@@ -65,7 +65,7 @@ where
     let debug_id = debug_id_for_object(elf_file)?;
     let name = std::str::from_utf8(name).ok()?;
     let candidate_paths = helper
-        .get_candidate_paths_for_gnu_debug_link_dest(name)
+        .get_candidate_paths_for_gnu_debug_link_dest(original_file_location, name)
         .ok()?;
 
     for candidate_path in candidate_paths {

--- a/samply-symbols/src/shared.rs
+++ b/samply-symbols/src/shared.rs
@@ -320,6 +320,7 @@ pub trait FileAndPathHelper<'h> {
     /// TODO
     fn get_candidate_paths_for_gnu_debug_link_dest(
         &self,
+        _original_file_location: &Self::FL,
         _debug_link_name: &str,
     ) -> FileAndPathHelperResult<Vec<Self::FL>> {
         Ok(Vec::new())


### PR DESCRIPTION
As defined in https://www-zeuthen.desy.de/unix/unixguide/infohtml/gdb/Separate-Debug-Files.html:

> For the “debug link” method, gdb looks up the named file in the directory of the executable file, then in a subdirectory of that directory named .debug, and finally under the global debug directory, in a subdirectory whose name is identical to the leading directories of the executable's absolute file name. 

The paths were hardcoded by using the directories provided in the examples, which might not work, especially if the app is not installed via a package.

I'm not 100% sure of the assumptions I made to get the original file location as a `Path`.

Note that in the three cases it uses an absolute path but it might be enough to use a relative path for the two first locations.

Fixes #37 for me.