### PR TITLE
Add --unlink-aux-files option

### DIFF
--- a/samply/src/import/perf.rs
+++ b/samply/src/import/perf.rs
@@ -104,7 +104,7 @@ where
     let interpretation = EventInterpretation::divine_from_attrs(attributes);
 
     let mut converter = Converter::<U>::new(
-        &profile_creation_props.profile_name,
+        &profile_creation_props,
         Some(Box::new(move |name| {
             format!("{name} on {host} (perf version {perf_version})")
         })),
@@ -115,8 +115,6 @@ where
         cache,
         extra_dir,
         interpretation.clone(),
-        profile_creation_props.reuse_threads,
-        profile_creation_props.fold_recursive_prefix,
     );
 
     let mut last_timestamp = 0;

--- a/samply/src/linux/profiler.rs
+++ b/samply/src/linux/profiler.rs
@@ -356,7 +356,7 @@ fn make_converter(
     };
 
     Converter::<framehop::UnwinderNative<MmapRangeOrVec, framehop::MayAllocateDuringUnwind>>::new(
-        &profile_creation_props.profile_name,
+        &profile_creation_props,
         None,
         HashMap::new(),
         machine_info.as_ref().map(|info| info.release.as_str()),
@@ -365,8 +365,6 @@ fn make_converter(
         framehop::CacheNative::new(),
         None,
         interpretation,
-        profile_creation_props.reuse_threads,
-        profile_creation_props.fold_recursive_prefix,
     )
 }
 

--- a/samply/src/linux_shared/process.rs
+++ b/samply/src/linux_shared/process.rs
@@ -60,7 +60,7 @@ where
         Self {
             profile_process: process_handle,
             unwinder: U::default(),
-            jitdump_manager: JitDumpManager::new(),
+            jitdump_manager: JitDumpManager::new(false),
             lib_mapping_ops: Default::default(),
             name,
             pid,
@@ -181,7 +181,7 @@ where
             None
         };
 
-        let jitdump_manager = std::mem::replace(&mut self.jitdump_manager, JitDumpManager::new());
+        let jitdump_manager = std::mem::replace(&mut self.jitdump_manager, JitDumpManager::new(false));
         let jitdump_ops = jitdump_manager.finish(
             jit_category_manager,
             profile,

--- a/samply/src/linux_shared/process.rs
+++ b/samply/src/linux_shared/process.rs
@@ -56,11 +56,12 @@ where
         name: Option<String>,
         thread_recycler: Option<ThreadRecycler>,
         jit_function_recycler: Option<JitFunctionRecycler>,
+        unlink_aux_files: bool,
     ) -> Self {
         Self {
             profile_process: process_handle,
             unwinder: U::default(),
-            jitdump_manager: JitDumpManager::new(false),
+            jitdump_manager: JitDumpManager::new(unlink_aux_files),
             lib_mapping_ops: Default::default(),
             name,
             pid,
@@ -181,7 +182,8 @@ where
             None
         };
 
-        let jitdump_manager = std::mem::replace(&mut self.jitdump_manager, JitDumpManager::new(false));
+        let jitdump_manager =
+            std::mem::replace(&mut self.jitdump_manager, JitDumpManager::new(false));
         let jitdump_ops = jitdump_manager.finish(
             jit_category_manager,
             profile,

--- a/samply/src/linux_shared/processes.rs
+++ b/samply/src/linux_shared/processes.rs
@@ -25,13 +25,16 @@ where
 
     /// The sample data for all removed processes.
     process_sample_datas: Vec<ProcessSampleData>,
+
+    /// Whether aux files (like jitdump) should be unlinked on open
+    unlink_aux_data: bool,
 }
 
 impl<U> Processes<U>
 where
     U: Unwinder + Default,
 {
-    pub fn new(allow_reuse: bool) -> Self {
+    pub fn new(allow_reuse: bool, unlink_aux_data: bool) -> Self {
         let process_recycler = if allow_reuse {
             Some(ProcessRecycler::new())
         } else {
@@ -41,6 +44,7 @@ where
             processes_by_pid: HashMap::new(),
             process_recycler,
             process_sample_datas: Vec::new(),
+            unlink_aux_data,
         }
     }
 
@@ -70,6 +74,7 @@ where
                             name,
                             Some(thread_recycler),
                             Some(jit_function_recycler),
+                            self.unlink_aux_data,
                         );
                         return entry.insert(process);
                     }
@@ -101,6 +106,7 @@ where
                     name,
                     thread_recycler,
                     jit_function_recycler,
+                    self.unlink_aux_data,
                 );
                 entry.insert(process)
             }
