### PR TITLE
use libc::SYS_perf_event_open to linux sycall

### DIFF
--- a/samply/src/linux/sys.rs
+++ b/samply/src/linux/sys.rs
@@ -1,6 +1,6 @@
 #![allow(unused)]
 
-use libc::{c_int, c_ulong, pid_t, syscall};
+use libc::{c_int, c_ulong, pid_t, syscall, SYS_perf_event_open};
 use std::fmt;
 
 #[cfg(target_endian = "big")]
@@ -353,33 +353,6 @@ pub struct PerfEventHeader {
     pub size: u16,
 }
 
-#[cfg(target_arch = "x86")]
-const PERF_EVENT_OPEN: usize = 336;
-
-#[cfg(target_arch = "x86_64")]
-const PERF_EVENT_OPEN: usize = 298;
-
-#[cfg(target_arch = "mips")]
-const PERF_EVENT_OPEN: usize = 4333;
-
-#[cfg(target_arch = "powerpc")]
-const PERF_EVENT_OPEN: usize = 319;
-
-#[cfg(target_arch = "powerpc64")]
-const PERF_EVENT_OPEN: usize = 319;
-
-#[cfg(target_arch = "arm")]
-const PERF_EVENT_OPEN: usize = 364;
-
-#[cfg(target_arch = "sparc64")]
-const PERF_EVENT_OPEN: usize = 327;
-
-#[cfg(target_arch = "mips64")]
-const PERF_EVENT_OPEN: usize = 5292;
-
-#[cfg(target_arch = "aarch64")]
-const PERF_EVENT_OPEN: usize = 241;
-
 pub fn sys_perf_event_open(
     attr: &PerfEventAttr,
     pid: pid_t,
@@ -389,7 +362,7 @@ pub fn sys_perf_event_open(
 ) -> c_int {
     unsafe {
         syscall(
-            PERF_EVENT_OPEN as _,
+            SYS_perf_event_open,
             attr as *const _,
             pid,
             cpu,


### PR DESCRIPTION
This allows:  

- not redefine it our-self
- support all the architecture used by libc