### PR TITLE
Clean up Java stacks by eliding libart frames.

### DIFF
--- a/samply/src/linux_shared/process.rs
+++ b/samply/src/linux_shared/process.rs
@@ -271,7 +271,7 @@ where
         start_address: u64,
         end_address: u64,
         relative_address_at_start: u32,
-        lib_handle: LibraryHandle,
+        info: LibMappingInfo,
     ) {
         self.lib_mapping_ops.push(
             timestamp,
@@ -279,7 +279,7 @@ where
                 start_avma: start_address,
                 end_avma: end_address,
                 relative_address_at_start,
-                info: LibMappingInfo::new_lib(lib_handle),
+                info,
             }),
         );
     }

--- a/samply/src/shared/lib_mappings.rs
+++ b/samply/src/shared/lib_mappings.rs
@@ -9,6 +9,15 @@ pub struct LibMappingInfo {
     pub lib_handle: LibraryHandle,
     pub category: Option<CategoryPairHandle>,
     pub js_frame: Option<JsFrame>,
+    pub art_info: Option<AndroidArtInfo>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AndroidArtInfo {
+    /// Set when the lib mapping is for `libart.so`.
+    LibArt,
+    /// Set on Android `OAT` and `DEX` mappings.
+    DexOrOat,
 }
 
 impl LibMappingInfo {
@@ -17,6 +26,7 @@ impl LibMappingInfo {
             lib_handle,
             category: None,
             js_frame: None,
+            art_info: None,
         }
     }
 
@@ -29,6 +39,28 @@ impl LibMappingInfo {
             lib_handle,
             category: Some(category),
             js_frame,
+            art_info: None,
+        }
+    }
+
+    pub fn new_libart_mapping(lib_handle: LibraryHandle) -> Self {
+        Self {
+            lib_handle,
+            category: None,
+            js_frame: None,
+            art_info: Some(AndroidArtInfo::LibArt),
+        }
+    }
+
+    pub fn new_dex_or_oat_mapping(
+        lib_handle: LibraryHandle,
+        category: Option<CategoryPairHandle>,
+    ) -> Self {
+        Self {
+            lib_handle,
+            category,
+            js_frame: None,
+            art_info: Some(AndroidArtInfo::DexOrOat),
         }
     }
 }

--- a/samply/src/shared/perf_map.rs
+++ b/samply/src/shared/perf_map.rs
@@ -110,11 +110,7 @@ pub fn try_load_perf_map(
             start_address,
             end_address,
             relative_address,
-            LibMappingInfo {
-                lib_handle,
-                category: Some(category),
-                js_frame,
-            },
+            LibMappingInfo::new_jit_function(lib_handle, category, js_frame),
         );
     }
 

--- a/samply/src/shared/stack_converter.rs
+++ b/samply/src/shared/stack_converter.rs
@@ -1,7 +1,7 @@
 use fxprof_processed_profile::{CategoryPairHandle, Frame, FrameFlags, FrameInfo};
 
 use super::jit_category_manager::{JsFrame, JsName};
-use super::lib_mappings::LibMappingsHierarchy;
+use super::lib_mappings::{AndroidArtInfo, LibMappingsHierarchy};
 use super::types::{StackFrame, StackMode};
 
 #[derive(Debug, Clone, Copy)]
@@ -15,8 +15,10 @@ pub struct ConvertedStackIter<'a> {
     lib_mappings: &'a LibMappingsHierarchy,
     user_category: CategoryPairHandle,
     kernel_category: CategoryPairHandle,
-    pending_frame: Option<FrameInfo>,
+    pending_frame_info: Option<FrameInfo>,
+    pending_frame: Option<&'a StackFrame>,
     js_name_for_baseline_interpreter: Option<JsName>,
