### PR TITLE
A few small fixes

### DIFF
--- a/samply/src/linux/profiler.rs
+++ b/samply/src/linux/profiler.rs
@@ -59,11 +59,19 @@ pub fn start_recording(
     // We want to profile a child process which we are about to launch.
 
     let ProcessLaunchProps {
-        env_vars,
+        mut env_vars,
         command_name,
         args,
         iteration_count,
     } = process_launch_props;
+
+    if recording_props.coreclr {
+        // We need to set DOTNET_PerfMapEnabled=2 in the environment if it's not already set.
+        // TODO: implement unlink_aux_files for linux
+        if !env_vars.iter().any(|p| p.0 == "DOTNET_PerfMapEnabled") {
+            env_vars.push(("DOTNET_PerfMapEnabled".into(), "2".into()));
+        }
+    }
 
     // Ignore Ctrl+C while the subcommand is running. The signal still reaches the process
     // under observation while we continue to record it. (ctrl+c will send the SIGINT signal

--- a/samply/src/main.rs
+++ b/samply/src/main.rs
@@ -181,8 +181,7 @@ struct RecordArgs {
     #[arg(short, long, conflicts_with = "pid")]
     all: bool,
 
-    /// Enable CoreCLR event capture (Windows only).
-    #[cfg(target_os = "windows")]
+    /// Enable CoreCLR event capture.
     #[arg(long)]
     coreclr: bool,
 
@@ -406,9 +405,9 @@ impl RecordArgs {
         let interval = Duration::from_secs_f64(1.0 / self.rate);
         cfg_if::cfg_if! {
             if #[cfg(target_os = "windows")] {
-                let (coreclr, coreclr_allocs, vm_hack) = (self.coreclr, self.coreclr_allocs, self.vm_hack);
+                let (vm_hack, coreclr_allocs) = (self.vm_hack, self.coreclr_allocs);
             } else {
-                let (coreclr, coreclr_allocs, vm_hack) = (false, false, false);
+                let (vm_hack, coreclr_allocs) = (false, false);
             }
         }
         RecordingProps {
@@ -416,7 +415,7 @@ impl RecordArgs {
             time_limit,
             interval,
             main_thread_only: self.main_thread_only,
-            coreclr,
+            coreclr: self.coreclr,
             coreclr_allocs,
             vm_hack,
         }

--- a/samply/src/main.rs
+++ b/samply/src/main.rs
@@ -194,6 +194,10 @@ struct RecordArgs {
     #[cfg(target_os = "windows")]
     #[arg(long)]
     vm_hack: bool,
+
+    /// Enable Graphics-related event capture.
+    #[arg(long)]
+    gfx: bool,
 }
 
 #[derive(Debug, Args)]
@@ -418,6 +422,7 @@ impl RecordArgs {
             coreclr: self.coreclr,
             coreclr_allocs,
             vm_hack,
+            gfx: self.gfx,
         }
     }
 

--- a/samply/src/main.rs
+++ b/samply/src/main.rs
@@ -117,13 +117,13 @@ struct ImportArgs {
     #[command(flatten)]
     server_args: ServerArgs,
 
-    /// Only include processes with these names
+    /// Only include processes with this name substring (can be specified multiple times).
     #[arg(long)]
-    process_names: Option<Vec<String>>,
+    name: Option<Vec<String>>,
 
-    /// Only include processes with these PIDs
+    /// Only include process with this PID (can be specified multiple times).
     #[arg(long)]
-    pids: Option<Vec<u32>>,
+    pid: Option<Vec<u32>>,
 
     /// Explicitly specify architecture of profile to import.
     #[arg(long)]
@@ -373,7 +373,7 @@ impl ImportArgs {
     }
 
     fn included_processes(&self) -> Option<IncludedProcesses> {
-        match (&self.process_names, &self.pids) {
+        match (&self.name, &self.pid) {
             (None, None) => None, // No filtering, include all processes
             (names, pids) => Some(IncludedProcesses {
                 name_substrings: names.clone().unwrap_or_default(),

--- a/samply/src/shared/recording_props.rs
+++ b/samply/src/shared/recording_props.rs
@@ -13,6 +13,7 @@ pub struct RecordingProps {
     pub coreclr: bool,
     pub coreclr_allocs: bool,
     pub vm_hack: bool,
+    pub gfx: bool,
 }
 
 /// Which process(es) to record.

--- a/samply/src/windows/elevated_helper.rs
+++ b/samply/src/windows/elevated_helper.rs
@@ -26,6 +26,7 @@ pub struct ElevatedRecordingProps {
     pub coreclr_allocs: bool,
     pub vm_hack: bool,
     pub is_attach: bool,
+    pub gfx: bool,
 }
 
 impl ElevatedRecordingProps {
@@ -40,6 +41,7 @@ impl ElevatedRecordingProps {
             coreclr_allocs: recording_props.coreclr_allocs,
             vm_hack: recording_props.vm_hack,
             is_attach: recording_mode.is_attach_mode(),
+            gfx: recording_props.gfx,
         }
     }
 }

--- a/samply/src/windows/gfx.rs
+++ b/samply/src/windows/gfx.rs
@@ -1,0 +1,23 @@
+use super::elevated_helper::ElevatedRecordingProps;
+
+pub fn gfx_xperf_args(props: &ElevatedRecordingProps) -> Vec<String> {
+    let mut providers = vec![];
+
+    if !props.gfx {
+        return providers;
+    }
+
+    const DXGKRNL_BASE_KEYWORD: u64 = 0x1;
+
+    // er I don't know what level 1 is.
+    let level_1_dxgkrnl_keywords = DXGKRNL_BASE_KEYWORD;
+
+    if level_1_dxgkrnl_keywords != 0 {
+        providers.push(format!(
+            "Microsoft-Windows-DxgKrnl:0x{:x}:1",
+            level_1_dxgkrnl_keywords
+        ));
+    }
+
+    providers
+}

--- a/samply/src/windows/mod.rs
+++ b/samply/src/windows/mod.rs
@@ -2,6 +2,7 @@ mod console;
 mod coreclr;
 mod elevated_helper;
 mod etw_gecko;
+mod gfx;
 pub mod import;
 mod profile_context;
 pub mod profiler;

--- a/samply/src/windows/xperf.rs
+++ b/samply/src/windows/xperf.rs
@@ -58,6 +58,7 @@ impl Xperf {
         let mut user_providers = vec![];
 
         user_providers.append(&mut super::coreclr::coreclr_xperf_args(props));
+        user_providers.append(&mut super::gfx::gfx_xperf_args(props));
 
         let xperf_path = self.get_xperf_path()?;
         // start xperf.exe, logging to the same location as the output file, just with a .etl


### PR DESCRIPTION
Sorry for the rollup PR, it's a bunch of small stuff from unity-land. Each commit is discrete, but:

- renames `--process_names`/`--pids` for `import` to `--name` `--pid`; `--pid` in particular matches the `record` option. `--name` I'm not in love with, I just wanted to drop the `s` suffix because I did that wrong in the first place (you can't pass a comma separated list without additional work)
- makes `--coreclr` available everywhere; sets the env var for linux like macOS
- adds `record --gfx` to turn on some graphics ETW providers. mostly a stub, just turns on vsync.
- small refactor for macos attach code that I had sitting around, in preparation for walking the process tree on attach instead of just attaching to a single process