### PR TITLE
Add categories for markers in MarkerTable.

### DIFF
--- a/fxprof-processed-profile/src/profile.rs
+++ b/fxprof-processed-profile/src/profile.rs
@@ -443,6 +443,7 @@ impl Profile {
     pub fn add_marker<T: ProfilerMarker>(
         &mut self,
         thread: ThreadHandle,
+        category: CategoryHandle,
         name: &str,
         marker: T,
         timing: MarkerTiming,
@@ -450,13 +451,14 @@ impl Profile {
         self.marker_schemas
             .entry(T::MARKER_TYPE_NAME)
             .or_insert_with(T::schema);
-        self.threads[thread.0].add_marker(name, marker, timing, None);
+        self.threads[thread.0].add_marker(category, name, marker, timing, None);
     }
 
     /// Add a marker to the given thread, with a stack.
     pub fn add_marker_with_stack<T: ProfilerMarker>(
         &mut self,
         thread: ThreadHandle,
+        category: CategoryHandle,
         name: &str,
         marker: T,
         timing: MarkerTiming,
@@ -466,7 +468,7 @@ impl Profile {
             .entry(T::MARKER_TYPE_NAME)
             .or_insert_with(T::schema);
         let stack_index = self.stack_index_for_frames(thread, stack_frames);
-        self.threads[thread.0].add_marker(name, marker, timing, stack_index);
+        self.threads[thread.0].add_marker(category, name, marker, timing, stack_index);
     }
 
     /// Add a data point to a counter. For a memory counter, `value_delta` is the number

--- a/fxprof-processed-profile/src/thread.rs
+++ b/fxprof-processed-profile/src/thread.rs
@@ -16,7 +16,7 @@ use crate::sample_table::SampleTable;
 use crate::stack_table::StackTable;
 use crate::string_table::{GlobalStringIndex, GlobalStringTable};
 use crate::thread_string_table::{ThreadInternalStringIndex, ThreadStringTable};
-use crate::{MarkerTiming, ProfilerMarker, Timestamp};
+use crate::{CategoryHandle, MarkerTiming, ProfilerMarker, Timestamp};
 
 /// A process. Can be created with [`Profile::add_process`](crate::Profile::add_process).
 #[derive(Debug, Clone, Copy, PartialOrd, Ord, PartialEq, Eq, Hash)]
@@ -143,6 +143,7 @@ impl Thread {
 
     pub fn add_marker<T: ProfilerMarker>(
         &mut self,
+        category: CategoryHandle,
         name: &str,
         marker: T,
         timing: MarkerTiming,
@@ -155,7 +156,8 @@ impl Thread {
                 obj.insert("cause".to_string(), json!({ "stack": stack_index }));
             }
         }
-        self.markers.add_marker(name_string_index, timing, data);
+        self.markers
+            .add_marker(category, name_string_index, timing, data);
     }
 
     pub fn contains_js_function(&self) -> bool {

--- a/fxprof-processed-profile/tests/integration_tests/main.rs
+++ b/fxprof-processed-profile/tests/integration_tests/main.rs
@@ -3,10 +3,10 @@ use debugid::DebugId;
 use serde_json::json;
 
 use fxprof_processed_profile::{
-    CategoryColor, CpuDelta, Frame, FrameFlags, FrameInfo, LibraryInfo, MarkerDynamicField,
-    MarkerFieldFormat, MarkerLocation, MarkerSchema, MarkerSchemaField, MarkerStaticField,
-    MarkerTiming, Profile, ProfilerMarker, ReferenceTimestamp, SamplingInterval, Symbol,
-    SymbolTable, Timestamp,
+    CategoryColor, CategoryHandle, CpuDelta, Frame, FrameFlags, FrameInfo, LibraryInfo,
+    MarkerDynamicField, MarkerFieldFormat, MarkerLocation, MarkerSchema, MarkerSchemaField,
+    MarkerStaticField, MarkerTiming, Profile, ProfilerMarker, ReferenceTimestamp, SamplingInterval,
+    Symbol, SymbolTable, Timestamp,
 };
 
 use std::sync::Arc;
@@ -271,12 +271,14 @@ fn profile_without_js() {
 
     profile.add_marker(
         thread,
+        CategoryHandle::OTHER,
         "Experimental",
         TextMarker("Hello world!".to_string()),
         MarkerTiming::Instant(Timestamp::from_millis_since_reference(0.0)),
     );
     profile.add_marker(
         thread,
+        CategoryHandle::OTHER,
         "CustomName",
         CustomMarker {
             event_name: "My event".to_string(),

--- a/samply/src/linux_shared/process.rs
+++ b/samply/src/linux_shared/process.rs
@@ -2,7 +2,8 @@ use std::path::{Path, PathBuf};
 
 use framehop::Unwinder;
 use fxprof_processed_profile::{
-    CounterHandle, LibraryHandle, MarkerTiming, ProcessHandle, Profile, ThreadHandle, Timestamp,
+    CategoryHandle, CounterHandle, LibraryHandle, MarkerTiming, ProcessHandle, Profile,
+    ThreadHandle, Timestamp,
 };
 
 use super::process_threads::ProcessThreads;
@@ -258,6 +259,7 @@ where
         let timing = MarkerTiming::Instant(profile_timestamp);
         profile.add_marker(
             main_thread,
+            CategoryHandle::OTHER,
             "JitFunctionAdd",
             JitFunctionAddMarker(symbol_name.unwrap_or("<unknown>").to_owned()),
             timing,

--- a/samply/src/shared/jitdump_manager.rs
+++ b/samply/src/shared/jitdump_manager.rs
@@ -1,5 +1,5 @@
 use fxprof_processed_profile::{
-    LibraryHandle, MarkerTiming, Profile, Symbol, SymbolTable, ThreadHandle,
+    CategoryHandle, LibraryHandle, MarkerTiming, Profile, Symbol, SymbolTable, ThreadHandle,
 };
 use linux_perf_data::jitdump::{JitDumpReader, JitDumpRecord, JitDumpRecordType};
 
@@ -183,6 +183,7 @@ impl SingleJitDumpProcessor {
                     let timing = MarkerTiming::Instant(timestamp);
                     profile.add_marker(
                         self.thread_handle,
+                        CategoryHandle::OTHER,
                         "JitFunctionAdd",
                         JitFunctionAddMarker(symbol_name.to_owned()),
                         timing,

--- a/samply/src/shared/process_sample_data.rs
+++ b/samply/src/shared/process_sample_data.rs
@@ -1,7 +1,7 @@
 use fxprof_processed_profile::{
-    CategoryPairHandle, LibMappings, MarkerDynamicField, MarkerFieldFormat, MarkerLocation,
-    MarkerSchema, MarkerSchemaField, MarkerStaticField, MarkerTiming, Profile, ProfilerMarker,
-    ThreadHandle, Timestamp,
+    CategoryHandle, CategoryPairHandle, LibMappings, MarkerDynamicField, MarkerFieldFormat,
+    MarkerLocation, MarkerSchema, MarkerSchemaField, MarkerStaticField, MarkerTiming, Profile,
+    ProfilerMarker, ThreadHandle, Timestamp,
 };
 use serde_json::json;
 
@@ -125,6 +125,7 @@ impl ProcessSampleData {
                     };
                     profile.add_marker_with_stack(
                         thread_handle,
+                        CategoryHandle::OTHER,
                         name,
                         RssStatMarker(size, delta),
                         timing,
@@ -136,6 +137,7 @@ impl ProcessSampleData {
                         let timing = MarkerTiming::Instant(timestamp);
                         profile.add_marker_with_stack(
                             thread_handle,
+                            CategoryHandle::OTHER,
                             name,
                             OtherEventMarker,
                             timing,
@@ -149,6 +151,7 @@ impl ProcessSampleData {
         for marker in marker_spans {
             profile.add_marker(
                 marker.thread_handle,
+                CategoryHandle::OTHER,
                 "SimpleMarker",
                 SimpleMarker(marker.name.clone()),
                 MarkerTiming::Interval(marker.start_time, marker.end_time),


### PR DESCRIPTION
* Introduce a new MarkerTableEntry type to alter a marker table entry after creation. It can add a category for the marker and will be easy to extend while preserving the public API in the future.

* Change the return type of `add_marker()` and `add_marker_with_stack()` functions from `()` to `MarkerTableEntry`. This means the `add_*` calls can now be chained with methods that apply on a MarkerTableEntry to alter the entry that was created; in particular to add a category.

This patch changes the public API of the crate. If users of the crate were calling `add_*` methods without a trailing `;`, they will now need to add that trailing `;`.