### PR TITLE
Support marker file paths with thread ID

### DIFF
--- a/samply/src/mac/task_profiler.rs
+++ b/samply/src/mac/task_profiler.rs
@@ -537,7 +537,8 @@ impl TaskProfiler {
                     // count the number of - characters in marker_file_path
                     let marker_info = marker_file::parse_marker_file_path(&marker_file_path);
                     let thread_handle = if marker_info.tid.is_some() {
-                        self.live_threads.iter()
+                        self.live_threads
+                            .iter()
                             .find(|(_, thread)| thread.tid == marker_info.tid.unwrap())
                             .map(|(_, thread)| thread.profile_thread)
                             .unwrap_or(self.main_thread_handle)

--- a/samply/src/mac/thread_profiler.rs
+++ b/samply/src/mac/thread_profiler.rs
@@ -25,8 +25,8 @@ use super::thread_info::{
 pub struct ThreadProfiler {
     thread_act: thread_act_t,
     name: Option<String>,
-    tid: u32,
-    profile_thread: ThreadHandle,
+    pub(crate) tid: u32,
+    pub(crate) profile_thread: ThreadHandle,
     tick_count: usize,
     stack_memory: ForeignMemory,
     previous_sample_cpu_time_us: u64,

--- a/samply/src/shared/marker_file.rs
+++ b/samply/src/shared/marker_file.rs
@@ -57,6 +57,29 @@ impl Iterator for MarkerFile {
     }
 }
 
+pub struct MarkerFileInfo {
+    pub prefix: String,
+    pub pid: u32,
+    pub tid: Option<u32>,
+}
+
+pub fn parse_marker_file_path(
+    path: &Path,
+) -> MarkerFileInfo {
+    let filename = path.file_name().unwrap().to_str().unwrap();
+    // strip .txt extension
+    let filename = &filename[..filename.len() - 4];
+    let mut parts = filename.splitn(3, '-');
+    let prefix = parts.next().unwrap().to_owned();
+    let pid = parts.next().unwrap().parse().unwrap();
+    let tid = parts.next().map(|tid| tid.parse().unwrap());
+    MarkerFileInfo {
+        prefix,
+        pid,
+        tid,
+    }
+}
+
 pub fn get_markers(
     marker_file: &Path,
     extra_dir: Option<&Path>,

--- a/samply/src/shared/marker_file.rs
+++ b/samply/src/shared/marker_file.rs
@@ -63,9 +63,7 @@ pub struct MarkerFileInfo {
     pub tid: Option<u32>,
 }
 
-pub fn parse_marker_file_path(
-    path: &Path,
-) -> MarkerFileInfo {
+pub fn parse_marker_file_path(path: &Path) -> MarkerFileInfo {
     let filename = path.file_name().unwrap().to_str().unwrap();
     // strip .txt extension
     let filename = &filename[..filename.len() - 4];
@@ -73,11 +71,7 @@ pub fn parse_marker_file_path(
     let prefix = parts.next().unwrap().to_owned();
     let pid = parts.next().unwrap().parse().unwrap();
     let tid = parts.next().map(|tid| tid.parse().unwrap());
-    MarkerFileInfo {
-        prefix,
-        pid,
-        tid,
-    }
+    MarkerFileInfo { prefix, pid, tid }
 }
 
 pub fn get_markers(

--- a/samply/src/shared/marker_file.rs
+++ b/samply/src/shared/marker_file.rs
@@ -63,6 +63,7 @@ pub struct MarkerFileInfo {
     pub tid: Option<u32>,
 }
 
+#[allow(unused)]
 pub fn parse_marker_file_path(path: &Path) -> MarkerFileInfo {
     let filename = path.file_name().unwrap().to_str().unwrap();
     // strip .txt extension


### PR DESCRIPTION
Adds support for marker files of the format `marker-pid-tid.txt` so that markers can be assigned the correct thread, if provided. Non-tid files still work fine and go to the main thread as before.