### PR TITLE
Fix kernel module symbol tables.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1026,9 +1026,9 @@ checksum = "bfae20f6b19ad527b550c223fddc3077a547fc70cda94b9b566575423fd303ee"
 
 [[package]]
 name = "linux-perf-data"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0b1d8bef01c1e379b35acf22e784aebbdf50892afaa04a7c2f839ca11c10a51"
+checksum = "ab6ca5ed6c97474bb07087546ab4201772868214e25d7dc15fe7a9900b70ad67"
 dependencies = [
  "byteorder",
  "linear-map",

--- a/samply/Cargo.toml
+++ b/samply/Cargo.toml
@@ -15,7 +15,7 @@ fxprof-processed-profile = { version = "0.7", path = "../fxprof-processed-profil
 # framehop = { path = "../../framehop" }
 framehop = "0.11.1"
 # linux-perf-data = { path = "../../linux-perf-data" }
-linux-perf-data = "0.10.0"
+linux-perf-data = "0.10.1"
 
 tokio = { version = "1.37.0", features = ["rt", "rt-multi-thread", "macros"] }
 tokio-util = "0.7.10"


### PR DESCRIPTION
The symbol addresses for kernel modules in the simpleperf symbol tables are already relative to the base address, unlike the addresses for the main kernel image.
We were subtracting with overflow. This is now fixed.