### PR TITLE
Implement --unstable-presymbolicate

### DIFF
--- a/fxprof-processed-profile/src/frame_table.rs
+++ b/fxprof-processed-profile/src/frame_table.rs
@@ -33,7 +33,7 @@ impl FrameTable {
         resource_table: &mut ResourceTable,
         func_table: &mut FuncTable,
         native_symbol_table: &mut NativeSymbols,
-        global_libs: &GlobalLibTable,
+        global_libs: &mut GlobalLibTable,
         frame: InternalFrame,
     ) -> usize {
         let addresses = &mut self.addresses;
@@ -73,6 +73,9 @@ impl FrameTable {
                                 (Some(native_symbol), name_string_index)
                             }
                             None => {
+                                // This isn't in the pre-provided symbol table, and we know it's in a library.
+                                global_libs.add_lib_used_rva(lib_index, address);
+
                                 let location_string = format!("0x{address:x}");
                                 (None, string_table.index_for_string(&location_string))
                             }

--- a/fxprof-processed-profile/src/lib.rs
+++ b/fxprof-processed-profile/src/lib.rs
@@ -63,7 +63,7 @@ pub use category_color::CategoryColor;
 pub use counters::CounterHandle;
 pub use cpu_delta::CpuDelta;
 pub use frame::{Frame, FrameFlags, FrameInfo};
-pub use global_lib_table::LibraryHandle;
+pub use global_lib_table::{LibraryHandle, UsedLibraryAddressesIterator};
 pub use lib_mappings::LibMappings;
 pub use library_info::{LibraryInfo, Symbol, SymbolTable};
 pub use markers::*;

--- a/fxprof-processed-profile/src/profile.rs
+++ b/fxprof-processed-profile/src/profile.rs
@@ -11,7 +11,7 @@ use crate::cpu_delta::CpuDelta;
 use crate::fast_hash_map::FastHashMap;
 use crate::frame::{Frame, FrameInfo};
 use crate::frame_table::{InternalFrame, InternalFrameLocation};
-use crate::global_lib_table::{GlobalLibTable, LibraryHandle};
+use crate::global_lib_table::{GlobalLibTable, LibraryHandle, UsedLibraryAddressesIterator};
 use crate::lib_mappings::LibMappings;
 use crate::library_info::LibraryInfo;
 use crate::process::{Process, ThreadHandle};
@@ -601,7 +601,7 @@ impl Profile {
                 flags: frame_info.flags,
                 category_pair: frame_info.category_pair,
             };
-            let frame_index = thread.frame_index_for_frame(internal_frame, &self.global_libs);
+            let frame_index = thread.frame_index_for_frame(internal_frame, &mut self.global_libs);
             prefix =
                 Some(thread.stack_index_for_stack(prefix, frame_index, frame_info.category_pair));
         }
@@ -664,6 +664,10 @@ impl Profile {
 
     fn contains_js_function(&self) -> bool {
         self.threads.iter().any(|t| t.contains_js_function())
+    }
+
+    pub fn lib_used_rva_iter(&self) -> UsedLibraryAddressesIterator {
+        self.global_libs.lib_used_rva_iter()
     }
 }
 

