### PR TITLE
Linux: Use mio to get ring buffer notifications. 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,12 +167,11 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a246e68bb43f6cd9db24bea052a53e40405417c5fb372e3d1a8a7f770a564ef5"
+checksum = "6798148dccfbff0fae41c7574d2fa8f1ef3492fba0face179de5d8d447d67b05"
 dependencies = [
  "memchr",
- "once_cell",
  "regex-automata",
  "serde",
 ]
@@ -889,9 +888,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.139"
+version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "linear-map"
@@ -1037,14 +1036,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.5"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
+checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
 dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys 0.42.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1363,9 +1362,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.1.10"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+checksum = "fed1ceff11a1dddaee50c9dc8e4938bd106e9d89ae372f192311e7da498e3b69"
 
 [[package]]
 name = "reqwest"
@@ -1500,6 +1499,7 @@ dependencies = [
  "mach",
  "memchr",
  "memmap2",
+ "mio",
  "nix",
  "nix-base32",
  "num_cpus",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1254,9 +1254,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.56"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]

--- a/samply/Cargo.toml
+++ b/samply/Cargo.toml
@@ -41,6 +41,7 @@ wholesym = { version = "0.3.0", path = "../wholesym" }
 dirs = "5.0.0"
 once_cell = "1.17"
 fxhash = "0.2.1"
+mio = { version = "0.8.6", features = ["os-ext", "os-poll"] }
 
 [target.'cfg(any(target_os = "macos", target_os = "linux"))'.dependencies]
 


### PR DESCRIPTION
This makes the polling happen with epoll() instead of poll(), to cut down on FD registration overhead (there can be lots of perf FDs when attaching to a multithreaded process). It's also edge triggered, reducing false-positive notifications.

The reason to use mio instead of native epoll is:
- mio is a safe abstraction which saves us from inventing another.
- We already depend on mio through other async web runtime stuff.
- It integrates with native FDs without much boilerplate.

This also includes a version bump in lockfile for `proc-macro2` as it was breaking nightly build.