### PR TITLE
Add Scala Native demangling and tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1774,6 +1774,7 @@ dependencies = [
  "pdb-addr2line",
  "rangemap",
  "rustc-demangle",
+ "scala-native-demangle",
  "srcsrv",
  "thiserror",
  "uuid",
@@ -1782,6 +1783,12 @@ dependencies = [
  "zerocopy",
  "zerocopy-derive",
 ]
+
+[[package]]
+name = "scala-native-demangle"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a4416eddc0eaf31e04aa4039bd3db4288ea1ba613955d86cf9c310049c5d1e2"
 
 [[package]]
 name = "scopeguard"

--- a/samply-symbols/Cargo.toml
+++ b/samply-symbols/Cargo.toml
@@ -38,6 +38,7 @@ thiserror = "1.0.57"
 cpp_demangle = "0.4.0"
 msvc-demangler = "0.10.0"
 rustc-demangle = "0.1.21"
+scala-native-demangle = "0.0.6" 
 bitflags = "2"
 bytesize = { version = "1.0.1", optional = true }
 bitvec = { version = "1.0.0", optional = true }

--- a/samply-symbols/src/demangle.rs
+++ b/samply-symbols/src/demangle.rs
@@ -14,6 +14,12 @@ pub fn demangle_any(name: &str) -> String {
         return msvc_demangler::demangle(name, flags).unwrap_or_else(|_| name.to_string());
     }
 
+    if name.starts_with("__S") {
+        if let Ok(symbol) = scala_native_demangle::demangle_with_defaults(&name[1..name.len()]) {
+            return symbol;
+        }
+    }
+
     if let Ok(demangled_symbol) = rustc_demangle::try_demangle(name) {
         return format!("{demangled_symbol:#}");
     }
@@ -36,4 +42,52 @@ pub fn demangle_any(name: &str) -> String {
     }
 
     name.to_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::demangle::demangle_any;
+    #[test]
+    fn cpp_demangling() {
+        assert_eq!(
+            demangle_any("_ZNK8KxVectorI16KxfArcFileRecordjEixEj"),
+            "KxVector<KxfArcFileRecord, unsigned int>::operator[](unsigned int) const"
+        )
+    }
+
+    #[test]
+    fn mscvc_demangling() {
+        assert_eq!(
+            demangle_any("??_R3?$KxSet@V?$KxSpe@DI@@I@@8"),
+            "KxSet<KxSpe<char, unsigned int>, unsigned int>::`RTTI Class Hierarchy Descriptor'"
+        )
+    }
+
+    #[test]
+    fn rust_demangling() {
+        assert_eq!(
+            demangle_any(
+                "_RNvMsr_NtCs3ssYzQotkvD_3std4pathNtB5_7PathBuf3newCs15kBYyAo9fc_7mycrate"
+            ),
+            "<std::path::PathBuf>::new"
+        )
+    }
+
+    #[test]
+    fn ocaml_demangling() {
+        assert_eq!(demangle_any("camlA__b__c_1002"), "A.b.c_1002")
+    }
+
+    #[test]
+    fn scala_native_demangling() {
+        assert_eq!(
+            demangle_any("__SM17java.lang.IntegerD7compareiiiEo"),
+            "java.lang.Integer.compare(Int,Int): Int"
+        )
+    }
+
+    #[test]
+    fn no_demangling() {
+        assert_eq!(demangle_any("_!!!!!!!bla"), "!!!!!!!bla")
+    }
 }


### PR DESCRIPTION
This PR adds demangling of [Scala Native](https://scala-native.org/en/stable/) symbols, using a crate I've written and updated specifically to be used in samply: https://crates.io/crates/scala-native-demangle

I've verified that demangling works:

![CleanShot 2024-03-07 at 09 58 21@2x](https://github.com/mstange/samply/assets/1052965/2ae49b9a-385f-47c3-ac70-b6069fabdc95)

The crate source is here: https://github.com/indoorvivants/scala-native-demangle-rs, it has no dependencies and as much as I can see with my very limited Rust ability, it shouldn't panic under normal circumstances.

Additionally, I put down some smoke tests for existing demanglers. 