@@ -130,6 +136,7 @@ where
                 None, // no name
                 thread_recycler,
                 jit_function_recycler,
+                self.unlink_aux_data,
             )
         })
     }

--- a/samply/src/mac/task_profiler.rs
+++ b/samply/src/mac/task_profiler.rs
@@ -254,7 +254,7 @@ impl TaskProfiler {
             ignored_errors: Vec::new(),
             unwinder: UnwinderNative::new(),
             path_receiver,
-            jitdump_manager: JitDumpManager::new(),
+            jitdump_manager: JitDumpManager::new(profile_creation_props.unlink_aux_files),
             marker_file_paths: Vec::new(),
             lib_mapping_ops: Default::default(),
             unresolved_samples: Default::default(),
@@ -602,6 +602,9 @@ impl TaskProfiler {
                         name: span.name,
                     }
                 }));
+                if self.profile_creation_props.unlink_aux_files {
+                    std::fs::remove_file(marker_file_path).ok();
+                }
             }
         }
         let process_sample_data = ProcessSampleData::new(

--- a/samply/src/main.rs
+++ b/samply/src/main.rs
@@ -180,6 +180,12 @@ pub struct ProfileCreationArgs {
     /// Fold repeated frames at the base of the stack.
     #[arg(long)]
     fold_recursive_prefix: bool,
+
+    /// If a process produces jitdump or marker files, unlink them after
+    /// opening. This ensures that the files will not be left in /tmp,
+    /// but it will also be impossible to look at JIT disassembly.
+    #[arg(long)]
+    unlink_aux_files: bool,
 }
 
 fn main() {
@@ -293,6 +299,7 @@ impl ImportArgs {
             profile_name,
             reuse_threads: self.profile_creation_args.reuse_threads,
             fold_recursive_prefix: self.profile_creation_args.fold_recursive_prefix,
+            unlink_aux_files: self.profile_creation_args.unlink_aux_files,
         }
     }
 }
@@ -371,6 +378,7 @@ impl RecordArgs {
             profile_name,
             reuse_threads: self.profile_creation_args.reuse_threads,
             fold_recursive_prefix: self.profile_creation_args.fold_recursive_prefix,
+            unlink_aux_files: self.profile_creation_args.unlink_aux_files,
         }
     }
 }

--- a/samply/src/main.rs
+++ b/samply/src/main.rs
@@ -183,7 +183,8 @@ pub struct ProfileCreationArgs {
 
     /// If a process produces jitdump or marker files, unlink them after
     /// opening. This ensures that the files will not be left in /tmp,
-    /// but it will also be impossible to look at JIT disassembly.
+    /// but it will also be impossible to look at JIT disassembly, and line
+    /// numbers will be missing for JIT frames.
     #[arg(long)]
     unlink_aux_files: bool,
 }

--- a/samply/src/shared/recording_props.rs
+++ b/samply/src/shared/recording_props.rs
@@ -17,6 +17,8 @@ pub struct ProfileCreationProps {
     pub reuse_threads: bool,
     /// Fold repeated frames at the base of the stack.
     pub fold_recursive_prefix: bool,
+    /// Unlink jitdump/marker files
+    pub unlink_aux_files: bool,
 }
 
 /// Properties which are meaningful for launching and recording a fresh process.


### PR DESCRIPTION
Adds an option to `record` to unlink jitdump/marker files after they've been read. Fixes #64.

.. though looking over this, I only added it to mac, will add to linux.