### PR TITLE
Add --profile-name to record command

### DIFF
--- a/samply/src/linux/profiler.rs
+++ b/samply/src/linux/profiler.rs
@@ -32,6 +32,7 @@ pub type ConvertRegsNative = crate::linux_shared::ConvertRegsAarch64;
 #[allow(clippy::too_many_arguments)]
 pub fn start_recording(
     output_file: &Path,
+    profile_name: Option<String>,
     command_name: OsString,
     command_args: &[OsString],
     time_limit: Option<Duration>,
@@ -66,10 +67,9 @@ pub fn start_recording(
 
     // Launch the observer thread. This thread will manage the perf events.
     let output_file_copy = output_file.to_owned();
-    let command_name_copy = command_name.to_string_lossy().to_string();
+    let product = profile_name.unwrap_or_else(|| command_name.to_string_lossy().to_string());
     let conversion_args = conversion_args.clone();
     let observer_thread = thread::spawn(move || {
-        let product = command_name_copy;
         let mut converter = make_converter(interval, &product, &conversion_args);
 
         // Wait for the initial pid to profile.
@@ -191,6 +191,7 @@ pub fn start_recording(
 
 pub fn start_profiling_pid(
     output_file: &Path,
+    profile_name: Option<String>,
     pid: u32,
     time_limit: Option<Duration>,
     interval: Duration,
@@ -215,7 +216,7 @@ pub fn start_profiling_pid(
         crossbeam_channel::bounded(2);
 
     let output_file_copy = output_file.to_owned();
-    let product = format!("PID {pid}");
+    let product = profile_name.unwrap_or_else(|| format!("PID {pid}"));
     let conversion_args = conversion_args.clone();
     let observer_thread = thread::spawn({
         let stop = stop.clone();

--- a/samply/src/mac/profiler.rs
+++ b/samply/src/mac/profiler.rs
@@ -22,6 +22,7 @@ use crate::ConversionArgs;
 
 pub fn start_profiling_pid(
     _output_file: &Path,
+    _profile_name: Option<String>,
     _pid: u32,
     _time_limit: Option<Duration>,
     _interval: Duration,
@@ -36,6 +37,7 @@ pub fn start_profiling_pid(
 #[allow(clippy::too_many_arguments)]
 pub fn start_recording(
     output_file: &Path,
+    profile_name: Option<String>,
     command_name: OsString,
     command_args: &[OsString],
     time_limit: Option<Duration>,
@@ -47,9 +49,11 @@ pub fn start_recording(
     let (task_sender, task_receiver) = unbounded();
     let command_name_copy = command_name.to_string_lossy().to_string();
     let conversion_args = conversion_args.clone();
+    let product_name = profile_name.unwrap_or_else(|| command_name_copy.clone());
     let sampler_thread = thread::spawn(move || {
         let sampler = Sampler::new(
             command_name_copy,
+            product_name,
             task_receiver,
             interval,
             time_limit,

--- a/samply/src/mac/sampler.rs
+++ b/samply/src/mac/sampler.rs
@@ -26,6 +26,7 @@ pub struct TaskInit {
 }
 
 pub struct Sampler {
+    product_name: String,
     command_name: String,
     task_receiver: Receiver<TaskInit>,
     interval: Duration,
@@ -37,6 +38,7 @@ pub struct Sampler {
 impl Sampler {
     pub fn new(
         command: String,
+        product_name: String,
         task_receiver: Receiver<TaskInit>,
         interval: Duration,
         time_limit: Option<Duration>,
@@ -57,6 +59,7 @@ impl Sampler {
 
         Sampler {
             command_name,
+            product_name,
             task_receiver,
             interval,
             time_limit,
@@ -75,7 +78,7 @@ impl Sampler {
         };
 
         let mut profile = Profile::new(
-            &self.command_name,
+            &self.product_name,
             ReferenceTimestamp::from_system_time(reference_system_time),
             self.interval.into(),
         );

--- a/samply/src/main.rs
+++ b/samply/src/main.rs
@@ -98,6 +98,11 @@ struct RecordArgs {
     #[arg(short, long, default_value = "profile.json")]
     output: PathBuf,
 
+    /// Overwrite the name shown at the top of the profiler results
+    /// By default it is either the command that was run or the process pid.
+    #[arg(long)]
+    profile_name: Option<String>,
+
     /// How many times to run the profiled command.
     #[arg(long, default_value = "1")]
     iteration_count: u32,
@@ -191,6 +196,7 @@ fn main() {
             if let Some(pid) = record_args.pid {
                 profiler::start_profiling_pid(
                     &record_args.output,
+                    record_args.profile_name,
                     pid,
                     time_limit,
                     interval,
@@ -200,6 +206,7 @@ fn main() {
             } else {
                 let exit_status = match profiler::start_recording(
                     &record_args.output,
+                    record_args.profile_name,
                     record_args.command[0].clone(),
                     &record_args.command[1..],
                     time_limit,


### PR DESCRIPTION
Adds a `--profile-name` option to the record command that sets the "product" field in the output json so that the name in the top left hand corner of the profiler UI is set to the provided value.

I run a script that profiles my application under various scenarios and then opens all the results in my browser.
Currently the name in the corner is just set to the pid of the process which does not allow me to distinguish which tab corresponds to which scenario.
This PR fixes that.

Hovering over the profile name in the UI yields a tooltip "Edit the profile name".
So I think `--profile-name` is definitely the best name to expose to users

Example:
![image](https://github.com/mstange/samply/assets/5120858/2538a49e-493c-4d3f-825c-be5f48d26b4a)

Marked as draft for now to see if mac os passes CI.