--- a/fxprof-processed-profile/src/thread.rs
+++ b/fxprof-processed-profile/src/thread.rs
@@ -97,7 +97,7 @@ impl Thread {
     pub fn frame_index_for_frame(
         &mut self,
         frame: InternalFrame,
-        global_libs: &GlobalLibTable,
+        global_libs: &mut GlobalLibTable,
     ) -> usize {
         self.frame_table.index_for_frame(
             &mut self.string_table,

--- a/samply-symbols/src/lib.rs
+++ b/samply-symbols/src/lib.rs
@@ -256,7 +256,7 @@ pub use crate::shared::{
     MultiArchDisambiguator, OptionallySendFuture, PeCodeId, SourceFilePath, SymbolInfo,
     SyncAddressInfo,
 };
-pub use crate::symbol_map::SymbolMap;
+pub use crate::symbol_map::{SymbolMap, SymbolMapTrait};
 
 pub struct SymbolManager<H: FileAndPathHelper> {
     helper: Arc<H>,
@@ -304,6 +304,14 @@ where
     /// Obtain a symbol map for the library, given the (partial) `LibraryInfo`.
     /// At least the debug_id has to be given.
     pub async fn load_symbol_map(&self, library_info: &LibraryInfo) -> Result<SymbolMap<H>, Error> {
+        if let Some((fl, symbol_map)) = self
+            .helper()
+            .as_ref()
+            .get_symbol_map_for_library(library_info)
+        {
+            return Ok(SymbolMap::with_symbol_map_trait(fl, symbol_map));
+        }
+
         let debug_id = match library_info.debug_id {
             Some(debug_id) => debug_id,
             None => return Err(Error::NotEnoughInformationToIdentifySymbolMap),

--- a/samply-symbols/src/shared.rs
+++ b/samply-symbols/src/shared.rs
@@ -5,6 +5,7 @@ use std::future::Future;
 use std::marker::PhantomData;
 use std::ops::{Deref, Range};
 use std::str::FromStr;
+use std::sync::Arc;
 
 #[cfg(feature = "partial_read_stats")]
 use bitvec::{bitvec, prelude::BitVec};
@@ -14,6 +15,7 @@ use object::FileFlags;
 use uuid::Uuid;
 
 use crate::mapped_path::MappedPath;
+use crate::symbol_map::SymbolMapTrait;
 
 pub type FileAndPathHelperError = Box<dyn std::error::Error + Send + Sync + 'static>;
 pub type FileAndPathHelperResult<T> = std::result::Result<T, FileAndPathHelperError>;
@@ -402,6 +404,14 @@ pub trait FileAndPathHelper {
         &self,
         location: Self::FL,
     ) -> std::pin::Pin<Box<dyn OptionallySendFuture<Output = FileAndPathHelperResult<Self::F>> + '_>>;
+
+    /// Ask the helper to return a SymbolMap if it happens to have one available already.
+    fn get_symbol_map_for_library(
+        &self,
+        _info: &LibraryInfo,
+    ) -> Option<(Self::FL, Arc<dyn SymbolMapTrait + Send + Sync>)> {
+        None
+    }
 }
 
 /// Provides synchronous access to the raw bytes of a file.

--- a/samply-symbols/src/symbol_map.rs
+++ b/samply-symbols/src/symbol_map.rs
@@ -42,6 +42,7 @@ pub trait GetInnerSymbolMapWithLookupFramesExt<FC> {
 enum InnerSymbolMap<FC> {
     WithoutAddFile(Box<dyn GetInnerSymbolMap + Send + Sync>),
     WithAddFile(Box<dyn GetInnerSymbolMapWithLookupFramesExt<FC> + Send + Sync>),
+    Direct(Arc<dyn SymbolMapTrait + Send + Sync>),
 }
 
 pub struct SymbolMap<H: FileAndPathHelper> {
@@ -74,10 +75,22 @@ impl<H: FileAndPathHelper> SymbolMap<H> {
         }
     }
 
+    pub fn with_symbol_map_trait(
+        debug_file_location: H::FL,
+        inner: Arc<dyn SymbolMapTrait + Send + Sync>,
+    ) -> Self {
+        Self {
+            debug_file_location,
+            inner: InnerSymbolMap::Direct(inner),
+            helper: None,
+        }
+    }
+
     fn inner(&self) -> &dyn SymbolMapTrait {
         match &self.inner {
             InnerSymbolMap::WithoutAddFile(inner) => inner.get_inner_symbol_map(),
             InnerSymbolMap::WithAddFile(inner) => inner.get_inner_symbol_map().get_as_symbol_map(),
+            InnerSymbolMap::Direct(inner) => inner.as_ref(),
         }
     }
 
@@ -111,7 +124,7 @@ impl<H: FileAndPathHelper> SymbolMap<H> {
                     frames: Some(frames),
                 });
             }
-            (None, _) | (_, InnerSymbolMap::WithoutAddFile(_)) => {
+            (None, _) | (_, InnerSymbolMap::WithoutAddFile(_)) | (_, InnerSymbolMap::Direct(_)) => {
                 return Some(AddressInfo {
                     symbol,
                     frames: None,
@@ -168,7 +181,7 @@ impl<H: FileAndPathHelper> SymbolMap<H> {
     ) -> Option<Vec<FrameDebugInfo>> {
         let helper = self.helper.as_deref()?;
         let inner = match &self.inner {
-            InnerSymbolMap::WithoutAddFile(_) => return None,
+            InnerSymbolMap::WithoutAddFile(_) | InnerSymbolMap::Direct(_) => return None,
             InnerSymbolMap::WithAddFile(inner) => inner.get_inner_symbol_map(),
         };
 

--- a/samply/src/linux/profiler.rs
+++ b/samply/src/linux/profiler.rs
@@ -89,6 +89,7 @@ pub fn start_recording(
     let interval = recording_props.interval;
     let time_limit = recording_props.time_limit;
     let observer_thread = thread::spawn(move || {
+        let unstable_presymbolicate = profile_creation_props.unstable_presymbolicate;
         let mut converter = make_converter(interval, profile_creation_props);
 
         // Wait for the initial pid to profile.
@@ -120,6 +121,7 @@ pub fn start_recording(
             profile_another_pid_request_receiver,
             profile_another_pid_reply_sender,
             stop_receiver,
+            unstable_presymbolicate,
         );
     });
 
@@ -534,6 +536,7 @@ fn run_profiler(
     more_processes_request_receiver: Receiver<SamplerRequest>,
     more_processes_reply_sender: Sender<bool>,
     mut stop_receiver: oneshot::Receiver<()>,
+    unstable_presymbolicate: bool,
 ) {
     // eprintln!("Running...");
 
@@ -659,9 +662,18 @@ fn run_profiler(
 
     let profile = converter.finish();
 
-    let output_file = File::create(output_filename).unwrap();
-    let writer = BufWriter::new(output_file);
-    serde_json::to_writer(writer, &profile).expect("Couldn't write JSON");
+    {
+        let output_file = File::create(output_filename).unwrap();
+        let writer = BufWriter::new(output_file);
+        serde_json::to_writer(writer, &profile).expect("Couldn't write JSON");
+    }
+
+    if unstable_presymbolicate {
+        crate::shared::symbol_precog::presymbolicate(
+            &profile,
+            &output_filename.with_extension("syms.json"),
+        );
+    }
 }
 
 pub fn read_string_lossy<P: AsRef<Path>>(path: P) -> std::io::Result<String> {

--- a/samply/src/linux/profiler.rs
+++ b/samply/src/linux/profiler.rs
@@ -528,6 +528,7 @@ enum SamplerRequest {
     StopProfilingOncePerfEventsExhausted,
 }
 
+#[allow(clippy::too_many_arguments)]
 fn run_profiler(
     mut perf: PerfGroup,
     mut converter: Converter<

--- a/samply/src/linux/profiler.rs
+++ b/samply/src/linux/profiler.rs
@@ -259,6 +259,7 @@ fn start_profiling_pid(
         move || {
             let interval = recording_props.interval;
             let time_limit = recording_props.time_limit;
+            let unstable_presymbolicate = profile_creation_props.unstable_presymbolicate;
             let mut converter = make_converter(interval, profile_creation_props);
             let SamplerRequest::StartProfilingAnotherProcess(pid, attach_mode) =
                 profile_another_pid_request_receiver.recv().unwrap()
@@ -279,6 +280,7 @@ fn start_profiling_pid(
                 profile_another_pid_request_receiver,
                 profile_another_pid_reply_sender,
                 ctrl_c_receiver,
+                unstable_presymbolicate,
             )
         }
     });

--- a/samply/src/mac/profiler.rs
+++ b/samply/src/mac/profiler.rs
@@ -85,6 +85,8 @@ pub fn start_recording(
         ..profile_creation_props
     };
 
+    let unstable_presymbolicate = profile_creation_props.unstable_presymbolicate;
+
     let (task_sender, task_receiver) = unbounded();
 
     let sampler_thread = thread::spawn(move || {
@@ -208,6 +210,13 @@ pub fn start_recording(
         let file = File::create(&output_file).unwrap();
         let writer = BufWriter::new(file);
         to_writer(writer, &profile).expect("Couldn't write JSON");
+    }
+
+    if unstable_presymbolicate {
+        crate::shared::symbol_precog::presymbolicate(
+            &profile,
+            &output_file.with_extension("syms.json"),
+        );
     }
 
     if let Some(server_props) = server_props {

--- a/samply/src/main.rs
+++ b/samply/src/main.rs
@@ -237,6 +237,14 @@ pub struct ProfileCreationArgs {
     /// Create a separate thread for each CPU. Not supported on macOS
     #[arg(long)]
     per_cpu_threads: bool,
+
+    /// Emit .syms.json sidecar file containing gathered symbol info for all frames referenced by
+    /// this profile. With this file along with the profile, samply can load the profile
+    /// and provide symbols to the front end without needing debug files to be
+    /// available. (Unstable: will probably change to include the full information
+    /// in the profile.json, instead of a sidecar file.)
+    #[arg(long)]
+    unstable_presymbolicate: bool,
 }
 
 #[derive(Debug, Args)]
@@ -369,6 +377,7 @@ impl ImportArgs {
             unlink_aux_files: self.profile_creation_args.unlink_aux_files,
             create_per_cpu_threads: self.profile_creation_args.per_cpu_threads,
             override_arch: self.override_arch.clone(),
+            unstable_presymbolicate: self.profile_creation_args.unstable_presymbolicate,
         }
     }
 
@@ -472,6 +481,7 @@ impl RecordArgs {
             unlink_aux_files: self.profile_creation_args.unlink_aux_files,
             create_per_cpu_threads: self.profile_creation_args.per_cpu_threads,
             override_arch: None,
+            unstable_presymbolicate: self.profile_creation_args.unstable_presymbolicate,
         }
     }
 }

--- a/samply/src/server.rs
+++ b/samply/src/server.rs
@@ -21,6 +21,7 @@ use tokio_util::io::ReaderStream;
 use wholesym::debugid::DebugId;
 use wholesym::{LibraryInfo, SymbolManager, SymbolManagerConfig};
 
+use crate::shared;
 use crate::shared::ctrl_c::CtrlC;
 
 #[derive(Clone, Debug)]
@@ -112,6 +113,16 @@ async fn start_server(
         .respect_nt_symbol_path(true)
         .use_debuginfod(std::env::var("SAMPLY_USE_DEBUGINFOD").is_ok())
         .use_spotlight(true);
+
+    if let Some(profile_filename) = profile_filename {
+        let precog_filename = profile_filename.with_extension("syms.json");
+        if let Some(precog_info) =
+            shared::symbol_precog::PrecogSymbolInfo::try_load(&precog_filename)
+        {
+            config = config.set_precog_data(precog_info.into_hash_map());
+        }
+    }
+
     if let Some(home_dir) = dirs::home_dir() {
         config = config.debuginfod_cache_dir_if_not_installed(home_dir.join("sym"));
     }
@@ -124,6 +135,7 @@ async fn start_server(
     for lib_info in libinfo_map.into_values() {
         symbol_manager.add_known_library(lib_info);
     }
+
     let symbol_manager = Arc::new(symbol_manager);
 
     let server = tokio::task::spawn(run_server(

--- a/samply/src/shared/mod.rs
+++ b/samply/src/shared/mod.rs
@@ -13,6 +13,7 @@ pub mod recording_props;
 pub mod recycling;
 pub mod stack_converter;
 pub mod stack_depth_limiting_frame_iter;
+pub mod symbol_precog;
 pub mod timestamp_converter;
 pub mod types;
 pub mod unresolved_samples;

--- a/samply/src/shared/recording_props.rs
+++ b/samply/src/shared/recording_props.rs
@@ -53,6 +53,8 @@ pub struct ProfileCreationProps {
     /// Override system architecture.
     #[allow(dead_code)]
     pub override_arch: Option<String>,
+    /// Dump presymbolication info.
+    pub unstable_presymbolicate: bool,
 }
 
 /// Properties which are meaningful for launching and recording a fresh process.

--- a/samply/src/shared/symbol_precog.rs
+++ b/samply/src/shared/symbol_precog.rs
@@ -1,0 +1,386 @@
+use std::fs::File;
+use std::io::BufWriter;
+use std::str::FromStr;
+use std::sync::Arc;
+use std::{collections::HashMap, path::Path};
+
+use debugid::DebugId;
+use serde::{
+    ser::SerializeMap, ser::SerializeSeq, Deserialize, Deserializer, Serialize, Serializer,
+};
+use serde_derive::{Deserialize, Serialize};
+use serde_json::to_writer;
+
+#[derive(Debug, Copy, Clone, PartialOrd, Ord, PartialEq, Eq, Hash)]
+struct StringTableIndex(usize);
+//struct StringTableIndex(String);
+
+impl Serialize for StringTableIndex {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.0.serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for StringTableIndex {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let value = String::deserialize(deserializer)?;
+        Ok(StringTableIndex(usize::from_str(&value).unwrap()))
+        //Ok(StringTableIndex(value))
+    }
+}
+
+impl StringTableIndex {
+    fn unknown() -> StringTableIndex {
+        StringTableIndex(0)
+        //StringTableIndex("UNKNOWN".to_owned())
+    }
+}
+
+// so many string tables, none of them convenient
+struct StringTable {
+    string_map: HashMap<String, usize>,
+    strings: Vec<String>,
+}
+
+impl StringTable {
+    fn new() -> Self {
+        let mut result = Self {
+            string_map: HashMap::new(),
+            strings: Vec::new(),
+        };
+        result.intern_string("UNKNOWN"); // always at index 0
+        result
+    }
+
+    fn intern_string(&mut self, string: &str) -> StringTableIndex {
+        let index = match self.string_map.get(string) {
+            Some(&index) => index,
+            None => {
+                let index = self.strings.len();
+                self.strings.push(string.to_string());
+                self.string_map.insert(string.to_string(), index);
+                index
+            }
+        };
+        StringTableIndex(index)
+        //StringTableIndex(string.to_owned())
+    }
+
+    fn get(&self, index: StringTableIndex) -> &str {
+        &self.strings[index.0]
+        //&index.0
+    }
+}
+
+impl Serialize for StringTable {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut seq = serializer.serialize_seq(Some(self.strings.len()))?;
+        for string in &self.strings {
+            seq.serialize_element(string)?;
+        }
+        seq.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for StringTable {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let strings = Vec::<String>::deserialize(deserializer)?;
+        let mut string_map = HashMap::new();
+        for (index, string) in strings.iter().enumerate() {
+            string_map.insert(string.clone(), index);
+        }
+        Ok(StringTable {
+            string_map,
+            strings,
+        })
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+struct InternedFrameDebugInfo {
+    function: StringTableIndex,
+    file: StringTableIndex,
+    line: u32,
+}
+
+impl InternedFrameDebugInfo {
+    fn new(frame: &wholesym::FrameDebugInfo, strtab: &mut StringTable) -> InternedFrameDebugInfo {
+        let function = frame
+            .function
+            .as_ref()
+            .map_or(StringTableIndex::unknown(), |name| {
+                strtab.intern_string(name)
+            });
+        let file = frame
+            .file_path
+            .as_ref()
+            .map_or(StringTableIndex::unknown(), |name| {
+                strtab.intern_string(name.raw_path())
+            });
+        let line = frame.line_number.unwrap_or(0);
+        InternedFrameDebugInfo {
+            function,
+            file,
+            line,
+        }
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+struct InternedAddressInfo {
+    symbol: StringTableIndex,
+
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    frames: Vec<InternedFrameDebugInfo>,
+}
+
+impl InternedAddressInfo {
+    fn new(info: &wholesym::AddressInfo, strtab: &mut StringTable) -> InternedAddressInfo {
+        let symbol = strtab.intern_string(&info.symbol.name);
+        let frames = info
+            .frames
+            .as_ref()
+            .unwrap_or(&Vec::new())
+            .iter()
+            .map(|frame| InternedFrameDebugInfo::new(frame, strtab))
+            .collect();
+        InternedAddressInfo { symbol, frames }
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+struct PrecogLibrarySymbols {
+    debug_name: String,
+    debug_id: String,
+    code_id: String,
+    known_addresses: Vec<(u32, InternedAddressInfo)>,
+
+    #[serde(skip)]
+    string_table: Option<Arc<StringTable>>,
+}
+
+pub struct PrecogSymbolInfo {
+    string_table: Arc<StringTable>,
+    data: Vec<PrecogLibrarySymbols>,
+}
+
+impl Serialize for PrecogSymbolInfo {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let string_table = self.string_table.as_ref();
+        let mut map = serializer.serialize_map(Some(2))?;
+        map.serialize_entry("string_table", string_table)?;
+        map.serialize_entry("data", &self.data)?;
+        map.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for PrecogSymbolInfo {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct PrecogSymbolInfoVisitor;
+
+        impl<'de> serde::de::Visitor<'de> for PrecogSymbolInfoVisitor {
+            type Value = PrecogSymbolInfo;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("struct PrecogSymbolInfo")
+            }
+
+            fn visit_map<A: serde::de::MapAccess<'de>>(
+                self,
+                mut map: A,
+            ) -> Result<Self::Value, A::Error> {
+                let mut string_table: Option<StringTable> = None;
+                let mut data: Option<Vec<PrecogLibrarySymbols>> = None;
+                while let Some(key) = map.next_key()? {
+                    match key {
+                        "string_table" => {
+                            string_table = Some(map.next_value()?);
+                        }
+                        "data" => {
+                            data = Some(map.next_value()?);
+                        }
+                        _ => {
+                            map.next_value::<serde::de::IgnoredAny>()?;
+                        }
+                    }
+                }
+
+                // Give the shared string table to each PrecogLibrarySymbols
+                let (string_table, mut data) = (string_table.unwrap(), data.unwrap());
+                let string_table = Arc::new(string_table);
+                for lib in &mut data {
+                    lib.string_table = Some(string_table.clone());
+                }
+                Ok(PrecogSymbolInfo { string_table, data })
+            }
+        }
+
+        deserializer.deserialize_map(PrecogSymbolInfoVisitor)
+    }
+}
+
+impl PrecogLibrarySymbols {
+    fn get_string(&self, index: StringTableIndex) -> &str {
+        self.string_table.as_ref().unwrap().get(index)
+    }
+}
+
+impl wholesym::samply_symbols::SymbolMapTrait for PrecogLibrarySymbols {
+    fn debug_id(&self) -> debugid::DebugId {
+        debugid::DebugId::from_str(&self.debug_id).expect("bad debugid")
+    }
+
+    fn symbol_count(&self) -> usize {
+        // not correct but maybe it's OK
+        self.known_addresses.len()
+    }
+
+    fn iter_symbols(&self) -> Box<dyn Iterator<Item = (u32, std::borrow::Cow<'_, str>)> + '_> {
+        let iter = self.known_addresses.iter().map(move |(rva, info)| {
+            (
+                *rva,
+                std::borrow::Cow::Borrowed(self.get_string(info.symbol)),
+            )
+        });
+
+        Box::new(iter)
+    }
+
+    fn lookup_sync(&self, address: wholesym::LookupAddress) -> Option<wholesym::SyncAddressInfo> {
+        match address {
+            wholesym::LookupAddress::Relative(rva) => {
+                for (known_rva, info) in &self.known_addresses {
+                    if *known_rva == rva {
+                        //eprintln!("lookup_sync: 0x{:x} -> {}", rva, info.symbol.0);
+                        return Some(wholesym::SyncAddressInfo {
+                            symbol: wholesym::SymbolInfo {
+                                address: rva,
+                                size: None,
+                                name: self.get_string(info.symbol).to_owned(),
+                            },
+                            frames: None,
+                        });
+                    }
+                }
+                None
+            }
+            wholesym::LookupAddress::Svma(_) => todo!(),
+            wholesym::LookupAddress::FileOffset(_) => todo!(),
+        }
+    }
+}
+
+impl std::fmt::Debug for PrecogSymbolInfo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "PrecogSymbolInfo")
+    }
+}
+
+impl PrecogSymbolInfo {
+    pub fn try_load(path: &Path) -> Option<Self> {
+        let file = File::open(path).ok()?;
+        let reader = std::io::BufReader::new(file);
+        serde_json::from_reader(reader).ok()
+    }
+
+    pub fn into_hash_map(
+        self,
+    ) -> HashMap<DebugId, Arc<dyn wholesym::samply_symbols::SymbolMapTrait + Send + Sync>> {
+        self.data
+            .into_iter()
+            .map(|lib| {
+                (
+                    DebugId::from_str(&lib.debug_id).unwrap(),
+                    Arc::new(lib)
+                        as Arc<dyn wholesym::samply_symbols::SymbolMapTrait + Send + Sync>,
+                )
+            })
+            .collect()
+    }
+}
+
+pub fn presymbolicate(profile: &fxprof_processed_profile::Profile, precog_output: &Path) {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+
+    let mut string_table = StringTable::new();
+    let mut results = Vec::new();
+
+    let config = wholesym::SymbolManagerConfig::new()
+        .use_spotlight(true)
+        // .verbose(true)
+        .respect_nt_symbol_path(true);
+    let mut symbol_manager = wholesym::SymbolManager::with_config(config);
+
+    for (lib, rvas) in profile.lib_used_rva_iter() {
+        let Some(rvas) = rvas else { continue };
+
+        // Add the library to the symbol manager with all the info, so that load_symbol_map can find it later
+        symbol_manager.add_known_library(wholesym::LibraryInfo {
+            name: Some(lib.debug_name.clone()),
+            path: Some(lib.path.clone()),
+            debug_path: Some(lib.debug_path.clone()),
+            debug_id: Some(lib.debug_id),
+            arch: lib.arch.clone(),
+            debug_name: Some(lib.debug_name.clone()),
+            code_id: lib
+                .code_id
+                .as_ref()
+                .map(|id| wholesym::CodeId::from_str(id).expect("bad codeid")),
+        });
+
+        //eprintln!("Library {} ({}) has {} rvas", lib.debug_name, lib.debug_id, rvas.len());
+
+        let result = rt.block_on(async {
+            let Ok(symbol_map) = symbol_manager
+                .load_symbol_map(&lib.debug_name, lib.debug_id)
+                .await
+            else {
+                //eprintln!("Couldn't load symbol map for {} at {} {} ({})", lib.debug_name, lib.path, lib.debug_path, lib.debug_id);
+                return None;
+            };
+
+            let mut known_addresses = Vec::new();
+            for rva in rvas {
+                if let Some(addr_info) = symbol_map
+                    .lookup(wholesym::LookupAddress::Relative(*rva))
+                    .await
+                {
+                    let info = InternedAddressInfo::new(&addr_info, &mut string_table);
+                    known_addresses.push((*rva, info));
+                }
+            }
+
+            Some(PrecogLibrarySymbols {
+                debug_name: lib.debug_name.clone(),
+                debug_id: lib.debug_id.to_string(),
+                code_id: lib
+                    .code_id
+                    .as_ref()
+                    .map(|id| id.to_string())
+                    .unwrap_or("".to_owned()),
+                known_addresses,
+                string_table: None,
+            })
+        });
+
+        if let Some(result) = result {
+            results.push(result);
+        }
+    }
+
+    {
+        let string_table = Arc::new(string_table);
+        for lib in &mut results {
+            lib.string_table = Some(string_table.clone());
+        }
+        let info = PrecogSymbolInfo {
+            string_table,
+            data: results,
+        };
+
+        let file = File::create(precog_output).unwrap();
+        let writer = BufWriter::new(file);
+        to_writer(writer, &info).expect("Couldn't write JSON for presymbolication");
+    }
+}

--- a/samply/src/shared/symbol_precog.rs
+++ b/samply/src/shared/symbol_precog.rs
@@ -313,8 +313,6 @@ pub fn presymbolicate(profile: &fxprof_processed_profile::Profile, precog_output
     let mut symbol_manager = wholesym::SymbolManager::with_config(config);
 
     for (lib, rvas) in profile.lib_used_rva_iter() {
-        let Some(rvas) = rvas else { continue };
-
         // Add the library to the symbol manager with all the info, so that load_symbol_map can find it later
         symbol_manager.add_known_library(wholesym::LibraryInfo {
             name: Some(lib.debug_name.clone()),

--- a/samply/src/shared/symbol_precog.rs
+++ b/samply/src/shared/symbol_precog.rs
@@ -13,7 +13,6 @@ use serde_json::to_writer;
 
 #[derive(Debug, Copy, Clone, PartialOrd, Ord, PartialEq, Eq, Hash)]
 struct StringTableIndex(usize);
-//struct StringTableIndex(String);
 
 impl Serialize for StringTableIndex {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -23,16 +22,14 @@ impl Serialize for StringTableIndex {
 
 impl<'de> Deserialize<'de> for StringTableIndex {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        let value = String::deserialize(deserializer)?;
-        Ok(StringTableIndex(usize::from_str(&value).unwrap()))
-        //Ok(StringTableIndex(value))
+        let value = usize::deserialize(deserializer)?;
+        Ok(StringTableIndex(value))
     }
 }
 
 impl StringTableIndex {
     fn unknown() -> StringTableIndex {
         StringTableIndex(0)
-        //StringTableIndex("UNKNOWN".to_owned())
     }
 }
 

--- a/samply/src/shared/symbol_precog.rs
+++ b/samply/src/shared/symbol_precog.rs
@@ -189,8 +189,8 @@ impl<'de> Deserialize<'de> for PrecogSymbolInfo {
             ) -> Result<Self::Value, A::Error> {
                 let mut string_table: Option<StringTable> = None;
                 let mut data: Option<Vec<PrecogLibrarySymbols>> = None;
-                while let Some(key) = map.next_key()? {
-                    match key {
+                while let Some(key) = map.next_key::<String>()? {
+                    match key.as_str() {
                         "string_table" => {
                             string_table = Some(map.next_value()?);
                         }
@@ -278,7 +278,7 @@ impl PrecogSymbolInfo {
     pub fn try_load(path: &Path) -> Option<Self> {
         let file = File::open(path).ok()?;
         let reader = std::io::BufReader::new(file);
-        serde_json::from_reader(reader).ok()
+        serde_json::from_reader(reader).expect("failed to parse sidecar syms.json")
     }
 
     pub fn into_hash_map(

--- a/samply/src/windows/profiler.rs
+++ b/samply/src/windows/profiler.rs
@@ -158,11 +158,18 @@ pub fn start_recording(
     });
 
     // write the profile to a json file
-    let file = File::create(&output_file).unwrap();
-    let writer = BufWriter::new(file);
     {
+        let file = File::create(&output_file).unwrap();
+        let writer = BufWriter::new(file);
         let profile = context.profile.borrow();
         to_writer(writer, &*profile).expect("Couldn't write JSON");
+    }
+
+    if profile_creation_props.unstable_presymbolicate {
+        crate::shared::symbol_precog::presymbolicate(
+            &context.profile.borrow(),
+            &output_file.with_extension("syms.json"),
+        );
     }
 
     // then fire up the server for the profiler front end, if not save-only

--- a/samply/src/windows/profiler.rs
+++ b/samply/src/windows/profiler.rs
@@ -167,7 +167,7 @@ pub fn start_recording(
 
     if profile_creation_props.unstable_presymbolicate {
         crate::shared::symbol_precog::presymbolicate(
-            &context.profile.borrow(),
+            &profile,
             &output_file.with_extension("syms.json"),
         );
     }

--- a/wholesym/src/config.rs
+++ b/wholesym/src/config.rs
@@ -1,25 +1,12 @@
+use std::collections::HashMap;
 use std::path::PathBuf;
-use std::{collections::HashMap, sync::Arc};
 
-use debugid::DebugId;
 use symsrv::{parse_nt_symbol_path, NtSymbolPathEntry};
-
-// Helper struct to avoid not being able to derive Debug on SymbolManagerConfig
-pub(crate) struct PrecogDataContainer {
-    pub(crate) precog_data: HashMap<DebugId, Arc<dyn samply_symbols::SymbolMapTrait + Send + Sync>>,
-}
-
-impl std::fmt::Debug for PrecogDataContainer {
-    // Explicit implementation needed due to precog_data
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str("...")
-    }
-}
 
 /// The configuration of a [`SymbolManager`](crate::SymbolManager).
 ///
 /// Allows specifying various sources of symbol files.
-#[derive(Debug, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct SymbolManagerConfig {
     pub(crate) verbose: bool,
     pub(crate) redirect_paths: HashMap<PathBuf, PathBuf>,
@@ -33,7 +20,6 @@ pub struct SymbolManagerConfig {
     pub(crate) use_spotlight: bool,
     pub(crate) debuginfod_cache_dir_if_not_installed: Option<PathBuf>,
     pub(crate) debuginfod_servers: Vec<(String, PathBuf)>,
-    pub(crate) precog_data: Option<PrecogDataContainer>,
 }
 
 impl SymbolManagerConfig {
@@ -186,15 +172,6 @@ impl SymbolManagerConfig {
     /// of dSYM files based on a mach-O UUID. Ignored on non-macOS.
     pub fn use_spotlight(mut self, use_spotlight: bool) -> Self {
         self.use_spotlight = use_spotlight;
-        self
-    }
-
-    /// Provide explicit symbol maps for a set of debug IDs.
-    pub fn set_precog_data(
-        mut self,
-        precog_data: HashMap<DebugId, Arc<dyn samply_symbols::SymbolMapTrait + Send + Sync>>,
-    ) -> Self {
-        self.precog_data = Some(PrecogDataContainer { precog_data });
         self
     }
 }

--- a/wholesym/src/helper.rs
+++ b/wholesym/src/helper.rs
@@ -917,7 +917,6 @@ impl FileAndPathHelper for Helper {
         &self,
         info: &LibraryInfo,
     ) -> Option<(Self::FL, Arc<dyn SymbolMapTrait + Send + Sync>)> {
-        eprintln!("get_symbol_map_for_library: {:?}", info);
         let precog_symbol_data = self.precog_symbol_data.lock().unwrap();
         let symbol_map = precog_symbol_data.get(&info.debug_id?)?;
         let location = WholesymFileLocation::LocalFile(

--- a/wholesym/src/helper.rs
+++ b/wholesym/src/helper.rs
@@ -244,6 +244,7 @@ pub struct Helper {
     debuginfod_symbol_cache: Option<DebuginfodSymbolCache>,
     known_libs: Mutex<KnownLibs>,
     config: SymbolManagerConfig,
+    precog_symbol_data: Mutex<HashMap<DebugId, Arc<dyn SymbolMapTrait + Send + Sync>>>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -281,6 +282,7 @@ impl Helper {
             debuginfod_symbol_cache,
             known_libs: Mutex::new(Default::default()),
             config,
+            precog_symbol_data: Mutex::new(Default::default()),
         }
     }
 
@@ -308,6 +310,18 @@ impl Helper {
             }
             _ => {}
         }
+    }
+
+    pub fn add_precog_symbol_map(
+        &self,
+        lib_info: LibraryInfo,
+        symbol_map: Arc<dyn SymbolMapTrait + Send + Sync>,
+    ) {
+        let debug_id = lib_info
+            .debug_id
+            .expect("LibraryInfo must have a debug_id to add precog symbols");
+        let mut precog_symbol_data = self.precog_symbol_data.lock().unwrap();
+        precog_symbol_data.insert(debug_id, symbol_map);
     }
 
     async fn load_file_impl(
@@ -903,20 +917,16 @@ impl FileAndPathHelper for Helper {
         &self,
         info: &LibraryInfo,
     ) -> Option<(Self::FL, Arc<dyn SymbolMapTrait + Send + Sync>)> {
-        let precog_data = self.config.precog_data.as_ref()?;
-
-        precog_data
-            .precog_data
-            .get(&info.debug_id?)
-            .map(|symbol_map| {
-                let location = WholesymFileLocation::LocalFile(
-                    info.debug_path
-                        .clone()
-                        .unwrap_or_else(|| "UNKNOWN".to_string())
-                        .into(),
-                );
-                (location, symbol_map.clone())
-            })
+        eprintln!("get_symbol_map_for_library: {:?}", info);
+        let precog_symbol_data = self.precog_symbol_data.lock().unwrap();
+        let symbol_map = precog_symbol_data.get(&info.debug_id?)?;
+        let location = WholesymFileLocation::LocalFile(
+            info.debug_path
+                .clone()
+                .unwrap_or_else(|| "UNKNOWN".to_string())
+                .into(),
+        );
+        Some((location, symbol_map.clone()))
     }
 }
 

--- a/wholesym/src/symbol_manager.rs
+++ b/wholesym/src/symbol_manager.rs
@@ -1,10 +1,11 @@
 use std::borrow::Cow;
 use std::path::Path;
+use std::sync::Arc;
 
 use debugid::DebugId;
 use samply_symbols::{
     self, AddressInfo, Error, ExternalFileAddressInFileRef, ExternalFileAddressRef, FrameDebugInfo,
-    LibraryInfo, LookupAddress, MultiArchDisambiguator, SyncAddressInfo,
+    LibraryInfo, LookupAddress, MultiArchDisambiguator, SymbolMapTrait, SyncAddressInfo,
 };
 
 use crate::config::SymbolManagerConfig;
@@ -232,6 +233,20 @@ impl SymbolManager {
     /// The list of "known libraries" is this auxiliary information.
     pub fn add_known_library(&mut self, lib_info: LibraryInfo) {
         self.symbol_manager.helper().add_known_lib(lib_info);
+    }
+
+    /// Tell the `SymbolManager` about a library's symbol table. The library
+    /// must contain a DebugId. This is useful when a library's symbols are
+    /// available in some way other than normal symbol lookup, or if a custom
+    /// format is desired that is not natively supported.
+    pub fn add_known_library_symbols(
+        &mut self,
+        lib_info: LibraryInfo,
+        symbol_map: Arc<dyn SymbolMapTrait + Send + Sync>,
+    ) {
+        self.symbol_manager
+            .helper()
+            .add_precog_symbol_map(lib_info, symbol_map);
     }
 
     /// Obtain a symbol map for the given `debug_name` and `debug_id`.


### PR DESCRIPTION
Adds `--unstable-presymbolicate`, which will output ` .syms.json` file alongside the regular profile output. If that file is present when the server is fired up (based on the profile name, i.e. `foo.json` -> `foo.syms.json`), it is parsed and the data is added to be used when symbolicating. If a library has presymbolicated info (by debugid), _only_ that info is used. There's no attempt to fall back to on-disk etc.

This allows a capture to be entirely self-contained, so that no symbol servers or on-disk data are needed for looking at the profile, which is very useful for running in CI or other locations where publishing the debuginfo isn't necessarily useful otherwise.