### PR TITLE
Add a --per-cpu-threads flag.

### DIFF
--- a/samply/src/linux_shared/converter.rs
+++ b/samply/src/linux_shared/converter.rs
@@ -31,6 +31,7 @@ use super::injected_jit_object::{correct_bad_perf_jit_so_file, jit_function_name
 use super::kernel_symbols::{kernel_module_build_id, KernelSymbols};
 use super::mmap_range_or_vec::MmapRangeOrVec;
 use super::pe_mappings::{PeMappings, SuspectedPeMapping};
+use super::per_cpu::Cpus;
 use super::processes::Processes;
 use super::rss_stat::{RssStat, MM_ANONPAGES, MM_FILEPAGES, MM_SHMEMPAGES, MM_SWAPENTS};
 use super::svma_file_range::compute_vma_bias;
@@ -70,6 +71,7 @@ where
     kernel_symbols: Option<KernelSymbols>,
     pe_mappings: PeMappings,
     jit_category_manager: JitCategoryManager,
+    cpus: Option<Cpus>,
 
     /// Whether repeated frames at the base of the stack should be folded
     /// into one frame.
@@ -98,7 +100,7 @@ where
             Some(nanos) => SamplingInterval::from_nanos(nanos),
             None => SamplingInterval::from_millis(1),
         };
-        let profile = Profile::new(
+        let mut profile = Profile::new(
             &profile_creation_props.profile_name,
             ReferenceTimestamp::from_system_time(SystemTime::now()),
             interval,
@@ -118,6 +120,13 @@ where
         let timestamp_converter = TimestampConverter {
             reference_raw: first_sample_time,
             raw_to_ns_factor: 1,
+        };
+
+        let cpus = if profile_creation_props.create_per_cpu_threads {
+            let start_timestamp = timestamp_converter.convert_time(first_sample_time);
+            Some(Cpus::new(start_timestamp, &mut profile))
+        } else {
+            None
         };
 
         Self {
@@ -143,6 +152,7 @@ where
             pe_mappings: PeMappings::new(),
             jit_category_manager: JitCategoryManager::new(),
             fold_recursive_prefix: profile_creation_props.fold_recursive_prefix,
+            cpus,
         }
     }
 
@@ -241,6 +251,46 @@ where
             1,
             None,
         );
+
+        if let (Some(cpu_index), Some(cpus)) = (e.cpu, &mut self.cpus) {
+            let cpu = cpus.get_mut(cpu_index as usize, &mut self.profile);
+
+            let thread_handle = cpu.thread_handle;
+
+            // Consume idle cpu time.
+            let _idle_cpu_sample = self
+                .context_switch_handler
+                .handle_on_cpu_sample(timestamp, &mut cpu.context_switch_data);
+
+            let cpu_delta = if self.off_cpu_indicator.is_some() {
+                CpuDelta::from_nanos(
+                    self.context_switch_handler
+                        .consume_cpu_delta(&mut cpu.context_switch_data),
+                )
+            } else {
+                CpuDelta::from_nanos(0)
+            };
+
+            process.unresolved_samples.add_sample(
+                thread_handle,
+                profile_timestamp,
+                timestamp,
+                stack_index,
+                cpu_delta,
+                1,
+                Some(thread.thread_label_frame.clone()),
+            );
+
+            process.unresolved_samples.add_sample(
+                cpus.combined_thread_handle(),
+                profile_timestamp,
+                timestamp,
+                stack_index,
+                CpuDelta::ZERO,
+                1,
+                Some(thread.thread_label_frame.clone()),
+            );
+        }
     }
 
     pub fn handle_sched_switch_sample<C: ConvertRegs<UnwindRegs = U::UnwindRegs>>(
@@ -661,10 +711,21 @@ where
                         &mut process.unresolved_samples,
                     );
                 }
+                if let (Some(cpus), Some(cpu_index)) = (&mut self.cpus, common.cpu) {
+                    let cpu = cpus.get_mut(cpu_index as usize, &mut self.profile);
+                    let _idle_cpu_sample = self
+                        .context_switch_handler
+                        .handle_switch_in(timestamp, &mut cpu.context_switch_data);
+                }
             }
             ContextSwitchRecord::Out { .. } => {
                 self.context_switch_handler
                     .handle_switch_out(timestamp, &mut thread.context_switch_data);
+                if let (Some(cpus), Some(cpu_index)) = (&mut self.cpus, common.cpu) {
+                    let cpu = cpus.get_mut(cpu_index as usize, &mut self.profile);
+                    self.context_switch_handler
+                        .handle_switch_out(timestamp, &mut cpu.context_switch_data);
+                }
             }
         }
     }

--- a/samply/src/linux_shared/mod.rs
+++ b/samply/src/linux_shared/mod.rs
@@ -8,6 +8,7 @@ mod kernel_symbols;
 mod mmap_range_or_vec;
 mod object_rewriter;
 mod pe_mappings;
+mod per_cpu;
 mod process;
 mod process_threads;
 mod processes;

--- a/samply/src/linux_shared/per_cpu.rs
+++ b/samply/src/linux_shared/per_cpu.rs
@@ -1,0 +1,51 @@
+use fxprof_processed_profile::{ProcessHandle, Profile, ThreadHandle, Timestamp};
+
+use super::context_switch::ThreadContextSwitchData;
+
+pub struct Cpus {
+    start_time: Timestamp,
+    process_handle: ProcessHandle,
+    combined_thread_handle: ThreadHandle,
+    cpus: Vec<Cpu>,
+}
+
+pub struct Cpu {
+    pub thread_handle: ThreadHandle,
+    pub context_switch_data: ThreadContextSwitchData,
+}
+
+impl Cpu {
+    pub fn new(thread_handle: ThreadHandle) -> Self {
+        Self {
+            thread_handle,
+            context_switch_data: Default::default(),
+        }
+    }
+}
+
+impl Cpus {
+    pub fn new(start_time: Timestamp, profile: &mut Profile) -> Self {
+        let process_handle = profile.add_process("CPU", 0, start_time);
+        let combined_thread_handle = profile.add_thread(process_handle, 0, start_time, true);
+        Self {
+            start_time,
+            process_handle,
+            combined_thread_handle,
+            cpus: Vec::new(),
+        }
+    }
+
+    pub fn combined_thread_handle(&self) -> ThreadHandle {
+        self.combined_thread_handle
+    }
+
+    pub fn get_mut(&mut self, cpu: usize, profile: &mut Profile) -> &mut Cpu {
+        while self.cpus.len() <= cpu {
+            let i = self.cpus.len();
+            let thread = profile.add_thread(self.process_handle, i as u32, self.start_time, false);
+            profile.set_thread_name(thread, &format!("CPU {i}"));
+            self.cpus.push(Cpu::new(thread));
+        }
+        &mut self.cpus[cpu]
+    }
+}

