### PR TITLE
Fix CI and remove usage of actions-rs/cargo

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,73 +6,101 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
+  format:
+    name: Format
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - run: rustup update stable
+      - name: Check formatting
+        run: cargo fmt --all --check --verbose
 
+  build:
+    name: Build & Test
     strategy:
       matrix:
-        # List of targets to check. See https://forge.rust-lang.org/release/platform-support.html.
-        target: 
-          - aarch64-linux-android
-          - aarch64-unknown-linux-gnu
-          - x86_64-apple-darwin
-          - x86_64-pc-windows-msvc
+        target:
           - x86_64-unknown-linux-gnu
           - x86_64-unknown-linux-musl
-        # Specify the OS for each target. If a target needs `cross` to be installed, set `cross: true`.
+          - aarch64-apple-darwin
+          - x86_64-apple-darwin
+          - x86_64-pc-windows-msvc
         include:
-          - target: aarch64-linux-android
-            os: ubuntu-latest
-            cross: true
-          - target: aarch64-unknown-linux-gnu
-            os: ubuntu-latest
-            cross: true
-          - target: x86_64-apple-darwin
-            os: macos-latest
-          - target: x86_64-pc-windows-msvc
-            os: windows-latest
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
           - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
-            cross: true
+            is_musl: true
+          - target: x86_64-apple-darwin
+            os: macos-latest
+          - target: aarch64-apple-darwin
+            os: macos-latest
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
     runs-on: ${{ matrix.os }}
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - if: matrix.cross
-        name: Install cross
-        # Latest cross release 0.2.5 fails to link binaries for the `aar64-linux-android` target. A release is pending.
-        # Use a specific commit until the release is out.
-        run: cargo install --git https://github.com/cross-rs/cross.git --rev 44011c8 cross
+      - name: Install Rust
+        run: rustup update stable && rustup default stable && rustup target add ${{ matrix.target }}
+      - if: ${{ matrix.is_musl }}
+        name: Install musl-tools
+        run: sudo apt-get install -y musl-tools
       - name: Check samply-api with default features
-        uses: actions-rs/cargo@v1
-        with:
-            use-cross: ${{ matrix.cross}}
-            command: check
-            args: -p samply-api --verbose --target=${{ matrix.target }}
+        run: cargo check -p samply-api --verbose --target=${{ matrix.target }}
       - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-            use-cross: ${{ matrix.cross}}
-            command: build
-            args: --workspace --verbose --target=${{ matrix.target }}
+        run: cargo build --workspace --verbose --target=${{ matrix.target }}
       - name: Test
-        uses: actions-rs/cargo@v1
-        with:
-            use-cross: ${{ matrix.cross}}
-            command: test
-            args: --workspace --verbose --target=${{ matrix.target }}
-      # The formatting check could be done just once because it's completly target independant.
-      # For the sake of simplicity, it's done for each target.
-      - name: Check formatting
-        uses: actions-rs/cargo@v1
-        with:
-            command: fmt
-            args: -- --check --verbose
+        run: cargo test --workspace --verbose --target=${{ matrix.target }}
       - name: Clippy
-        uses: actions-rs/cargo@v1
-        with:
-            use-cross: ${{ matrix.cross}}
-            command: clippy
-            args: --workspace --verbose --target=${{ matrix.target }} -- -Dwarnings
+        run: cargo clippy --workspace --verbose --target=${{ matrix.target }} -- -Dwarnings
+
+  cross-compile:
+    name: With Cross
+    strategy:
+      matrix:
+        target:
+          - aarch64-unknown-linux-gnu
+          - aarch64-linux-android
+        include:
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: aarch64-linux-android
+            os: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install Rust
+        run: rustup update stable && rustup default stable && rustup target add ${{ matrix.target }}
+      - name: Install cross
+        # Latest cross release 0.2.5 fails to link binaries for the `aarch64-linux-android` target. A release is pending.
+        # Use a specific commit until the release is out. See https://github.com/cross-rs/cross/issues/1222
+        run: cargo install --git https://github.com/cross-rs/cross.git --rev 44011c8 cross
+      - name: Build
+        run: cross build --workspace --verbose --target=${{ matrix.target }}
+      - name: Test
+        run: cross test --workspace --verbose --target=${{ matrix.target }}
+      - name: Clippy
+        run: cross clippy --workspace --verbose --target=${{ matrix.target }} -- -Dwarnings
+
+  aarch64-win:
+    name: Aarch64 Windows
+    strategy:
+      matrix:
+        target:
+          - aarch64-pc-windows-msvc
+        include:
+          - target: aarch64-pc-windows-msvc
+            os: windows-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install Rust
+        run: rustup update stable && rustup default stable && rustup target add ${{ matrix.target }}
+      - name: Check
+        run: cargo check --workspace --verbose --target=${{ matrix.target }}
+      - name: Clippy
+        run: cargo clippy --workspace --verbose --target=${{ matrix.target }} -- -Dwarnings


### PR DESCRIPTION
The macOS build recently started failing because it kept getting aborted half-way through, I'm not sure what caused this.

But I wanted to change the way CI is setup anyway because actions-rs/cargo seems unmaintained and uses something old I got a deprecation warning about at some point, but I forgot what exactly and where I saw the warning.

Anyway, with these changes, CI is green again.

I've also added a `cargo check` job for aarch64 Windows.