+    previous_frame_was_dex_or_oat: bool,
 }
 
 impl<'a> Iterator for ConvertedStackIter<'a> {
@@ -33,10 +35,10 @@ impl<'a> Iterator for ConvertedStackIter<'a> {
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {
-            if let Some(pending_frame) = self.pending_frame.take() {
-                return Some(pending_frame);
+            if let Some(pending_frame_info) = self.pending_frame_info.take() {
+                return Some(pending_frame_info);
             }
-            let frame = self.inner.next()?;
+            let frame = self.pending_frame.take().or_else(|| self.inner.next())?;
             let (mode, addr, lookup_address, from_ip) = match *frame {
                 StackFrame::InstructionPointer(addr, mode) => (mode, addr, addr, true),
                 StackFrame::ReturnAddress(addr, mode) => {
@@ -44,7 +46,7 @@ impl<'a> Iterator for ConvertedStackIter<'a> {
                 }
                 StackFrame::TruncatedStackMarker => continue,
             };
-            let (location, category, js_frame) = match mode {
+            let (location, category, js_frame, art_info) = match mode {
                 StackMode::User => match self.lib_mappings.convert_address(lookup_address) {
                     Some((relative_lookup_address, info)) => {
                         let location = if from_ip {
@@ -64,6 +66,7 @@ impl<'a> Iterator for ConvertedStackIter<'a> {
                             location,
                             info.category.unwrap_or(self.user_category),
                             info.js_frame,
+                            info.art_info,
                         )
                     }
                     None => {
@@ -71,7 +74,7 @@ impl<'a> Iterator for ConvertedStackIter<'a> {
                             true => Frame::InstructionPointer(addr),
                             false => Frame::ReturnAddress(addr),
                         };
-                        (location, self.user_category, None)
+                        (location, self.user_category, None, None)
                     }
                 },
                 StackMode::Kernel => {
@@ -79,9 +82,30 @@ impl<'a> Iterator for ConvertedStackIter<'a> {
                         true => Frame::InstructionPointer(addr),
                         false => Frame::ReturnAddress(addr),
                     };
-                    (location, self.kernel_category, None)
+                    (location, self.kernel_category, None, None)
                 }
             };
+
+            match art_info {
+                Some(AndroidArtInfo::LibArt) if self.previous_frame_was_dex_or_oat => {
+                    // We want to skip libart frames if they're immediately surrounded by
+                    // dex_or_oat frames on both sides.
+                    if let Some(next_frame) = self.inner.next() {
+                        let should_skip =
+                            StackConverter::frame_is_dex_or_oat(next_frame, self.lib_mappings);
+                        self.pending_frame = Some(next_frame);
+                        if should_skip {
+                            continue; // Skip this libart frame.
+                        }
+                    }
+                    self.previous_frame_was_dex_or_oat = false;
+                }
+                Some(AndroidArtInfo::DexOrOat) => {
+                    self.previous_frame_was_dex_or_oat = true;
+                }
+                _ => self.previous_frame_was_dex_or_oat = false,
+            }
+
             let frame_info = FrameInfo {
                 frame: location,
                 category_pair: category,
@@ -116,7 +140,7 @@ impl<'a> Iterator for ConvertedStackIter<'a> {
             let frame_info = match js_name {
                 Some(JsName::NonSelfHosted(js_name)) => {
                     // Prepend a JS frame.
-                    self.pending_frame = Some(frame_info);
+                    self.pending_frame_info = Some(frame_info);
                     FrameInfo {
                         frame: Frame::Label(js_name),
                         category_pair: category,
@@ -150,8 +174,22 @@ impl StackConverter {
             lib_mappings,
             user_category: self.user_category,
             kernel_category: self.kernel_category,
-            pending_frame: extra_first_frame,
+            pending_frame_info: extra_first_frame,
+            pending_frame: None,
             js_name_for_baseline_interpreter: None,
+            previous_frame_was_dex_or_oat: false,
         }
+    }
+
+    fn frame_is_dex_or_oat(frame: &StackFrame, lib_mappings: &LibMappingsHierarchy) -> bool {
+        let lookup_address = match *frame {
+            StackFrame::InstructionPointer(addr, StackMode::User) => addr,
+            StackFrame::ReturnAddress(addr, StackMode::User) => addr.saturating_sub(1),
+            _ => return false,
+        };
+        let Some((_, info)) = lib_mappings.convert_address(lookup_address) else {
+            return false;
+        };
+        info.art_info == Some(AndroidArtInfo::DexOrOat)
     }
 }


### PR DESCRIPTION
This also adds DEX and OAT categories.

libart frames are elided if they are immediately surrounded by dex/oat frames on both sides.

Before: https://share.firefox.dev/49Z4MEN
After: https://share.firefox.dev/4ds1cq3