--- a/samply/src/linux_shared/per_cpu.rs
+++ b/samply/src/linux_shared/per_cpu.rs
@@ -1,4 +1,11 @@
-use fxprof_processed_profile::{ProcessHandle, Profile, ThreadHandle, Timestamp};
+use fxprof_processed_profile::{
+    CategoryHandle, MarkerDynamicField, MarkerFieldFormat, MarkerLocation, MarkerSchema,
+    MarkerSchemaField, MarkerTiming, ProcessHandle, Profile, ProfilerMarker, StringHandle,
+    ThreadHandle, Timestamp,
+};
+use serde_json::json;
+
+use crate::shared::timestamp_converter::TimestampConverter;
 
 use super::context_switch::ThreadContextSwitchData;
 
@@ -10,15 +17,86 @@ pub struct Cpus {
 }
 
 pub struct Cpu {
+    pub name: String,
     pub thread_handle: ThreadHandle,
     pub context_switch_data: ThreadContextSwitchData,
+    pub current_tid: Option<(i32, StringHandle, u64)>,
 }
 
 impl Cpu {
-    pub fn new(thread_handle: ThreadHandle) -> Self {
+    pub fn new(cpu_index: usize, thread_handle: ThreadHandle) -> Self {
         Self {
+            name: format!("CPU {cpu_index}"),
             thread_handle,
             context_switch_data: Default::default(),
+            current_tid: None,
+        }
+    }
+
+    pub fn notify_switch_in(
+        &mut self,
+        tid: i32,
+        thread_name: StringHandle,
+        timestamp: u64,
+        converter: &TimestampConverter,
+        thread_handles: &[ThreadHandle],
+        profile: &mut Profile,
+    ) {
+        let previous_tid =
+            std::mem::replace(&mut self.current_tid, Some((tid, thread_name, timestamp)));
+        if let Some((_previous_tid, previous_thread_name, switch_in_timestamp)) = previous_tid {
+            // eprintln!("Missing switch-out (noticed during switch-in) on {}: {previous_tid}, {switch_in_timestamp}", self.name);
+            let name = profile.get_string(previous_thread_name).to_string();
+            let start_timestamp = converter.convert_time(switch_in_timestamp);
+            let end_timestamp = converter.convert_time(timestamp);
+            let timing = MarkerTiming::Interval(start_timestamp, end_timestamp);
+            for thread_handle in thread_handles {
+                profile.add_marker(
+                    *thread_handle,
+                    CategoryHandle::OTHER,
+                    &self.name,
+                    ThreadNameMarkerForCpuTrack(name.clone()),
+                    timing.clone(),
+                );
+            }
+        }
+    }
+
+    pub fn notify_switch_out(
+        &mut self,
+        tid: i32,
+        timestamp: u64,
+        converter: &TimestampConverter,
+        thread_handles: &[ThreadHandle],
+        profile: &mut Profile,
+    ) {
+        let previous_tid = self.current_tid.take();
+        if let Some((previous_tid, previous_thread_name, switch_in_timestamp)) = previous_tid {
+            let name = profile.get_string(previous_thread_name).to_string();
+            let start_timestamp = converter.convert_time(switch_in_timestamp);
+            let end_timestamp = converter.convert_time(timestamp);
+            let timing = MarkerTiming::Interval(start_timestamp, end_timestamp);
+            for thread_handle in thread_handles {
+                profile.add_marker(
+                    *thread_handle,
+                    CategoryHandle::OTHER,
+                    &self.name,
+                    ThreadNameMarkerForCpuTrack(name.clone()),
+                    timing.clone(),
+                );
+            }
+            if previous_tid != tid {
+                // eprintln!("Missing switch-out (noticed during switch-out) on {}: {previous_tid}, {switch_in_timestamp}", self.name);
+                // eprintln!(
+                //     "Missing switch-in (noticed during switch-out) on {}: {tid}, {timestamp}",
+                //     self.name
+                // );
+            }
+        } else {
+            // eprintln!(
+            //     "Missing switch-in (noticed during switch-out) on {}: {tid}, {timestamp}",
+            //     self.name
+            // );
         }
     }
 }
@@ -43,9 +121,41 @@ impl Cpus {
         while self.cpus.len() <= cpu {
             let i = self.cpus.len();
             let thread = profile.add_thread(self.process_handle, i as u32, self.start_time, false);
-            profile.set_thread_name(thread, &format!("CPU {i}"));
-            self.cpus.push(Cpu::new(thread));
+            let cpu = Cpu::new(i, thread);
+            profile.set_thread_name(thread, &cpu.name);
+            self.cpus.push(cpu);
         }
         &mut self.cpus[cpu]
+    }
+}
+
+/// An example marker type with some text content.
+#[derive(Debug, Clone)]
+pub struct ThreadNameMarkerForCpuTrack(pub String);
+
+impl ProfilerMarker for ThreadNameMarkerForCpuTrack {
+    const MARKER_TYPE_NAME: &'static str = "ContextSwitch";
+
+    fn json_marker_data(&self) -> serde_json::Value {
+        json!({
+            "type": Self::MARKER_TYPE_NAME,
+            "name": self.0
+        })
+    }
+
+    fn schema() -> MarkerSchema {
+        MarkerSchema {
+            type_name: Self::MARKER_TYPE_NAME,
+            locations: vec![MarkerLocation::MarkerChart, MarkerLocation::MarkerTable],
+            chart_label: Some("{marker.data.name}"),
+            tooltip_label: Some("{marker.data.name}"),
+            table_label: Some("{marker.name} - {marker.data.name}"),
+            fields: vec![MarkerSchemaField::Dynamic(MarkerDynamicField {
+                key: "thread",
+                label: "Thread",
+                format: MarkerFieldFormat::String,
+                searchable: true,
+            })],
+        }
     }
 }

