### PR TITLE
Gate `query_json_api` behind a feature flag.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2244,6 +2244,7 @@ dependencies = [
  "libc",
  "reqwest",
  "samply-api",
+ "samply-symbols",
  "symsrv",
  "tokio",
  "uuid",

--- a/wholesym/Cargo.toml
+++ b/wholesym/Cargo.toml
@@ -11,9 +11,15 @@ repository = "https://github.com/mstange/samply"
 license = "MIT OR Apache-2.0"
 keywords = ["symbols", "profiling", "addr2line", "debuginfo"]
 
+[features]
+default = ["api"]
+# Enable the JSON API interface.
+api = ["samply-api"]
+
 [dependencies]
 debugid = "0.8.0"
-samply-api = { version = "0.21.1", path = "../samply-api", features = ["send_futures"] }
+samply-api = { version = "0.21.1", path = "../samply-api", features = ["send_futures"], optional = true }
+samply-symbols = { version = "0.20.0", path = "../samply-symbols", features = ["send_futures"] }
 symsrv = "0.2.0"
 yoke = { version = "0.6.2", features = ["derive"] }
 libc = "0.2.71"

--- a/wholesym/src/helper.rs
+++ b/wholesym/src/helper.rs
@@ -1,10 +1,7 @@
 use debugid::DebugId;
-use samply_api::samply_symbols::{
-    self, BreakpadIndex, BreakpadIndexParser, ElfBuildId, LibraryInfo, PeCodeId,
-};
 use samply_symbols::{
-    CandidatePathInfo, CodeId, FileAndPathHelper, FileAndPathHelperResult, FileLocation,
-    OptionallySendFuture,
+    BreakpadIndex, BreakpadIndexParser, CandidatePathInfo, CodeId, ElfBuildId, FileAndPathHelper,
+    FileAndPathHelperResult, FileLocation, LibraryInfo, OptionallySendFuture, PeCodeId,
 };
 use symsrv::{memmap2, FileContents, SymbolCache};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -330,7 +327,7 @@ impl Helper {
         let file = tokio::fs::File::create(&dest_path).await?;
         let mut writer = tokio::io::BufWriter::new(file);
         use futures_util::StreamExt;
-        let mut parser = samply_symbols::BreakpadIndexParser::new();
+        let mut parser = BreakpadIndexParser::new();
         while let Some(item) = stream.next().await {
             let item = item?;
             let mut item_slice = item.as_ref();

--- a/wholesym/src/lib.rs
+++ b/wholesym/src/lib.rs
@@ -149,8 +149,8 @@ mod moria_mac_spotlight;
 mod symbol_manager;
 
 pub use config::SymbolManagerConfig;
-pub use samply_api::samply_symbols;
-pub use samply_api::samply_symbols::{
+pub use samply_symbols;
+pub use samply_symbols::{
     AddressInfo, CodeId, ElfBuildId, Error, ExternalFileAddressInFileRef, ExternalFileAddressRef,
     ExternalFileRef, ExternalFileSymbolMap, FrameDebugInfo, FramesLookupResult, LibraryInfo,
     MappedPath, MultiArchDisambiguator, PeCodeId, SourceFilePath, SymbolInfo,

--- a/wholesym/src/moria_mac.rs
+++ b/wholesym/src/moria_mac.rs
@@ -4,7 +4,6 @@
 #![warn(clippy::all)]
 
 use object::Object;
-use samply_api::samply_symbols;
 use samply_symbols::object;
 use std::fs;
 use std::path::{Path, PathBuf};


### PR DESCRIPTION
This adds an `api` flag to possibly reduce the dependency chain (e.g. those huge `yaxpeax-*` crates in `samply-api`).

I considered also adding a `network` flag to disable `reqwest` and `symsrv`, however the line dividing code using these crates isn't as clear (some debuginfod and other things would have to be removed or replaced with panics). I might do this in the future if vendoring/auditing becomes a chore (not to mention it's a nice way to ensure that no network access will occur).