### PR TITLE
Enable samply to run on Android

### DIFF
--- a/samply-api/src/symbolicate/mod.rs
+++ b/samply-api/src/symbolicate/mod.rs
@@ -143,7 +143,7 @@ fn gather_requested_addresses(
             for frame in &stack.0 {
                 requested_addresses_by_module_index
                     .entry(frame.module_index)
-                    .or_insert_with(Vec::new)
+                    .or_default()
                     .push(frame.address);
             }
         }
@@ -153,7 +153,7 @@ fn gather_requested_addresses(
             )?;
             requested_addresses
                 .entry((*lib).clone())
-                .or_insert_with(Vec::new)
+                .or_default()
                 .extend(addresses);
         }
     }

--- a/samply-symbols/src/lib.rs
+++ b/samply-symbols/src/lib.rs
@@ -446,7 +446,7 @@ where
         let candidate_paths_for_binary = self
             .helper
             .get_candidate_paths_for_binary(info)
-            .map_err(|e| Error::HelperErrorDuringGetCandidatePathsForBinary(e))?;
+            .map_err(Error::HelperErrorDuringGetCandidatePathsForBinary)?;
 
         let disambiguator = match (&info.debug_id, &info.arch) {
             (Some(debug_id), _) => Some(MultiArchDisambiguator::DebugId(*debug_id)),

--- a/samply/Cargo.toml
+++ b/samply/Cargo.toml
@@ -43,7 +43,7 @@ once_cell = "1.17"
 fxhash = "0.2.1"
 mio = { version = "0.8.6", features = ["os-ext", "os-poll"] }
 
-[target.'cfg(any(target_os = "macos", target_os = "linux"))'.dependencies]
+[target.'cfg(any(target_os = "android", target_os = "macos", target_os = "linux"))'.dependencies]
 
 libc = "0.2.71"
 crossbeam-channel = "0.5.4"
@@ -56,7 +56,7 @@ lazy_static = "1.4.0"
 flate2 = "1.0.23"
 sysctl = "0.5.4"
 
-[target.'cfg(target_os = "linux")'.dependencies]
+[target.'cfg(any(target_os = "android", target_os = "linux"))'.dependencies]
 
 parking_lot = "0.12.1"
 num_cpus = "1.13.1"

--- a/samply/src/main.rs
+++ b/samply/src/main.rs
@@ -1,7 +1,7 @@
 #[cfg(target_os = "macos")]
 mod mac;
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "android", target_os = "linux"))]
 mod linux;
 
 mod import;
@@ -22,7 +22,7 @@ use std::time::Duration;
 #[cfg(target_os = "macos")]
 pub use mac::{kernel_error, thread_act, thread_info};
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "android", target_os = "linux"))]
 use linux::profiler;
 #[cfg(target_os = "macos")]
 use mac::profiler;
@@ -64,7 +64,7 @@ enum Action {
     /// Load a profile from a file and display it.
     Load(LoadArgs),
 
-    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    #[cfg(any(target_os = "android", target_os = "macos", target_os = "linux"))]
     /// Record a profile and display it.
     Record(RecordArgs),
 }
@@ -176,7 +176,7 @@ fn main() {
             start_server_main(filename, load_args.server_args.server_props());
         }
 
-        #[cfg(any(target_os = "macos", target_os = "linux"))]
+        #[cfg(any(target_os = "android", target_os = "macos", target_os = "linux"))]
         Action::Record(record_args) => {
             let server_props = if record_args.save_only {
                 None
@@ -308,7 +308,7 @@ mod test {
         Opt::command().debug_assert();
     }
 
-    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    #[cfg(any(target_os = "android", target_os = "macos", target_os = "linux"))]
     #[test]
     fn verify_cli_record() {
         let opt = Opt::parse_from(["samply", "record", "rustup", "show"]);


### PR DESCRIPTION
Android is pretty much `linux` but needs to be enabled in the `target_os` guards. Tested on a headless Android 9 with 5.4.