### PR TITLE
Stop running rustup update in CI because it's broken on Windows as of today.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install Rust
-        run: rustup update stable && rustup default stable && rustup target add ${{ matrix.target }}
+        run: rustup target add ${{ matrix.target }}
       - if: ${{ matrix.is_musl }}
         name: Install musl-tools
         run: sudo apt-get install -y musl-tools


### PR DESCRIPTION
The error message says: error: could not remove 'setup' file: 'C:\Users\runneradmin\.cargo\bin/rustup-init.exe': Access is denied. (os error 5)