### PR TITLE
Only request elevation once

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1842,6 +1842,7 @@ dependencies = [
  "etw-reader",
  "flate2",
  "framehop",
+ "fs4",
  "futures-util",
  "fxhash",
  "fxprof-processed-profile",

--- a/samply/Cargo.toml
+++ b/samply/Cargo.toml
@@ -49,6 +49,7 @@ ctrlc = "3.4.4"
 log = "0.4.21"
 env_logger = "0.11.3"
 cfg-if = "1.0.0"
+fs4 = "0.8.2"
 
 [target.'cfg(any(target_os = "android", target_os = "macos", target_os = "linux"))'.dependencies]
 
@@ -98,7 +99,8 @@ features =  ["Win32",
              "Win32_System_SystemInformation",
              "Win32_System_Threading",
              "Win32_System_Time",
-             "Win32_System_WindowsProgramming"]
+             "Win32_System_WindowsProgramming",
+             "Win32_UI_WindowsAndMessaging"]
 
 [dependencies.object]
 default-features = false

--- a/samply/src/main.rs
+++ b/samply/src/main.rs
@@ -338,7 +338,8 @@ impl ImportArgs {
         let profile_name = if let Some(profile_name) = &self.profile_creation_args.profile_name {
             profile_name.clone()
         } else {
-            "Imported perf profile".to_string()
+            let name = self.file.file_name().unwrap_or(self.file.as_os_str());
+            name.to_string_lossy().into()
         };
         ProfileCreationProps {
             profile_name,

--- a/samply/src/main.rs
+++ b/samply/src/main.rs
@@ -82,6 +82,11 @@ enum Action {
 
     /// Import a perf.data file and display the profile.
     Import(ImportArgs),
+
+    #[cfg(target_os = "windows")]
+    #[clap(hide = true)]
+    /// Used in the elevated helper process.
+    RunElevatedHelper(RunElevatedHelperArgs),
 }
 
 #[derive(Debug, Args)]
@@ -234,6 +239,15 @@ pub struct ProfileCreationArgs {
     per_cpu_threads: bool,
 }
 
+#[derive(Debug, Args)]
+struct RunElevatedHelperArgs {
+    #[arg(long)]
+    ipc_directory: PathBuf,
+
+    #[arg(long)]
+    output_path: PathBuf,
+}
+
 fn main() {
     env_logger::init();
 
@@ -315,6 +329,13 @@ fn main() {
                 }
             };
             std::process::exit(exit_status.code().unwrap_or(0));
+        }
+        #[cfg(target_os = "windows")]
+        Action::RunElevatedHelper(RunElevatedHelperArgs {
+            ipc_directory,
+            output_path,
+        }) => {
+            windows::run_elevated_helper(&ipc_directory, output_path);
         }
     }
 }

--- a/samply/src/shared/recording_props.rs
+++ b/samply/src/shared/recording_props.rs
@@ -26,6 +26,17 @@ pub enum RecordingMode {
     Launch(ProcessLaunchProps),
 }
 
+impl RecordingMode {
+    #[allow(dead_code)]
+    pub fn is_attach_mode(&self) -> bool {
+        match self {
+            RecordingMode::All => true,
+            RecordingMode::Pid(_) => true,
+            RecordingMode::Launch(_) => false,
+        }
+    }
+}
+
 /// Properties which are meaningful both for recording a profile and
 /// for converting a perf.data file to a profile.
 #[derive(Debug, Clone)]

--- a/samply/src/windows/console.rs
+++ b/samply/src/windows/console.rs
@@ -1,0 +1,19 @@
+use std::ffi::CStr;
+
+use windows::core::PCSTR;
+use windows::Win32::Foundation::HWND;
+use windows::Win32::UI::WindowsAndMessaging::{FindWindowA, ShowWindow, SW_HIDE};
+
+/// Find the window associated with the console and hide it
+pub fn hide_console() {
+    unsafe {
+        let console_window_name = CStr::from_bytes_with_nul(b"ConsoleWindowClass\0").unwrap();
+        let console_window = FindWindowA(
+            PCSTR::from_raw(console_window_name.as_ptr() as *const u8),
+            PCSTR::null(),
+        );
+        if console_window != HWND(0) {
+            let _ = ShowWindow(console_window, SW_HIDE);
+        }
+    }
+}

