### PR TITLE
Upgrade addr2line to 0.20.0.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
+checksum = "f4fa78e18c64fce05e902adecd7a5eed15a5e0a3439f7b0e169f0252214865e3"
 dependencies = [
  "fallible-iterator",
  "gimli",
@@ -681,9 +681,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.27.0"
+version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec7af912d60cdbd3677c1af9352ebae6fb8394d165568a2234df0fa00f87793"
+checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
 dependencies = [
  "fallible-iterator",
  "indexmap",

--- a/samply-symbols/Cargo.toml
+++ b/samply-symbols/Cargo.toml
@@ -17,7 +17,7 @@ partial_read_stats = ["bytesize", "bitvec"]
 [dependencies.addr2line]
 default-features = false
 features = ["std", "fallible-iterator"]
-version = "0.19.0"
+version = "0.20.0"
 # path = "../../addr2line"
 
 [dependencies.gimli]

--- a/samply-symbols/src/dwarf.rs
+++ b/samply-symbols/src/dwarf.rs
@@ -16,7 +16,7 @@ pub fn get_frames<R: Reader>(
     context: Option<&addr2line::Context<R>>,
     path_mapper: &mut PathMapper<()>,
 ) -> Option<Vec<FrameDebugInfo>> {
-    let frame_iter = context?.find_frames(address).ok()?;
+    let frame_iter = context?.find_frames(address).skip_all_loads().ok()?;
     let frames: Vec<_> = frame_iter
         .map(|f| Ok(convert_stack_frame(f, &mut *path_mapper)))
         .collect()


### PR DESCRIPTION
This fixes an issue with DWARF 5 where the source file could not be identified.