### PR TITLE
Decouple `serde` from its `derive` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -644,6 +644,7 @@ dependencies = [
  "debugid",
  "fxhash",
  "serde",
+ "serde_derive",
  "serde_json",
 ]
 
@@ -654,6 +655,7 @@ dependencies = [
  "assert-json-diff",
  "debugid",
  "serde",
+ "serde_derive",
  "serde_json",
 ]
 
@@ -1274,9 +1276,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.26"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
@@ -1533,6 +1535,7 @@ dependencies = [
  "memmap2",
  "samply-symbols",
  "serde",
+ "serde_derive",
  "serde_json",
  "serde_tuple",
  "thiserror",
@@ -1598,22 +1601,22 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.152"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
+checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.152"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
+checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.107",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -1766,9 +1769,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.15"
+version = "2.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
+checksum = "c324c494eba9d92503e6f1ef2e6df781e78f6a7705a0202d9801b198807d518a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1916,7 +1919,7 @@ checksum = "61a573bdc87985e9d6ddeed1b3d864e8a302c847e40d647746df2f1de209d1ce"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.29",
 ]
 
 [[package]]

--- a/fxprof-processed-profile/Cargo.toml
+++ b/fxprof-processed-profile/Cargo.toml
@@ -12,7 +12,8 @@ readme = "README.md"
 [dependencies]
 bitflags = "2.0"
 serde_json = "1.0"
-serde = { version = "1.0", features = ["derive"] }
+serde = "1.0.188"
+serde_derive = "1.0.188"
 debugid = "0.8.0"
 fxhash = "0.2.1"
 

--- a/fxprof-processed-profile/src/markers.rs
+++ b/fxprof-processed-profile/src/markers.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use serde::Serialize;
+use serde_derive::Serialize;
 use serde_json::Value;
 
 use super::timestamp::Timestamp;

--- a/gecko_profile/Cargo.toml
+++ b/gecko_profile/Cargo.toml
@@ -11,7 +11,8 @@ readme = "README.md"
 
 [dependencies]
 serde_json = "1.0"
-serde = { version = "1.0", features = ["derive"] }
+serde = "1.0.188"
+serde_derive = "1.0.188"
 debugid = "0.8.0"
 
 [dev-dependencies]

--- a/gecko_profile/src/markers.rs
+++ b/gecko_profile/src/markers.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use serde::Serialize;
+use serde_derive::Serialize;
 use serde_json::{json, Value};
 use std::time::Instant;
 

--- a/samply-api/Cargo.toml
+++ b/samply-api/Cargo.toml
@@ -16,7 +16,8 @@ send_futures = ["samply-symbols/send_futures"]
 [dependencies]
 samply-symbols = { version = "0.20.0", path = "../samply-symbols" }
 thiserror = "1.0.26"
-serde = { version = "1.0.126", features = ["derive"] }
+serde = "1.0.188"
+serde_derive = "1.0.188"
 serde_json = "1.0.64"
 serde_tuple = "0.5.0"
 yaxpeax-arch = { version = "0.2.7", default-features = false }

--- a/samply-api/src/asm/request_json.rs
+++ b/samply-api/src/asm/request_json.rs
@@ -1,4 +1,4 @@
-use serde::Deserialize;
+use serde_derive::Deserialize;
 
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]

--- a/samply-api/src/source/request_json.rs
+++ b/samply-api/src/source/request_json.rs
@@ -1,4 +1,4 @@
-use serde::Deserialize;
+use serde_derive::Deserialize;
 
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]

--- a/samply-api/src/symbolicate/request_json.rs
+++ b/samply-api/src/symbolicate/request_json.rs
@@ -1,4 +1,4 @@
-use serde::Deserialize;
+use serde_derive::Deserialize;
 
 #[derive(Deserialize, Debug)]
 #[serde(untagged)]

--- a/samply-api/src/symbolicate/response_json.rs
+++ b/samply-api/src/symbolicate/response_json.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use serde::Serialize;
+use serde_derive::Serialize;
 
 #[derive(Serialize, Debug)]
 pub struct Response {


### PR DESCRIPTION
By not activating the `derive` feature on `serde`, the compilation speed can be improved by a lot. This is because `serde` can then compile in parallel to `serde_derive`, allowing it to finish compilation possibly even before `serde_derive`, unblocking all the crates waiting for `serde` to start compiling much sooner.

As it turns out the main deciding factor for how long the compile time of a project is, is primarly determined by the depth of dependencies rather than the width. In other words, a crate's compile times aren't affected by how many crates it depends on, but rather by the longest chain of dependencies that it needs to wait on. In many cases `serde` is part of that long chain, as it is part of a long chain if the `derive` feature is active:

`proc-macro2` compile build script > `proc-macro2` run build script > `proc-macro2` > `quote` > `syn` > `serde_derive` > `serde` > `serde_json` (or any crate that depends on serde)

By decoupling it from `serde_derive`, the chain is shortened and compile times get much better.

Check this issue for a deeper elaboration:
https://github.com/serde-rs/serde/issues/2584

For `samply` I'm seeing a reduction from 5.43s to 3.70s when compiling `fxprof-processed-profile` in `release` mode.

![image](https://github.com/mstange/samply/assets/1451630/b87779f9-fd4a-4970-add6-df1e1f1d590d)

The impact is even larger for crates that depend on `fxprof-processed-profile` such as `wasmtime`.