--- a/samply/src/linux_shared/process.rs
+++ b/samply/src/linux_shared/process.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 
 use framehop::Unwinder;
 use fxprof_processed_profile::{
-    CategoryHandle, CounterHandle, LibraryHandle, MarkerTiming, ProcessHandle, Profile,
+    CategoryHandle, CounterHandle, FrameInfo, LibraryHandle, MarkerTiming, ProcessHandle, Profile,
     ThreadHandle, Timestamp,
 };
 
@@ -49,10 +49,12 @@ impl<U> Process<U>
 where
     U: Unwinder + Default,
 {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         pid: i32,
         process_handle: ProcessHandle,
         main_thread_handle: ThreadHandle,
+        main_thread_label_frame: FrameInfo,
         name: Option<String>,
         thread_recycler: Option<ThreadRecycler>,
         jit_function_recycler: Option<JitFunctionRecycler>,
@@ -63,9 +65,16 @@ where
             unwinder: U::default(),
             jitdump_manager: JitDumpManager::new(unlink_aux_files),
             lib_mapping_ops: Default::default(),
-            name,
+            name: name.clone(),
             pid,
-            threads: ProcessThreads::new(pid, process_handle, main_thread_handle, thread_recycler),
+            threads: ProcessThreads::new(
+                pid,
+                process_handle,
+                main_thread_handle,
+                main_thread_label_frame,
+                name,
+                thread_recycler,
+            ),
             unresolved_samples: Default::default(),
             jit_function_recycler,
             marker_file_paths: Vec::new(),
@@ -91,35 +100,50 @@ where
         self.lib_mapping_ops = fork_data.lib_mapping_ops;
     }
 
