### PR TITLE
CoreCLR MethodStartAddress is always u64

### DIFF
--- a/samply/src/windows/coreclr.rs
+++ b/samply/src/windows/coreclr.rs
@@ -373,7 +373,7 @@ pub fn handle_coreclr_event(
                 let method_namespace: String = parser.parse("MethodNamespace");
                 let method_signature: String = parser.parse("MethodSignature");
 
-                let method_start_address: Address = if is_r2r { parser.parse("EntryPoint") } else { parser.parse("MethodStartAddress") };
+                let method_start_address: u64 = if is_r2r { parser.parse("EntryPoint") } else { parser.parse("MethodStartAddress") };
                 let method_size: u32 = parser.parse("MethodSize"); // TODO: R2R doesn't have a size?
 
                 // There's a v0, v1, and v2 version of this event. There are rules in `eventtrace.cpp` in the runtime
@@ -389,7 +389,6 @@ pub fn handle_coreclr_event(
                 let method_name = format!("{method_basename} [{method_namespace}] \u{2329}{method_signature}\u{232a}");
 
                 let mut process_jit_info = context.get_process_jit_info(process_id);
-                let start_address = method_start_address.as_u64();
                 let relative_address = process_jit_info.next_relative_address;
                 process_jit_info.next_relative_address += method_size;
 
@@ -400,8 +399,8 @@ pub fn handle_coreclr_event(
                 let category = context.get_category(KnownCategory::CoreClrJit);
                 let info = LibMappingInfo::new_jit_function(process_jit_info.lib_handle, category.into(), None);
                 process_jit_info.jit_mapping_ops.push(timestamp_raw, LibMappingOp::Add(LibMappingAdd {
-                    start_avma: start_address,
-                    end_avma: start_address + (method_size as u64),
+                    start_avma: method_start_address,
+                    end_avma: method_start_address + (method_size as u64),
                     relative_address_at_start: relative_address,
                     info
                 }));


### PR DESCRIPTION
Proper fix for #199 