### PR TITLE
Don't error out parsing 32-bit types from 64-bit events

### DIFF
--- a/etw-reader/src/parser.rs
+++ b/etw-reader/src/parser.rs
@@ -391,21 +391,19 @@ impl TryParse<Address> for Parser<'_> {
         let prop_info = &self.cache[indx];
 
         if let PropertyDesc::Primitive(desc) = &prop_info.property.desc {
-            if self.event.is_64bit() {
-                if desc.in_type == InTypeUInt64
-                    || desc.in_type == InTypePointer
-                    || desc.in_type == InTypeHexInt64
-                {
-                    if std::mem::size_of::<u64>() != prop_info.buffer.len() {
-                        return Err(ParserError::LengthMismatch);
-                    }
-                    return Ok(Address::Address64(u64::from_ne_bytes(
-                        prop_info.buffer.try_into()?,
-                    )));
+            if desc.in_type == InTypeUInt64
+                || desc.in_type == InTypeHexInt64
+                || (desc.in_type == InTypePointer && self.event.is_64bit())
+            {
+                if std::mem::size_of::<u64>() != prop_info.buffer.len() {
+                    return Err(ParserError::LengthMismatch);
                 }
+                return Ok(Address::Address64(u64::from_ne_bytes(
+                    prop_info.buffer.try_into()?,
+                )));
             } else if desc.in_type == InTypeUInt32
-                || desc.in_type == InTypePointer
                 || desc.in_type == InTypeHexInt32
+                || (desc.in_type == InTypePointer && !self.event.is_64bit())
             {
                 if std::mem::size_of::<u32>() != prop_info.buffer.len() {
                     return Err(ParserError::LengthMismatch);


### PR DESCRIPTION
Both 32-bit and 64-bit events can contain 32 bit or 64 bit datatypes; it's only the pointer type that changes size.