-    pub fn swap_recycling_data(
+    pub fn rename_with_recycling(
         &mut self,
+        name: String,
         recycling_data: ProcessRecyclingData,
-    ) -> Option<ProcessRecyclingData> {
+    ) -> (ProcessRecyclingData, Option<String>) {
         let ProcessRecyclingData {
             process_handle,
-            main_thread_handle,
+            main_thread_recycling_data,
             thread_recycler,
             jit_function_recycler,
         } = recycling_data;
         let old_process_handle = std::mem::replace(&mut self.profile_process, process_handle);
         let old_jit_function_recycler =
             std::mem::replace(&mut self.jit_function_recycler, Some(jit_function_recycler));
-        let (old_main_thread_handle, old_thread_recycler) = self.threads.swap_recycling_data(
-            process_handle,
-            main_thread_handle,
-            thread_recycler,
-        )?;
-        Some(ProcessRecyclingData {
+        let (old_thread_recycler, old_main_thread_recycling_data) =
+            self.threads.rename_process_with_recycling(
+                name.clone(),
+                process_handle,
+                main_thread_recycling_data,
+                thread_recycler,
+            );
+        let old_name = std::mem::replace(&mut self.name, Some(name));
+        let recycling_data = ProcessRecyclingData {
             process_handle: old_process_handle,
-            main_thread_handle: old_main_thread_handle,
+            main_thread_recycling_data: old_main_thread_recycling_data,
             thread_recycler: old_thread_recycler,
-            jit_function_recycler: old_jit_function_recycler?,
-        })
+            jit_function_recycler: old_jit_function_recycler
+                .expect("jit_function_recycler should be Some"),
+        };
+        (recycling_data, old_name)
     }
 
-    pub fn set_name(&mut self, name: String, profile: &mut Profile) {
+    pub fn rename_without_recycling(
+        &mut self,
+        name: String,
+        main_thread_label_frame: FrameInfo,
+        profile: &mut Profile,
+    ) {
         profile.set_process_name(self.profile_process, &name);
-        self.threads.main_thread.set_name(name.clone(), profile);
+        self.threads.main_thread.rename_without_recycling(
+            name.clone(),
+            main_thread_label_frame,
+            profile,
+        );
         self.name = Some(name);
     }
 
@@ -222,13 +246,13 @@ where
         let process_recycling_data = if let (
             Some(name),
             Some(mut jit_function_recycler),
-            (main_thread_handle, Some(thread_recycler)),
+            (Some(thread_recycler), main_thread_recycling_data),
         ) = (self.name, self.jit_function_recycler, thread_recycler)
         {
             jit_function_recycler.finish_round();
             let recycling_data = ProcessRecyclingData {
                 process_handle: self.profile_process,
-                main_thread_handle,
+                main_thread_recycling_data,
                 thread_recycler,
                 jit_function_recycler,
             };

--- a/samply/src/linux_shared/process_threads.rs
+++ b/samply/src/linux_shared/process_threads.rs
@@ -1,4 +1,6 @@
-use fxprof_processed_profile::{ProcessHandle, Profile, ThreadHandle, Timestamp};
+use fxprof_processed_profile::{
+    CategoryHandle, Frame, FrameFlags, FrameInfo, ProcessHandle, Profile, ThreadHandle, Timestamp,
+};
 
 use std::collections::hash_map::Entry;
 
@@ -20,28 +22,36 @@ impl ProcessThreads {
         pid: i32,
         process_handle: ProcessHandle,
         main_thread_handle: ThreadHandle,
+        main_thread_label_frame: FrameInfo,
+        name: Option<String>,
         thread_recycler: Option<ThreadRecycler>,
     ) -> Self {
         Self {
             pid,
             profile_process: process_handle,
-            main_thread: Thread::new(main_thread_handle),
+            main_thread: Thread::new(main_thread_handle, main_thread_label_frame, name),
             threads_by_tid: Default::default(),
             thread_recycler,
         }
     }
 
-    pub fn swap_recycling_data(
+    pub fn rename_process_with_recycling(
         &mut self,
+        name: String,
         process_handle: ProcessHandle,
-        main_thread_handle: ThreadHandle,
+        main_thread_recycling_data: (ThreadHandle, FrameInfo),
         thread_recycler: ThreadRecycler,
-    ) -> Option<(ThreadHandle, ThreadRecycler)> {
+    ) -> (ThreadRecycler, (ThreadHandle, FrameInfo)) {
         let _old_process_handle = std::mem::replace(&mut self.profile_process, process_handle);
-        let old_main_thread_handle = self.main_thread.swap_thread_handle(main_thread_handle);
+        let (_old_name, old_main_thread_recycling_data) = self
+            .main_thread
+            .rename_with_recycling(name, main_thread_recycling_data);
         let old_thread_recycler =
             std::mem::replace(&mut self.thread_recycler, Some(thread_recycler));
-        Some((old_main_thread_handle, old_thread_recycler?))
+        (
+            old_thread_recycler.expect("thread_recycler should be Some"),
+            old_main_thread_recycling_data,
+        )
     }
 
     pub fn recycle_or_get_new_thread(
@@ -58,8 +68,11 @@ impl ProcessThreads {
             Entry::Vacant(entry) => {
                 if let (Some(name), Some(thread_recycler)) = (&name, self.thread_recycler.as_mut())
                 {
-                    if let Some(thread_handle) = thread_recycler.recycle_by_name(name) {
-                        let thread = Thread::new(thread_handle);
+                    if let Some((thread_handle, thread_label_frame)) =
+                        thread_recycler.recycle_by_name(name)
+                    {
+                        let thread =
+                            Thread::new(thread_handle, thread_label_frame, Some(name.clone()));
                         return entry.insert(thread);
                     }
                 }
@@ -69,7 +82,9 @@ impl ProcessThreads {
                 if let Some(name) = &name {
                     profile.set_thread_name(thread_handle, name);
                 }
-                let thread = Thread::new(thread_handle);
+                let thread_label_frame =
+                    make_thread_label_frame(profile, name.as_deref(), self.pid, tid);
+                let thread = Thread::new(thread_handle, thread_label_frame, name);
                 entry.insert(thread)
             }
             Entry::Occupied(entry) => entry.into_mut(),
@@ -91,21 +106,24 @@ impl ProcessThreads {
                 self.recycle_or_get_new_thread(tid, Some(name), timestamp, profile);
             }
             Entry::Occupied(mut entry) => {
-                if entry.get().name.as_deref() == Some(&name) {
+                let thread = entry.get_mut();
+                if thread.name.as_deref() == Some(&name) {
                     return;
                 }
 
                 if let Some(thread_recycler) = self.thread_recycler.as_mut() {
-                    if let Some(recycled_thread_handle) = thread_recycler.recycle_by_name(&name) {
-                        let old_thread_handle =
-                            entry.get_mut().swap_thread_handle(recycled_thread_handle);
-                        if let Some(old_name) = entry.get().name.as_deref() {
-                            thread_recycler.add_to_pool(old_name, old_thread_handle);
+                    if let Some(thread_recycling_data) = thread_recycler.recycle_by_name(&name) {
+                        let (old_name, old_thread_recycling_data) =
+                            thread.rename_with_recycling(name, thread_recycling_data);
+                        if let Some(old_name) = old_name {
+                            thread_recycler.add_to_pool(&old_name, old_thread_recycling_data);
                         }
                     }
+                } else {
+                    let thread_label_frame =
+                        make_thread_label_frame(profile, Some(&name), self.pid, tid);
+                    thread.rename_without_recycling(name, thread_label_frame, profile);
                 }
-
-                entry.get_mut().set_name(name, profile);
             }
         }
     }
@@ -116,19 +134,20 @@ impl ProcessThreads {
         for (_tid, mut thread) in self.threads_by_tid.drain() {
             thread.notify_dead(end_time, profile);
 
-            let (name, thread_handle) = thread.finish();
+            let (name, thread_recycling_data) = thread.finish();
 
             if let (Some(name), Some(thread_recycler)) = (name, self.thread_recycler.as_mut()) {
-                thread_recycler.add_to_pool(&name, thread_handle);
+                thread_recycler.add_to_pool(&name, thread_recycling_data);
             }
         }
 
         self.main_thread.notify_dead(end_time, profile);
     }
+
     /// Called when the process has exited, or at the end of profiling. Called after notify_process_dead.
-    pub fn finish(self) -> (ThreadHandle, Option<ThreadRecycler>) {
-        let (_main_thread_name, main_thread_handle) = self.main_thread.finish();
-        (main_thread_handle, self.thread_recycler)
+    pub fn finish(self) -> (Option<ThreadRecycler>, (ThreadHandle, FrameInfo)) {
+        let (_main_thread_name, main_thread_recycling_data) = self.main_thread.finish();
+        (self.thread_recycler, main_thread_recycling_data)
     }
 
     pub fn get_thread_by_tid(&mut self, tid: i32, profile: &mut Profile) -> &mut Thread {
@@ -142,12 +161,14 @@ impl ProcessThreads {
                 Timestamp::from_millis_since_reference(0.0),
                 false,
             );
+            let thread_label_frame = make_thread_label_frame(profile, None, self.pid, tid);
             Thread {
                 profile_thread,
                 context_switch_data: Default::default(),
                 last_sample_timestamp: None,
                 off_cpu_stack: None,
                 name: None,
+                thread_label_frame,
             }
         })
     }
@@ -159,10 +180,28 @@ impl ProcessThreads {
 
         thread.notify_dead(time, profile);
 
-        let (name, thread_handle) = thread.finish();
+        let (name, thread_recylcing_data) = thread.finish();
 
         if let (Some(name), Some(thread_recycler)) = (name, self.thread_recycler.as_mut()) {
-            thread_recycler.add_to_pool(&name, thread_handle);
+            thread_recycler.add_to_pool(&name, thread_recylcing_data);
         }
+    }
+}
+
+pub fn make_thread_label_frame(
+    profile: &mut Profile,
+    name: Option<&str>,
+    pid: i32,
+    tid: i32,
+) -> FrameInfo {
+    let s = match name {
+        Some(name) => format!("{name} (pid: {pid}, tid: {tid})"),
+        None => format!("Thread {tid} (pid: {pid}, tid: {tid})"),
+    };
+    let thread_label = profile.intern_string(&s);
+    FrameInfo {
+        frame: Frame::Label(thread_label),
+        category_pair: CategoryHandle::OTHER.into(),
+        flags: FrameFlags::empty(),
     }
 }

--- a/samply/src/linux_shared/processes.rs
+++ b/samply/src/linux_shared/processes.rs
@@ -5,6 +5,7 @@ use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 
 use super::process::Process;
+use super::process_threads::make_thread_label_frame;
 
 use crate::shared::jit_category_manager::JitCategoryManager;
 use crate::shared::jit_function_recycler::JitFunctionRecycler;
@@ -62,15 +63,18 @@ where
                 {
                     if let Some(ProcessRecyclingData {
                         process_handle,
-                        main_thread_handle,
+                        main_thread_recycling_data,
                         thread_recycler,
                         jit_function_recycler,
                     }) = process_recycler.recycle_by_name(name_ref)
                     {
+                        let (main_thread_handle, main_thread_label_frame) =
+                            main_thread_recycling_data;
                         let process = Process::new(
                             pid,
                             process_handle,
                             main_thread_handle,
+                            main_thread_label_frame,
                             name,
                             Some(thread_recycler),
                             Some(jit_function_recycler),
@@ -91,6 +95,8 @@ where
                 if let Some(name) = name.as_deref() {
                     profile.set_thread_name(main_thread_handle, name);
                 }
+                let main_thread_label_frame =
+                    make_thread_label_frame(profile, name.as_deref(), pid, pid);
                 let (thread_recycler, jit_function_recycler) = if self.process_recycler.is_some() {
                     (
                         Some(ThreadRecycler::new()),
@@ -103,6 +109,7 @@ where
                     pid,
                     process_handle,
                     main_thread_handle,
+                    main_thread_label_frame,
                     name,
                     thread_recycler,
                     jit_function_recycler,
@@ -121,6 +128,7 @@ where
                 profile.add_process(&format!("<{pid}>"), pid as u32, fake_start_time);
             let main_thread_handle =
                 profile.add_thread(process_handle, pid as u32, fake_start_time, true);
+            let main_thread_label_frame = make_thread_label_frame(profile, None, pid, pid);
             let (thread_recycler, jit_function_recycler) = if self.process_recycler.is_some() {
                 (
                     Some(ThreadRecycler::new()),
@@ -133,6 +141,7 @@ where
                 pid,
                 process_handle,
                 main_thread_handle,
+                main_thread_label_frame,
                 None, // no name
                 thread_recycler,
                 jit_function_recycler,
@@ -180,22 +189,26 @@ where
                 self.recycle_or_get_new(pid, Some(name), timestamp, profile);
             }
             Entry::Occupied(mut entry) => {
-                if entry.get().name.as_deref() == Some(&name) {
+                let process = entry.get_mut();
+                if process.name.as_deref() == Some(&name) {
                     return;
                 }
 
                 if let Some(process_recycler) = self.process_recycler.as_mut() {
-                    if let Some(process_recycling_data) = process_recycler.recycle_by_name(&name) {
-                        let old_recycling_data =
-                            entry.get_mut().swap_recycling_data(process_recycling_data);
-                        if let (Some(old_recycling_data), Some(old_name)) =
-                            (old_recycling_data, entry.get().name.as_deref())
-                        {
-                            process_recycler.add_to_pool(old_name, old_recycling_data);
-                        }
+                    let Some(process_recycling_data) = process_recycler.recycle_by_name(&name)
+                    else {
+                        return;
+                    };
+                    let (old_recycling_data, old_name) =
+                        process.rename_with_recycling(name, process_recycling_data);
+                    if let Some(old_name) = old_name {
+                        process_recycler.add_to_pool(&old_name, old_recycling_data);
                     }
+                } else {
+                    let main_thread_label_frame =
+                        make_thread_label_frame(profile, Some(&name), pid, pid);
+                    process.rename_without_recycling(name, main_thread_label_frame, profile);
                 }
-                entry.get_mut().set_name(name, profile);
             }
         }
     }

--- a/samply/src/linux_shared/thread.rs
+++ b/samply/src/linux_shared/thread.rs
@@ -1,4 +1,4 @@
-use fxprof_processed_profile::{Profile, ThreadHandle, Timestamp};
+use fxprof_processed_profile::{FrameInfo, Profile, ThreadHandle, Timestamp};
 
 use std::fmt::Debug;
 
@@ -17,25 +17,45 @@ pub struct Thread {
     /// Refers to a stack in the containing Process's UnresolvedSamples stack table.
     pub off_cpu_stack: Option<UnresolvedStackHandle>,
     pub name: Option<String>,
+    pub thread_label_frame: FrameInfo,
 }
 
 impl Thread {
-    pub fn new(thread_handle: ThreadHandle) -> Self {
+    pub fn new(
+        thread_handle: ThreadHandle,
+        thread_label_frame: FrameInfo,
+        name: Option<String>,
+    ) -> Self {
         Self {
             profile_thread: thread_handle,
             context_switch_data: Default::default(),
             last_sample_timestamp: None,
             off_cpu_stack: None,
-            name: None,
+            name,
+            thread_label_frame,
         }
     }
 
-    pub fn swap_thread_handle(&mut self, thread_handle: ThreadHandle) -> ThreadHandle {
-        std::mem::replace(&mut self.profile_thread, thread_handle)
+    pub fn rename_with_recycling(
+        &mut self,
+        name: String,
+        (thread_handle, thread_label_frame): (ThreadHandle, FrameInfo),
+    ) -> (Option<String>, (ThreadHandle, FrameInfo)) {
+        let old_thread_handle = std::mem::replace(&mut self.profile_thread, thread_handle);
+        let old_thread_label_frame =
+            std::mem::replace(&mut self.thread_label_frame, thread_label_frame);
+        let old_name = std::mem::replace(&mut self.name, Some(name));
+        (old_name, (old_thread_handle, old_thread_label_frame))
     }
 
-    pub fn set_name(&mut self, name: String, profile: &mut Profile) {
+    pub fn rename_without_recycling(
+        &mut self,
+        name: String,
+        thread_label_frame: FrameInfo,
+        profile: &mut Profile,
+    ) {
         profile.set_thread_name(self.profile_thread, &name);
+        self.thread_label_frame = thread_label_frame;
         self.name = Some(name);
     }
 
@@ -43,7 +63,7 @@ impl Thread {
         profile.set_thread_end_time(self.profile_thread, end_time);
     }
 
-    pub fn finish(self) -> (Option<String>, ThreadHandle) {
-        (self.name, self.profile_thread)
+    pub fn finish(self) -> (Option<String>, (ThreadHandle, FrameInfo)) {
+        (self.name, (self.profile_thread, self.thread_label_frame))
     }
 }

--- a/samply/src/linux_shared/thread.rs
+++ b/samply/src/linux_shared/thread.rs
@@ -1,4 +1,4 @@
-use fxprof_processed_profile::{FrameInfo, Profile, ThreadHandle, Timestamp};
+use fxprof_processed_profile::{Frame, FrameInfo, Profile, StringHandle, ThreadHandle, Timestamp};
 
 use std::fmt::Debug;
 
@@ -33,6 +33,13 @@ impl Thread {
             off_cpu_stack: None,
             name,
             thread_label_frame,
+        }
+    }
+
+    pub fn thread_label(&self) -> StringHandle {
+        match self.thread_label_frame.frame {
+            Frame::Label(s) => s,
+            _ => panic!(),
         }
     }
 

--- a/samply/src/mac/task_profiler.rs
+++ b/samply/src/mac/task_profiler.rs
@@ -4,7 +4,10 @@ use framehop::{
     Unwinder, UnwinderNative,
 };
 use fxprof_processed_profile::debugid::DebugId;
-use fxprof_processed_profile::{LibraryInfo, ProcessHandle, Profile, ThreadHandle, Timestamp};
+use fxprof_processed_profile::{
+    CategoryHandle, Frame, FrameFlags, FrameInfo, LibraryInfo, ProcessHandle, Profile,
+    ThreadHandle, Timestamp,
+};
 use mach::mach_types::thread_act_port_array_t;
 use mach::mach_types::thread_act_t;
 use mach::message::mach_msg_type_number_t;
@@ -102,6 +105,7 @@ pub struct TaskProfiler {
     executable_name: String,
     profile_process: ProcessHandle,
     main_thread_handle: ThreadHandle,
+    main_thread_label_frame: FrameInfo,
     ignored_errors: Vec<SamplingError>,
     unwinder: UnwinderNative<UnwindSectionBytes, MayAllocateDuringUnwind>,
     path_receiver: Receiver<JitdumpOrMarkerPath>,
@@ -170,46 +174,63 @@ impl TaskProfiler {
             .map_err(|e| SamplingError::Ignorable("Could not get main thread tid", e))?;
         let main_thread_name = get_thread_name(main_thread_act)?;
 
-        let (profile_process, main_thread_handle, mut thread_recycler, jit_function_recycler) =
-            match recycling_data {
-                Some(ProcessRecyclingData {
+        let (
+            profile_process,
+            main_thread_handle,
+            main_thread_label_frame,
+            mut thread_recycler,
+            jit_function_recycler,
+        ) = match recycling_data {
+            Some(ProcessRecyclingData {
+                process_handle,
+                main_thread_recycling_data,
+                thread_recycler,
+                jit_function_recycler,
+            }) => {
+                let (main_thread_handle, main_thread_label_frame) = main_thread_recycling_data;
+                (
                     process_handle,
                     main_thread_handle,
-                    thread_recycler,
-                    jit_function_recycler,
-                }) => (
-                    process_handle,
-                    main_thread_handle,
+                    main_thread_label_frame,
                     Some(thread_recycler),
                     Some(jit_function_recycler),
-                ),
-                None => {
-                    let profile_process = profile.add_process(&executable_name, pid, start_time);
-                    let main_thread_handle =
-                        profile.add_thread(profile_process, main_thread_tid, start_time, true);
-                    if let Some(main_thread_name) = &main_thread_name {
-                        profile.set_thread_name(main_thread_handle, main_thread_name);
-                    }
-                    let (thread_recycler, jit_function_recycler) = match process_recycler {
-                        Some(_) => (
-                            Some(ThreadRecycler::new()),
-                            Some(JitFunctionRecycler::default()),
-                        ),
-                        None => (None, None),
-                    };
-                    (
-                        profile_process,
-                        main_thread_handle,
-                        thread_recycler,
-                        jit_function_recycler,
-                    )
+                )
+            }
+            None => {
+                let profile_process = profile.add_process(&executable_name, pid, start_time);
+                let main_thread_handle =
+                    profile.add_thread(profile_process, main_thread_tid, start_time, true);
+                if let Some(main_thread_name) = &main_thread_name {
+                    profile.set_thread_name(main_thread_handle, main_thread_name);
                 }
-            };
+                let main_thread_label_frame = make_thread_label_frame(
+                    profile,
+                    main_thread_name.as_deref(),
+                    pid,
+                    main_thread_tid,
+                );
+                let (thread_recycler, jit_function_recycler) = match process_recycler {
+                    Some(_) => (
+                        Some(ThreadRecycler::new()),
+                        Some(JitFunctionRecycler::default()),
+                    ),
+                    None => (None, None),
+                };
+                (
+                    profile_process,
+                    main_thread_handle,
+                    main_thread_label_frame,
+                    thread_recycler,
+                    jit_function_recycler,
+                )
+            }
+        };
 
         let main_thread = ThreadProfiler::new(
             task,
             main_thread_tid,
             main_thread_handle,
+            main_thread_label_frame.clone(),
             main_thread_act,
             main_thread_name,
         );
@@ -219,16 +240,22 @@ impl TaskProfiler {
             if let (Ok((tid, _is_libdispatch_thread)), Ok(name)) =
                 (get_thread_id(thread_act), get_thread_name(thread_act))
             {
-                let profile_thread = if let (Some(name), Some(thread_recycler)) =
-                    (&name, thread_recycler.as_mut())
+                let (profile_thread, thread_label_frame) = if let (
+                    Some(name),
+                    Some(thread_recycler),
+                ) = (&name, thread_recycler.as_mut())
                 {
-                    if let Some(profile_thread) = thread_recycler.recycle_by_name(name) {
-                        profile_thread
+                    if let Some((profile_thread, thread_label_frame)) =
+                        thread_recycler.recycle_by_name(name)
+                    {
+                        (profile_thread, thread_label_frame)
                     } else {
                         let profile_thread =
                             profile.add_thread(profile_process, tid, start_time, false);
                         profile.set_thread_name(profile_thread, name);
-                        profile_thread
+                        let thread_label_frame =
+                            make_thread_label_frame(profile, Some(name), pid, tid);
+                        (profile_thread, thread_label_frame)
                     }
                 } else {
                     let profile_thread =
@@ -236,10 +263,19 @@ impl TaskProfiler {
                     if let Some(name) = &name {
                         profile.set_thread_name(profile_thread, name);
                     }
-                    profile_thread
+                    let thread_label_frame =
+                        make_thread_label_frame(profile, name.as_deref(), pid, tid);
+                    (profile_thread, thread_label_frame)
                 };
 
-                let thread = ThreadProfiler::new(task, tid, profile_thread, thread_act, name);
+                let thread = ThreadProfiler::new(
+                    task,
+                    tid,
+                    profile_thread,
+                    thread_label_frame,
+                    thread_act,
+                    name,
+                );
                 live_threads.insert(thread_act, thread);
             }
         }
@@ -252,6 +288,7 @@ impl TaskProfiler {
             executable_name,
             profile_process,
             main_thread_handle,
+            main_thread_label_frame,
             ignored_errors: Vec::new(),
             unwinder: UnwinderNative::new(),
             path_receiver,
@@ -335,27 +372,43 @@ impl TaskProfiler {
                     if let (Ok((tid, _is_libdispatch_thread)), Ok(name)) =
                         (get_thread_id(thread_act), get_thread_name(thread_act))
                     {
-                        let profile_thread = if let (Some(name), Some(thread_recycler)) =
-                            (&name, self.thread_recycler.as_mut())
-                        {
-                            if let Some(profile_thread) = thread_recycler.recycle_by_name(name) {
-                                profile_thread
+                        let (profile_thread, thread_label_frame) =
+                            if let (Some(name), Some(thread_recycler)) =
+                                (&name, self.thread_recycler.as_mut())
+                            {
+                                if let Some(profile_thread) = thread_recycler.recycle_by_name(name)
+                                {
+                                    profile_thread
+                                } else {
+                                    let profile_thread =
+                                        profile.add_thread(self.profile_process, tid, now, false);
+                                    profile.set_thread_name(profile_thread, name);
+                                    let thread_label_frame =
+                                        make_thread_label_frame(profile, Some(name), self.pid, tid);
+                                    (profile_thread, thread_label_frame)
+                                }
                             } else {
                                 let profile_thread =
                                     profile.add_thread(self.profile_process, tid, now, false);
-                                profile.set_thread_name(profile_thread, name);
-                                profile_thread
-                            }
-                        } else {
-                            let profile_thread =
-                                profile.add_thread(self.profile_process, tid, now, false);
-                            if let Some(name) = &name {
-                                profile.set_thread_name(profile_thread, name);
-                            }
-                            profile_thread
-                        };
-                        let thread =
-                            ThreadProfiler::new(self.task, tid, profile_thread, thread_act, name);
+                                if let Some(name) = &name {
+                                    profile.set_thread_name(profile_thread, name);
+                                }
+                                let thread_label_frame = make_thread_label_frame(
+                                    profile,
+                                    name.as_deref(),
+                                    self.pid,
+                                    tid,
+                                );
+                                (profile_thread, thread_label_frame)
+                            };
+                        let thread = ThreadProfiler::new(
+                            self.task,
+                            tid,
+                            profile_thread,
+                            thread_label_frame,
+                            thread_act,
+                            name,
+                        );
                         entry.insert(thread)
                     } else {
                         continue;
@@ -382,11 +435,11 @@ impl TaskProfiler {
         for thread_act in dead_threads {
             let mut thread = self.live_threads.remove(thread_act).unwrap();
             thread.notify_dead(now, profile);
-            let (thread_name, thread_handle) = thread.finish();
+            let (thread_name, thread_handle, thread_label_frame) = thread.finish();
             if let (Some(thread_name), Some(thread_recycler)) =
                 (thread_name, self.thread_recycler.as_mut())
             {
-                thread_recycler.add_to_pool(&thread_name, thread_handle);
+                thread_recycler.add_to_pool(&thread_name, (thread_handle, thread_label_frame));
             }
         }
         Ok(())
@@ -570,12 +623,12 @@ impl TaskProfiler {
     pub fn notify_dead(&mut self, end_time: Timestamp, profile: &mut Profile) {
         for (_, mut thread) in self.live_threads.drain() {
             thread.notify_dead(end_time, profile);
-            let (thread_name, thread_handle) = thread.finish();
+            let (thread_name, thread_handle, thread_label_frame) = thread.finish();
 
             if let (Some(thread_name), Some(thread_recycler)) =
                 (thread_name, self.thread_recycler.as_mut())
             {
-                thread_recycler.add_to_pool(&thread_name, thread_handle);
+                thread_recycler.add_to_pool(&thread_name, (thread_handle, thread_label_frame));
             }
         }
         profile.set_process_end_time(self.profile_process, end_time);
@@ -633,7 +686,10 @@ impl TaskProfiler {
                 self.executable_name,
                 ProcessRecyclingData {
                     process_handle: self.profile_process,
-                    main_thread_handle: self.main_thread_handle,
+                    main_thread_recycling_data: (
+                        self.main_thread_handle,
+                        self.main_thread_label_frame,
+                    ),
                     thread_recycler,
                     jit_function_recycler,
                 },
@@ -746,4 +802,22 @@ fn compute_debug_id_from_text_section(
     let rel_end = text_section_svma.end.checked_sub(base_svma)?;
     let text_section = text_segment.get((rel_start as usize)..(rel_end as usize))?;
     Some(DebugId::from_text_first_page(text_section, true))
+}
+
+fn make_thread_label_frame(
+    profile: &mut Profile,
+    name: Option<&str>,
+    pid: u32,
+    tid: u32,
+) -> FrameInfo {
+    let s = match name {
+        Some(name) => format!("{name} (pid: {pid}, tid: {tid})"),
+        None => format!("Thread {tid} (pid: {pid}, tid: {tid})"),
+    };
+    let thread_label = profile.intern_string(&s);
+    FrameInfo {
+        frame: Frame::Label(thread_label),
+        category_pair: CategoryHandle::OTHER.into(),
+        flags: FrameFlags::empty(),
+    }
 }

--- a/samply/src/mac/thread_profiler.rs
+++ b/samply/src/mac/thread_profiler.rs
@@ -1,5 +1,5 @@
 use framehop::FrameAddress;
-use fxprof_processed_profile::{CpuDelta, Profile, ThreadHandle, Timestamp};
+use fxprof_processed_profile::{CpuDelta, FrameInfo, Profile, ThreadHandle, Timestamp};
 use mach::mach_types::thread_act_t;
 use mach::port::mach_port_t;
 use time::get_monotonic_timestamp;
@@ -27,6 +27,7 @@ pub struct ThreadProfiler {
     name: Option<String>,
     pub(crate) tid: u32,
     pub(crate) profile_thread: ThreadHandle,
+    thread_label_frame: FrameInfo,
     tick_count: usize,
     stack_memory: ForeignMemory,
     previous_sample_cpu_time_us: u64,
@@ -38,6 +39,7 @@ impl ThreadProfiler {
         task: mach_port_t,
         tid: u32,
         profile_thread: ThreadHandle,
+        thread_label_frame: FrameInfo,
         thread_act: thread_act_t,
         name: Option<String>,
     ) -> Self {
@@ -46,6 +48,7 @@ impl ThreadProfiler {
             tid,
             name,
             profile_thread,
+            thread_label_frame,
             tick_count: 0,
             stack_memory: ForeignMemory::new(task),
             previous_sample_cpu_time_us: 0,
@@ -61,10 +64,11 @@ impl ThreadProfiler {
     ) {
         if self.name.is_none() && self.tick_count % 10 == 0 {
             if let Ok(Some(name)) = get_thread_name(self.thread_act) {
-                if let Some(thread_handle) =
+                if let Some((thread_handle, thread_label_frame)) =
                     thread_recycler.and_then(|tr| tr.recycle_by_name(&name))
                 {
                     self.profile_thread = thread_handle;
+                    self.thread_label_frame = thread_label_frame;
                 } else {
                     profile.set_thread_name(self.profile_thread, &name);
                 }
@@ -199,8 +203,8 @@ impl ThreadProfiler {
         profile.set_thread_end_time(self.profile_thread, end_time);
     }
 
-    pub fn finish(self) -> (Option<String>, ThreadHandle) {
-        (self.name, self.profile_thread)
+    pub fn finish(self) -> (Option<String>, ThreadHandle, FrameInfo) {
+        (self.name, self.profile_thread, self.thread_label_frame)
     }
 }
 

--- a/samply/src/main.rs
+++ b/samply/src/main.rs
@@ -187,6 +187,10 @@ pub struct ProfileCreationArgs {
     /// numbers will be missing for JIT frames.
     #[arg(long)]
     unlink_aux_files: bool,
+
+    /// Create a separate thread for each CPU. Not supported         on macOS
+    #[arg(long)]
+    per_cpu_threads: bool,
 }
 
 fn main() {
@@ -301,6 +305,7 @@ impl ImportArgs {
             reuse_threads: self.profile_creation_args.reuse_threads,
             fold_recursive_prefix: self.profile_creation_args.fold_recursive_prefix,
             unlink_aux_files: self.profile_creation_args.unlink_aux_files,
+            create_per_cpu_threads: self.profile_creation_args.per_cpu_threads,
         }
     }
 }
@@ -380,6 +385,7 @@ impl RecordArgs {
             reuse_threads: self.profile_creation_args.reuse_threads,
             fold_recursive_prefix: self.profile_creation_args.fold_recursive_prefix,
             unlink_aux_files: self.profile_creation_args.unlink_aux_files,
+            create_per_cpu_threads: self.profile_creation_args.per_cpu_threads,
         }
     }
 }

--- a/samply/src/shared/recording_props.rs
+++ b/samply/src/shared/recording_props.rs
@@ -19,6 +19,8 @@ pub struct ProfileCreationProps {
     pub fold_recursive_prefix: bool,
     /// Unlink jitdump/marker files
     pub unlink_aux_files: bool,
+    /// Create a separate thread for each CPU.
+    pub create_per_cpu_threads: bool,
 }
 
 /// Properties which are meaningful for launching and recording a fresh process.

--- a/samply/src/shared/recycling.rs
+++ b/samply/src/shared/recycling.rs
@@ -1,13 +1,13 @@
 use std::cmp::Reverse;
 use std::collections::BinaryHeap;
 
-use fxprof_processed_profile::{ProcessHandle, ThreadHandle};
+use fxprof_processed_profile::{FrameInfo, ProcessHandle, ThreadHandle};
 
 use crate::shared::{jit_function_recycler::JitFunctionRecycler, types::FastHashMap};
 
 pub struct ProcessRecyclingData {
     pub process_handle: ProcessHandle,
-    pub main_thread_handle: ThreadHandle,
+    pub main_thread_recycling_data: (ThreadHandle, FrameInfo),
     pub thread_recycler: ThreadRecycler,
     pub jit_function_recycler: JitFunctionRecycler,
 }
@@ -33,7 +33,7 @@ impl Ord for ProcessRecyclingData {
 }
 
 pub type ProcessRecycler = RecyclerByName<ProcessRecyclingData>;
-pub type ThreadRecycler = RecyclerByName<ThreadHandle>;
+pub type ThreadRecycler = RecyclerByName<(ThreadHandle, FrameInfo)>;
 
 pub struct RecyclerByName<T: Ord>(FastHashMap<String, BinaryHeap<Reverse<T>>>);
 


### PR DESCRIPTION
This is works in the perf.data importer and should work (though I haven't tested it yet) with `samply record` on Linux.

It creates a synthetic thread per CPU, and also a combined thread (the main thread of the synthetic "CPU" process) which contains all samples from all threads. Example: https://share.firefox.dev/3W8qt2f