### PR TITLE
Allow attaching to existing macOS process

### DIFF
--- a/samply/resources/entitlement.xml
+++ b/samply/resources/entitlement.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.cs.debugger</key>
+	<true/>
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<true/>
+</dict>
+</plist>

--- a/samply/src/mac/process_launcher.rs
+++ b/samply/src/mac/process_launcher.rs
@@ -238,10 +238,7 @@ pub struct AcceptedTask {
 }
 
 impl AcceptedTask {
-    pub fn take_task(&mut self) -> mach_port_t {
-        // TODO: I think it's safe to not do this mem::replace; we may need to resume the task
-        // in start_execution()
-        //mem::replace(&mut self.task, MACH_PORT_NULL)
+    pub fn task(&self) -> mach_port_t {
         self.task
     }
 

--- a/samply/src/mac/process_launcher.rs
+++ b/samply/src/mac/process_launcher.rs
@@ -2,7 +2,6 @@ use std::collections::BTreeMap;
 use std::ffi::{OsStr, OsString};
 use std::fs::File;
 use std::io::Write;
-use std::mem;
 use std::os::unix::prelude::OsStrExt;
 use std::path::PathBuf;
 use std::process::{Child, Command, ExitStatus};
@@ -86,14 +85,12 @@ impl TaskLauncher {
         let args: Vec<OsString> = args.into_iter().map(|a| a.into()).collect();
         let program: OsString = program.into();
 
-        Ok(
-            TaskLauncher {
-                program,
-                args,
-                child_env,
-                iteration_count,
-            },
-        )
+        Ok(TaskLauncher {
+            program,
+            args,
+            child_env,
+            iteration_count,
+        })
     }
 
     pub fn launch_child(&self) -> Child {
@@ -271,7 +268,9 @@ impl RootTaskRunner for ExistingProcessRunner {
 
         eprintln!("Profiling {}, press Ctrl-C to stop...", self.pid);
 
-        ctrl_c_receiver.blocking_recv().expect("Ctrl+C receiver failed");
+        ctrl_c_receiver
+            .blocking_recv()
+            .expect("Ctrl+C receiver failed");
 
         eprintln!("Done.");
 
@@ -291,8 +290,11 @@ impl ExistingProcessRunner {
             task_suspend(task);
             task
         };
-        task_accepter.queue_received_stuff(ReceivedStuff::AcceptedTask(AcceptedTask { task, pid, sender_channel: None }));
+        task_accepter.queue_received_stuff(ReceivedStuff::AcceptedTask(AcceptedTask {
+            task,
+            pid,
+            sender_channel: None,
+        }));
         ExistingProcessRunner { pid }
     }
 }
-

--- a/samply/src/mac/profiler.rs
+++ b/samply/src/mac/profiler.rs
@@ -113,7 +113,7 @@ pub fn start_recording(
             }
             let timeout = Duration::from_secs_f64(1.0);
             match task_accepter.next_message(timeout) {
-                Ok(ReceivedStuff::AcceptedTask(mut accepted_task)) => {
+                Ok(ReceivedStuff::AcceptedTask(accepted_task)) => {
                     let pid = accepted_task.get_id();
                     let (path_sender, path_receiver) = unbounded();
                     let send_result = task_sender.send(TaskInitOrShutdown::TaskInit(TaskInit {

--- a/samply/src/mac/profiler.rs
+++ b/samply/src/mac/profiler.rs
@@ -118,7 +118,7 @@ pub fn start_recording(
                     let (path_sender, path_receiver) = unbounded();
                     let send_result = task_sender.send(TaskInitOrShutdown::TaskInit(TaskInit {
                         start_time_mono: get_monotonic_timestamp(),
-                        task: accepted_task.take_task(),
+                        task: accepted_task.task(),
                         pid,
                         path_receiver,
                     }));

--- a/samply/src/mac/profiler.rs
+++ b/samply/src/mac/profiler.rs
@@ -10,7 +10,9 @@ use crossbeam_channel::unbounded;
 use serde_json::to_writer;
 
 use super::error::SamplingError;
-use super::process_launcher::{ExistingProcessRunner, MachError, ReceivedStuff, RootTaskRunner, TaskAccepter, TaskLauncher};
+use super::process_launcher::{
+    ExistingProcessRunner, MachError, ReceivedStuff, RootTaskRunner, TaskAccepter, TaskLauncher,
+};
 use super::sampler::{JitdumpOrMarkerPath, Sampler, TaskInit, TaskInitOrShutdown};
 use super::time::get_monotonic_timestamp;
 use crate::server::{start_server_main, ServerProps};
@@ -26,7 +28,7 @@ pub fn start_recording(
 ) -> Result<ExitStatus, MachError> {
     let mut unlink_aux_files = profile_creation_props.unlink_aux_files;
     let output_file = recording_props.output_file.clone();
-    let mut profile_name: String = "".to_owned();
+    let profile_name;
 
     let mut task_accepter = TaskAccepter::new()?;
 
@@ -43,7 +45,10 @@ pub fn start_recording(
             Box::new(ExistingProcessRunner::new(pid, &mut task_accepter))
         }
         RecordingMode::Launch(process_launch_props) => {
-            profile_name = process_launch_props.command_name.to_string_lossy().to_string();
+            profile_name = process_launch_props
+                .command_name
+                .to_string_lossy()
+                .to_string();
 
             let ProcessLaunchProps {
                 mut env_vars,
@@ -63,8 +68,13 @@ pub fn start_recording(
                 }
             }
 
-            let task_launcher = TaskLauncher::new(&command_name, &args, iteration_count,
-                &env_vars, task_accepter.extra_env_vars())?;
+            let task_launcher = TaskLauncher::new(
+                &command_name,
+                &args,
+                iteration_count,
+                &env_vars,
+                task_accepter.extra_env_vars(),
+            )?;
 
             Box::new(task_launcher)
         }

--- a/samply/src/mac/sampler.rs
+++ b/samply/src/mac/sampler.rs
@@ -87,7 +87,7 @@ impl Sampler {
 
         let root_task_init = match self.task_receiver.recv() {
             Ok(TaskInitOrShutdown::TaskInit(task_init)) => task_init,
-            Ok(TaskInitOrShutdown::Shutdown) =>  {
+            Ok(TaskInitOrShutdown::Shutdown) => {
                 eprintln!("Unexpected Shutdown message for root task?");
                 return Err(SamplingError::CouldNotObtainRootTask);
             }
@@ -133,7 +133,9 @@ impl Sampler {
                     let all_dead_timeout = Duration::from_secs_f32(0.5);
                     self.task_receiver.recv_timeout(all_dead_timeout).ok()
                 };
-                let Some(task_or_shutdown) = task_init_or_shutdown else { break };
+                let Some(task_or_shutdown) = task_init_or_shutdown else {
+                    break;
+                };
                 let task_init = match task_or_shutdown {
                     TaskInitOrShutdown::TaskInit(task_init) => task_init,
                     TaskInitOrShutdown::Shutdown => {


### PR DESCRIPTION
Implement attaching to existing mac processes. This needs samply to be signed with the debugger entitlement:

1. Create a file `ent.xml`:
```
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
	<key>com.apple.security.cs.debugger</key>
	<true/>
</dict>
</plist>
```
2. `cargo build`
3. `codesign --force --options runtime --sign - --entitlements ent.xml target/debug/samply`

The basic functionality works, but there is still work to do:

1. This doesn't capture jitdump or markers. It's possible to just watch /tmp/ for appropriately-named jitdump files, but a real solution would need cooperation with the existing process to notify it to dump all existing jit compiled info to jitdump files.
2. This won't capture child processes. That relies on the dyld preload to send the task of every new process back, and there's no preload here because there's no env vars set.

For 2, this might be possible to sort out if can set the dyld preload env var in the target process. I don't know if there's a simpler way to do this, but one idea is to load the preload shared library into the target (I think this is doable?) and then create a new thread in that process that calls an init function from the preload lib which will set the process env.