### PR TITLE
fix cargo warning in rust 1.72

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,5 @@ members = [
     "tools/dump_table",
     "tools/query_api"
 ]
+resolver = "2"
 default-members = ["samply"]


### PR DESCRIPTION
When I run `cargo build` in the root of the repo I get:
```
warning: some crates are on edition 2021 which defaults to `resolver = "2"`, but virtual workspaces default to `resolver = "1"`
note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
note: to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest
```

This PR fixes that.