--- a/samply/src/windows/elevated_helper.rs
+++ b/samply/src/windows/elevated_helper.rs
@@ -1,0 +1,192 @@
+use std::error::Error;
+use std::path::{Path, PathBuf};
+
+use serde_derive::{Deserialize, Serialize};
+
+use crate::shared::recording_props::{RecordingMode, RecordingProps};
+
+use super::utility_process::{
+    run_child, UtilityProcess, UtilityProcessChild, UtilityProcessParent, UtilityProcessSession,
+};
+use super::xperf::Xperf;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "t", content = "c")]
+enum ElevatedHelperRequestMsg {
+    StartXperf(ElevatedRecordingProps),
+    StopXperf,
+    GetKernelModules,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ElevatedRecordingProps {
+    pub time_limit_seconds: Option<f64>,
+    pub interval_nanos: u64,
+    pub coreclr: bool,
+    pub coreclr_allocs: bool,
+    pub vm_hack: bool,
+    pub is_attach: bool,
+}
+
+impl ElevatedRecordingProps {
+    pub fn from_recording_props(
+        recording_props: &RecordingProps,
+        recording_mode: &RecordingMode,
+    ) -> Self {
+        Self {
+            time_limit_seconds: recording_props.time_limit.map(|l| l.as_secs_f64()),
+            interval_nanos: recording_props.interval.as_nanos().try_into().unwrap(),
+            coreclr: recording_props.coreclr,
+            coreclr_allocs: recording_props.coreclr_allocs,
+            vm_hack: recording_props.vm_hack,
+            is_attach: recording_mode.is_attach_mode(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "t", content = "c")]
+#[allow(clippy::enum_variant_names)]
+enum ElevatedHelperReplyMsg {
+    AckStartXperf,
+    AckStopXperf(PathBuf),
+    AckGetKernelModules,
+}
+
+// Runs in the helper process which has Administrator privileges.
+pub fn run_elevated_helper(ipc_directory: &Path, output_path: PathBuf) {
+    let child = ElevatedHelperChild::new(output_path);
+    run_child::<ElevatedHelper>(ipc_directory, child)
+}
+
+pub struct ElevatedHelperSession {
+    elevated_session: UtilityProcessSession<ElevatedHelper>,
+}
+
+impl ElevatedHelperSession {
+    pub fn new(output_path: PathBuf) -> Result<Self, Box<dyn Error + Send + Sync>> {
+        let parent = ElevatedHelperParent { output_path };
+        let elevated_session = UtilityProcessSession::spawn_process(parent)?;
+        Ok(Self { elevated_session })
+    }
+
+    pub fn start_xperf(
+        &mut self,
+        recording_props: &RecordingProps,
+        recording_mode: &RecordingMode,
+    ) -> Result<(), Box<dyn Error + Send + Sync>> {
+        let xperf_args =
+            ElevatedRecordingProps::from_recording_props(recording_props, recording_mode);
+        match self
+            .elevated_session
+            .send_msg_and_wait_for_response(ElevatedHelperRequestMsg::StartXperf(xperf_args))
+        {
+            Ok(reply) => match reply {
+                ElevatedHelperReplyMsg::AckStartXperf => Ok(()),
+                other_msg => {
+                    Err(format!("Unexpected reply to StartXperf msg: {other_msg:?}").into())
+                }
+            },
+            Err(err) => {
+                eprintln!("Could not start xperf: {err}");
+                std::process::exit(1);
+            }
+        }
+    }
+
+    pub fn stop_xperf(&mut self) -> Result<PathBuf, Box<dyn Error + Send + Sync>> {
+        let reply = self
+            .elevated_session
+            .send_msg_and_wait_for_response(ElevatedHelperRequestMsg::StopXperf)?;
+        match reply {
+            ElevatedHelperReplyMsg::AckStopXperf(path) => Ok(path),
+            other_msg => Err(format!("Unexpected reply to StartXperf msg: {other_msg:?}").into()),
+        }
+    }
+
+    pub fn shutdown(self) {
+        self.elevated_session.shutdown()
+    }
+}
+
+struct ElevatedHelper;
+
+impl UtilityProcess for ElevatedHelper {
+    const PROCESS_TYPE: &'static str = "windows-elevated-helper";
+    type Child = ElevatedHelperChild;
+    type Parent = ElevatedHelperParent;
+    type ParentToChildMsg = ElevatedHelperRequestMsg;
+    type ChildToParentMsg = ElevatedHelperReplyMsg;
+}
+
+struct ElevatedHelperParent {
+    output_path: PathBuf,
+}
+
+impl UtilityProcessParent for ElevatedHelperParent {
+    fn spawn_child(self, ipc_directory: &Path) {
+        let self_path = std::env::current_exe().expect("Couldn't obtain path of this binary");
+        // eprintln!(
+        //     "Run this: {} run-elevated-helper --ipc-directory {} --output-path {}",
+        //     self_path.to_string_lossy(),
+        //     ipc_directory.to_string_lossy(),
+        //     self.output_path.to_string_lossy()
+        // );
+
+        // let mut cmd = std::process::Command::new(&self_path);
+        let mut cmd = runas::Command::new(self_path);
+        cmd.arg("run-elevated-helper");
+
+        cmd.arg("--ipc-directory");
+        cmd.arg(ipc_directory);
+        cmd.arg("--output-path");
+        cmd.arg(expand_full_filename_with_cwd(&self.output_path));
+
+        let _ = cmd.status().expect("Failed to execute elevated helper");
+    }
+}
+
+pub fn expand_full_filename_with_cwd(filename: &Path) -> PathBuf {
+    if filename.is_absolute() {
+        filename.to_path_buf()
+    } else {
+        let mut fullpath = std::env::current_dir().unwrap();
+        fullpath.push(filename);
+        fullpath
+    }
+}
+
+struct ElevatedHelperChild {
+    output_path: PathBuf,
+    xperf: Xperf,
+}
+
+impl ElevatedHelperChild {
+    // Runs in the helper process which has Administrator privileges.
+    pub fn new(output_path: PathBuf) -> Self {
+        Self {
+            xperf: Xperf::new(),
+            output_path,
+        }
+    }
+}
+
+impl UtilityProcessChild<ElevatedHelperRequestMsg, ElevatedHelperReplyMsg> for ElevatedHelperChild {
+    // Runs in the helper process which has Administrator privileges.
+    fn handle_message(
+        &mut self,
+        msg: ElevatedHelperRequestMsg,
+    ) -> Result<ElevatedHelperReplyMsg, Box<dyn Error + Send + Sync>> {
+        match msg {
+            ElevatedHelperRequestMsg::StartXperf(props) => {
+                self.xperf.start_xperf(&self.output_path, &props)?;
+                Ok(ElevatedHelperReplyMsg::AckStartXperf)
+            }
+            ElevatedHelperRequestMsg::StopXperf => {
+                let output_file = self.xperf.stop_xperf()?;
+                Ok(ElevatedHelperReplyMsg::AckStopXperf(output_file))
+            }
+            ElevatedHelperRequestMsg::GetKernelModules => Err("todo".into()),
+        }
+    }
+}

--- a/samply/src/windows/mod.rs
+++ b/samply/src/windows/mod.rs
@@ -1,7 +1,12 @@
+mod console;
 mod coreclr;
+mod elevated_helper;
 mod etw_gecko;
 pub mod import;
 mod profile_context;
 pub mod profiler;
+mod utility_process;
 mod winutils;
 mod xperf;
+
+pub use elevated_helper::run_elevated_helper;

--- a/samply/src/windows/profile_context.rs
+++ b/samply/src/windows/profile_context.rs
@@ -128,16 +128,6 @@ fn strip_thread_numbers(name: &str) -> &str {
     name
 }
 
-fn expand_full_filename_with_cwd(filename: &Path) -> PathBuf {
-    if filename.is_absolute() {
-        filename.to_path_buf()
-    } else {
-        let mut fullpath = std::env::current_dir().unwrap();
-        fullpath.push(filename);
-        fullpath
-    }
-}
-
 // Known profiler categories, lazy-created
 #[derive(PartialEq, Eq, Hash, Copy, Clone, Debug)]
 pub enum KnownCategory {

--- a/samply/src/windows/utility_process/child.rs
+++ b/samply/src/windows/utility_process/child.rs
@@ -1,0 +1,83 @@
+use std::error::Error;
+use std::path::Path;
+
+use crate::windows::console::hide_console;
+
+use super::file_channel::BidiChannelCreator;
+use super::shared::{
+    ChildToParentMsgWrapper, InitMessage, ParentToChildMsgWrapper, PKG_NAME, PKG_VERSION,
+};
+use super::traits::{UtilityProcess, UtilityProcessChild};
+
+pub fn run_child<T: UtilityProcess>(ipc_directory: &Path, child: T::Child) {
+    match run_child_internal::<T>(ipc_directory, child) {
+        Ok(()) => {}
+        Err(e) => log::error!("Error running elevated helper: {e:?}"),
+    }
+}
+
+pub fn run_child_internal<T: UtilityProcess>(
+    ipc_directory: &Path,
+    mut child: T::Child,
+) -> Result<(), Box<dyn Error + Send + Sync>> {
+    hide_console();
+
+    let (mut receiver, mut sender) = BidiChannelCreator::open_in_child(ipc_directory)?;
+
+    let init_msg: ParentToChildMsgWrapper<T::ParentToChildMsg> = receiver.recv_blocking()?;
+    if let Err(e) = check_init_msg::<T>(init_msg) {
+        let _ = sender.send(ChildToParentMsgWrapper::Err(e.to_string()));
+        return Err(e);
+    }
+    sender.send(ChildToParentMsgWrapper::AckInit)?;
+
+    let mut shutting_down = false;
+    while !shutting_down {
+        let msg: ParentToChildMsgWrapper<T::ParentToChildMsg> = receiver.recv_blocking()?;
+        let reply: ChildToParentMsgWrapper<T::ChildToParentMsg> = match msg {
+            init_msg @ ParentToChildMsgWrapper::Init { .. } => ChildToParentMsgWrapper::Err(
+                format!("Unexpected init message after initialization: {init_msg:?}"),
+            ),
+            ParentToChildMsgWrapper::Msg(msg) => match child.handle_message(msg) {
+                Ok(reply) => ChildToParentMsgWrapper::AckMsg(reply),
+                Err(e) => ChildToParentMsgWrapper::Err(e.to_string()),
+            },
+            ParentToChildMsgWrapper::Shutdown => {
+                shutting_down = true;
+                ChildToParentMsgWrapper::AckShutdown
+            }
+        };
+        sender.send(reply)?;
+    }
+
+    Ok(())
+}
+
+fn check_init_msg<T: UtilityProcess>(
+    init_msg: ParentToChildMsgWrapper<T::ParentToChildMsg>,
+) -> Result<(), Box<dyn Error + Send + Sync>> {
+    let ParentToChildMsgWrapper::Init(init_msg) = init_msg else {
+        return Err(format!("Unexpected init message type: {init_msg:?}").into());
+    };
+
+    let InitMessage {
+        helper_type,
+        pkg_name,
+        pkg_version,
+    } = init_msg;
+
+    if helper_type != T::PROCESS_TYPE {
+        return Err(format!(
+            "Unexpected helper_type {helper_type}, expected {}",
+            T::PROCESS_TYPE
+        )
+        .into());
+    }
+    if pkg_name != PKG_NAME {
+        return Err(format!("Unexpected pkg_name {pkg_name}, expected {PKG_NAME}").into());
+    }
+    if pkg_version != PKG_VERSION {
+        return Err(format!("Unexpected pkg_version {pkg_version}, expected {PKG_VERSION}").into());
+    }
+    Ok(())
+}

--- a/samply/src/windows/utility_process/file_channel.rs
+++ b/samply/src/windows/utility_process/file_channel.rs
@@ -1,0 +1,212 @@
+//! This file contains an implementation of a bidirectional communication channel with
+//! a remote process using files in a temporary directory.
+//!
+//! It was created for use case of having the root samply process control an elevated
+//! helper process which collects ETW information. The elevated process is launched
+//! with "runas". The elevated process is not a child process of the parent samply
+//! process, so it doesn't inherit any handles for e.g. unnamed pipes.
+//!
+//! We could have probably used sockets for communication instead.
+//!
+//! The implementation in this file uses two text files and four lock files.
+//! The lock files allow one side to block until the other side has written a new
+//! message into the text file. They also allow one side to detect when the other
+//! side has gone away prematurely - the file lock will be lifted but the text file
+//! won't have any new content.
+//!
+//! The messages are written as length-delimited JSON. This is good enough for our
+//! purposes.
+
+use std::error::Error;
+use std::fmt::Debug;
+use std::fs::OpenOptions;
+use std::io::{Read, Write};
+use std::marker::PhantomData;
+use std::path::Path;
+
+use fs4::{lock_contended_error, FileExt};
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+
+#[derive(Debug)]
+struct FileMessageWriter<T> {
+    file: std::fs::File,
+    buf: Vec<u8>,
+    _phantom: PhantomData<T>,
+}
+
+impl<T: Serialize> FileMessageWriter<T> {
+    pub fn new(file: std::fs::File) -> Self {
+        Self {
+            file,
+            buf: Vec::new(),
+            _phantom: PhantomData,
+        }
+    }
+
+    pub fn send(&mut self, msg: T) -> Result<(), Box<dyn Error + Send + Sync>> {
+        self.buf.clear();
+        serde_json::to_writer(&mut self.buf, &msg)?;
+        let len = u32::try_from(self.buf.len())?;
+        self.file.write_all(&len.to_be_bytes())?;
+        self.file.write_all(&self.buf)?;
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+struct FileMessageReader<T> {
+    file: std::fs::File,
+    buf: Vec<u8>,
+    _phantom: PhantomData<T>,
+}
+
+impl<T: DeserializeOwned> FileMessageReader<T> {
+    pub fn new(file: std::fs::File) -> Self {
+        Self {
+            file,
+            buf: Vec::new(),
+            _phantom: PhantomData,
+        }
+    }
+
+    pub fn recv(&mut self) -> Result<T, Box<dyn Error + Send + Sync>> {
+        let mut len_bytes = [0; 4];
+        self.file.read_exact(&mut len_bytes)?;
+        let msg_len = u32::from_be_bytes(len_bytes);
+        let msg_len = usize::try_from(msg_len).unwrap();
+        self.buf.resize(msg_len, 0);
+        self.file.read_exact(&mut self.buf)?;
+        let msg_res = serde_json::from_slice(&self.buf);
+        Ok(msg_res?)
+    }
+}
+
+#[derive(Debug)]
+pub struct Receiver<T> {
+    reader: FileMessageReader<T>,
+    /// Locked by the other side most of the time; only unlocked once a new message is available.
+    current_lock: std::fs::File,
+    /// Becomes current_lock once current_lock is unlocked.
+    next_lock: std::fs::File,
+}
+
+impl<T: DeserializeOwned> Receiver<T> {
+    pub fn open(path: &Path, create: bool) -> std::io::Result<Self> {
+        let mut options = OpenOptions::new();
+        options.create(create).write(create).read(true);
+        let msgs_file = options.open(path)?;
+        let current_lock = options.open(path.with_extension("lock1"))?;
+        let next_lock = options.open(path.with_extension("lock2"))?;
+        let reader = FileMessageReader::new(msgs_file);
+        Ok(Self {
+            reader,
+            current_lock,
+            next_lock,
+        })
+    }
+
+    fn poll_until_other_side_exists(&self) -> std::io::Result<()> {
+        // Poll until self.current_lock is locked by the other side.
+        loop {
+            match self.current_lock.try_lock_exclusive() {
+                Ok(()) => {
+                    // Not locked yet.
+                    self.current_lock.unlock().unwrap();
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::Interrupted => {}
+                Err(e) if e.raw_os_error() == lock_contended_error().raw_os_error() => {
+                    // Success! The helper process now owns the file lock of self.current_lock.
+                    break;
+                }
+                Err(e) => return Err(e),
+            }
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        }
+
+        Ok(())
+    }
+
+    pub fn recv_blocking(&mut self) -> Result<T, Box<dyn Error + Send + Sync>> {
+        self.current_lock.lock_exclusive()?; // block until init message is written
+        let msg = self.reader.recv()?;
+        self.current_lock.unlock()?;
+        std::mem::swap(&mut self.current_lock, &mut self.next_lock);
+        Ok(msg)
+    }
+}
+
+#[derive(Debug)]
+pub struct Sender<T> {
+    writer: FileMessageWriter<T>,
+    /// Always locked by us.
+    current_lock: std::fs::File,
+    /// Becomes current_lock once a message has been written, just before we unlock the old current_lock.
+    next_lock: std::fs::File,
+}
+
+impl<T: Serialize> Sender<T> {
+    pub fn open(path: &Path, create: bool) -> std::io::Result<Self> {
+        let mut options = OpenOptions::new();
+        options.create(create).write(true);
+        let msgs_file = options.open(path)?;
+        let current_lock = options.open(path.with_extension("lock1"))?;
+        let next_lock = options.open(path.with_extension("lock2"))?;
+        current_lock.lock_exclusive()?;
+        let writer = FileMessageWriter::new(msgs_file);
+        Ok(Self {
+            writer,
+            current_lock,
+            next_lock,
+        })
+    }
+
+    pub fn send(&mut self, msg: T) -> Result<(), Box<dyn Error + Send + Sync>> {
+        self.writer.send(msg)?;
+        self.next_lock.lock_exclusive()?; // ready next lock
+        std::mem::swap(&mut self.current_lock, &mut self.next_lock);
+        self.next_lock.unlock()?; // indicate that reply has been written
+        Ok(())
+    }
+}
+
+pub struct BidiChannelCreator<ParentToChildMsg, ChildToParentMsg> {
+    receiver: Receiver<ChildToParentMsg>,
+    sender: Sender<ParentToChildMsg>,
+}
+
+impl<ParentToChildMsg, ChildToParentMsg> BidiChannelCreator<ParentToChildMsg, ChildToParentMsg>
+where
+    ParentToChildMsg: Serialize + DeserializeOwned,
+    ChildToParentMsg: Serialize + DeserializeOwned,
+{
+    pub fn create_in_parent(ipc_dir: &Path) -> std::io::Result<Self> {
+        let msgs_to_child_path = ipc_dir.join("msgs_to_child.txt");
+        let sender = Sender::open(&msgs_to_child_path, true)?;
+
+        let msgs_to_parent_path = ipc_dir.join("msgs_to_parent.txt");
+        let receiver = Receiver::open(&msgs_to_parent_path, true)?;
+
+        Ok(Self { receiver, sender })
+    }
+
+    pub fn open_in_child(
+        ipc_dir: &Path,
+    ) -> std::io::Result<(Receiver<ParentToChildMsg>, Sender<ChildToParentMsg>)> {
+        let msgs_to_child_path = ipc_dir.join("msgs_to_child.txt");
+        let receiver = Receiver::open(&msgs_to_child_path, false)?;
+
+        let msgs_to_parent_path = ipc_dir.join("msgs_to_parent.txt");
+        let sender = Sender::open(&msgs_to_parent_path, false)?;
+
+        Ok((receiver, sender))
+    }
+
+    pub fn wait_for_child_to_connect(
+        self,
+    ) -> std::io::Result<(Receiver<ChildToParentMsg>, Sender<ParentToChildMsg>)> {
+        self.receiver.poll_until_other_side_exists()?;
+
+        Ok((self.receiver, self.sender))
+    }
+}

--- a/samply/src/windows/utility_process/mod.rs
+++ b/samply/src/windows/utility_process/mod.rs
@@ -1,0 +1,24 @@
+//! This module contains APIs which allow launching a utility process and
+//! having bidirectional communication with it.
+//!
+//! Usage:
+//!
+//!  - Implement the [`UtilityProcess`] trait and its associated traits.
+//!  - In the parent process, create a [`UtilityProcessSession`]. This will set up a
+//!    communication channel on the file system and then call your implementation
+//!    of [`UtilityProcessParent::spawn_child`] to launch the child.
+//!  - In the child process, call [`run_child`]. This will process incoming messages
+//!    and call your implementation of [`UtilityProcessChild::handle_message`] for
+//!    each message.
+//!  - In the parent process, call [`UtilityProcessSession::send_msg_and_wait_for_response`]
+//!    whenever you want to send a message.
+
+mod child;
+mod file_channel;
+mod parent;
+mod shared;
+mod traits;
+
+pub use child::run_child;
+pub use parent::UtilityProcessSession;
+pub use traits::*;

--- a/samply/src/windows/utility_process/parent.rs
+++ b/samply/src/windows/utility_process/parent.rs
@@ -1,0 +1,84 @@
+use std::error::Error;
+use std::fmt::Debug;
+
+use tempfile::TempDir;
+
+use super::file_channel::{BidiChannelCreator, Receiver, Sender};
+use super::shared::{
+    ChildToParentMsgWrapper, InitMessage, ParentToChildMsgWrapper, PKG_NAME, PKG_VERSION,
+};
+use super::traits::{UtilityProcess, UtilityProcessParent};
+
+#[derive(Debug)]
+pub struct UtilityProcessSession<T: UtilityProcess> {
+    _ipc_dir: TempDir,
+    spawn_thread: std::thread::JoinHandle<()>,
+    sender: Sender<ParentToChildMsgWrapper<T::ParentToChildMsg>>,
+    receiver: Receiver<ChildToParentMsgWrapper<T::ChildToParentMsg>>,
+}
+
+impl<T: UtilityProcess> UtilityProcessSession<T> {
+    pub fn spawn_process(parent: T::Parent) -> Result<Self, Box<dyn Error + Send + Sync>> {
+        let ipc_dir = TempDir::with_prefix("samply-elevated-helper-")?;
+        let channel = BidiChannelCreator::create_in_parent(ipc_dir.path())?;
+
+        let ipc_dir_path = ipc_dir.path().to_owned();
+        let spawn_thread = std::thread::Builder::new()
+            .name("UtilityProcessSession".into())
+            .spawn(move || parent.spawn_child(&ipc_dir_path))?;
+        let (receiver, sender) = channel.wait_for_child_to_connect()?;
+
+        let mut session = Self {
+            _ipc_dir: ipc_dir,
+            spawn_thread,
+            sender,
+            receiver,
+        };
+
+        let init_reply = session.send_msg_and_wait_for_response_impl(
+            ParentToChildMsgWrapper::Init(InitMessage {
+                helper_type: T::PROCESS_TYPE.into(),
+                pkg_name: PKG_NAME.into(),
+                pkg_version: PKG_VERSION.into(),
+            }),
+        )?;
+        match init_reply {
+            ChildToParentMsgWrapper::AckInit => Ok(session),
+            ChildToParentMsgWrapper::Err(err) => Err(err.into()),
+            other_reply => Err(format!("Unexpected reply to init msg: {other_reply:?}").into()),
+        }
+    }
+
+    pub fn send_msg_and_wait_for_response(
+        &mut self,
+        msg: T::ParentToChildMsg,
+    ) -> Result<T::ChildToParentMsg, Box<dyn Error + Send + Sync>> {
+        let reply = self.send_msg_and_wait_for_response_impl(ParentToChildMsgWrapper::Msg(msg))?;
+        match reply {
+            ChildToParentMsgWrapper::AckMsg(reply) => Ok(reply),
+            ChildToParentMsgWrapper::Err(err) => Err(err.into()),
+            _ => Err(format!("Unexpected reply from helper: {reply:?}").into()),
+        }
+    }
+
+    fn send_msg_and_wait_for_response_impl(
+        &mut self,
+        msg: ParentToChildMsgWrapper<T::ParentToChildMsg>,
+    ) -> Result<ChildToParentMsgWrapper<T::ChildToParentMsg>, Box<dyn Error + Send + Sync>> {
+        log::info!("Sending message to elevated helper: {msg:?}");
+        self.sender.send(msg)?;
+        let reply: ChildToParentMsgWrapper<T::ChildToParentMsg> = self.receiver.recv_blocking()?;
+        log::info!("Received reply from elevated helper: {reply:?}");
+        Ok(reply)
+    }
+
+    pub fn shutdown(mut self) {
+        let reply_res = self.send_msg_and_wait_for_response_impl(ParentToChildMsgWrapper::Shutdown);
+        match reply_res {
+            Ok(ChildToParentMsgWrapper::AckShutdown) => {}
+            other_msg => log::warn!("Unexpected reply to Shutdown msg: {other_msg:?}"),
+        }
+
+        self.spawn_thread.join().unwrap();
+    }
+}

--- a/samply/src/windows/utility_process/shared.rs
+++ b/samply/src/windows/utility_process/shared.rs
@@ -1,0 +1,31 @@
+use std::fmt::Debug;
+
+use serde_derive::{Deserialize, Serialize};
+
+pub const PKG_VERSION: &str = env!("CARGO_PKG_VERSION");
+pub const PKG_NAME: &str = env!("CARGO_PKG_NAME");
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "t", content = "c")]
+pub enum ParentToChildMsgWrapper<T> {
+    Init(InitMessage),
+    Msg(T),
+    Shutdown,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InitMessage {
+    pub helper_type: String,
+    pub pkg_name: String,
+    pub pkg_version: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "t", content = "c")]
+#[allow(clippy::enum_variant_names)]
+pub enum ChildToParentMsgWrapper<T> {
+    AckInit,
+    AckMsg(T),
+    AckShutdown,
+    Err(String),
+}

--- a/samply/src/windows/utility_process/traits.rs
+++ b/samply/src/windows/utility_process/traits.rs
@@ -1,0 +1,25 @@
+use std::error::Error;
+use std::fmt::Debug;
+use std::path::Path;
+
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+
+pub trait UtilityProcess {
+    const PROCESS_TYPE: &'static str;
+    type Parent: UtilityProcessParent;
+    type Child: UtilityProcessChild<Self::ParentToChildMsg, Self::ChildToParentMsg>;
+    type ParentToChildMsg: Serialize + DeserializeOwned + Debug;
+    type ChildToParentMsg: Serialize + DeserializeOwned + Debug;
+}
+
+pub trait UtilityProcessParent: Send + 'static {
+    fn spawn_child(self, ipc_directory: &Path);
+}
+
+pub trait UtilityProcessChild<ParentToChildMsg, ChildToParentMsg> {
+    fn handle_message(
+        &mut self,
+        msg: ParentToChildMsg,
+    ) -> Result<ChildToParentMsg, Box<dyn Error + Send + Sync>>;
+}


### PR DESCRIPTION
The UAC prompt when stopping the profiler is very annoying.

This PR adds a helper process that only needs to be elevated once and which launches both xperf processes. In the future we'll be able to use this helper process to implement more of what xperf is doing at the moment.

I got a bit carried away during the implementation. There's probably a simpler implementation hiding in there. The current implementation uses no less than four lock files, and two more files for the actual IPC messages, all stored in a TempDir.