### PR TITLE
Consolidate state and remove refcells

### DIFF
--- a/samply/src/windows/chrome_etw_flags.rs
+++ b/samply/src/windows/chrome_etw_flags.rs
@@ -1,6 +1,7 @@
 use bitflags::bitflags;
 
 bitflags! {
+    // https://source.chromium.org/chromium/chromium/src/+/main:base/trace_event/trace_event_etw_export_win.cc;l=103;drc=8c29f4a8930c3ccccdf1b66c28fe484cee7c7362
     #[derive(PartialEq, Eq)]
     pub struct KeywordNames: u64 {
         const benchmark = 0x1;

--- a/samply/src/windows/chrome_etw_flags.rs
+++ b/samply/src/windows/chrome_etw_flags.rs
@@ -1,0 +1,55 @@
+use bitflags::bitflags;
+
+bitflags! {
+    #[derive(PartialEq, Eq)]
+    pub struct KeywordNames: u64 {
+        const benchmark = 0x1;
+        const blink = 0x2;
+        const browser = 0x4;
+        const cc = 0x8;
+        const evdev = 0x10;
+        const gpu = 0x20;
+        const input = 0x40;
+        const netlog = 0x80;
+        const sequence_manager = 0x100;
+        const toplevel = 0x200;
+        const v8 = 0x400;
+        const disabled_by_default_cc_debug = 0x800;
+        const disabled_by_default_cc_debug_picture = 0x1000;
+        const disabled_by_default_toplevel_flow = 0x2000;
+        const startup = 0x4000;
+        const latency = 0x8000;
+        const blink_user_timing = 0x10000;
+        const media = 0x20000;
+        const loading = 0x40000;
+        const base = 0x80000;
+        const devtools_timeline = 0x100000;
+        const unused_bit_21 = 0x200000;
+        const unused_bit_22 = 0x400000;
+        const unused_bit_23 = 0x800000;
+        const unused_bit_24 = 0x1000000;
+        const unused_bit_25 = 0x2000000;
+        const unused_bit_26 = 0x4000000;
+        const unused_bit_27 = 0x8000000;
+        const unused_bit_28 = 0x10000000;
+        const unused_bit_29 = 0x20000000;
+        const unused_bit_30 = 0x40000000;
+        const unused_bit_31 = 0x80000000;
+        const unused_bit_32 = 0x100000000;
+        const unused_bit_33 = 0x200000000;
+        const unused_bit_34 = 0x400000000;
+        const unused_bit_35 = 0x800000000;
+        const unused_bit_36 = 0x1000000000;
+        const unused_bit_37 = 0x2000000000;
+        const unused_bit_38 = 0x4000000000;
+        const unused_bit_39 = 0x8000000000;
+        const unused_bit_40 = 0x10000000000;
+        const unused_bit_41 = 0x20000000000;
+        const navigation = 0x40000000000;
+        const ServiceWorker = 0x80000000000;
+        const edge_webview = 0x100000000000;
+        const diagnostic_event = 0x200000000000;
+        const __OTHER_EVENTS = 0x400000000000;
+        const __DISABLED_OTHER_EVENTS = 0x800000000000;
+    }
+}

--- a/samply/src/windows/coreclr.rs
+++ b/samply/src/windows/coreclr.rs
@@ -1,5 +1,3 @@
-#![allow(unused)]
-#![allow(clippy::wildcard_in_or_patterns)]
 use std::{
     collections::{hash_map::Entry, HashMap, HashSet, VecDeque},
     convert::TryInto,
@@ -134,6 +132,7 @@ bitflags! {
     }
 }
 
+#[allow(unused)]
 mod constants {
     pub const CORECLR_GC_KEYWORD: u64 = 0x1; // https://learn.microsoft.com/en-us/dotnet/fundamentals/diagnostics/runtime-garbage-collection-events
     pub const CORECLR_GC_HANDLE_KEYWORD: u64 = 0x2;

--- a/samply/src/windows/coreclr.rs
+++ b/samply/src/windows/coreclr.rs
@@ -131,6 +131,28 @@ bitflags! {
     }
 }
 
+mod constants {
+    pub const CORECLR_GC_KEYWORD: u64 = 0x1; // https://learn.microsoft.com/en-us/dotnet/fundamentals/diagnostics/runtime-garbage-collection-events
+    pub const CORECLR_GC_HANDLE_KEYWORD: u64 = 0x2;
+    pub const CORECLR_BINDER_KEYWORD: u64 = 0x4; // https://learn.microsoft.com/en-us/dotnet/fundamentals/diagnostics/runtime-loader-binder-events
+    pub const CORECLR_LOADER_KEYWORD: u64 = 0x8; // https://learn.microsoft.com/en-us/dotnet/fundamentals/diagnostics/runtime-loader-binder-events
+    pub const CORECLR_JIT_KEYWORD: u64 = 0x10; // https://learn.microsoft.com/en-us/dotnet/fundamentals/diagnostics/runtime-method-events
+    pub const CORECLR_NGEN_KEYWORD: u64 = 0x20; // https://learn.microsoft.com/en-us/dotnet/fundamentals/diagnostics/runtime-method-events
+    pub const CORECLR_RUNDOWN_START_KEYWORD: u64 = 0x00000040;
+    pub const CORECLR_INTEROP_KEYWORD: u64 = 0x2000; // https://learn.microsoft.com/en-us/dotnet/fundamentals/diagnostics/runtime-interop-events
+    pub const CORECLR_CONTENTION_KEYWORD: u64 = 0x4000;
+    pub const CORECLR_EXCEPTION_KEYWORD: u64 = 0x8000; // https://learn.microsoft.com/en-us/dotnet/fundamentals/diagnostics/runtime-exception-events
+    pub const CORECLR_THREADING_KEYWORD: u64 = 0x10000; // https://learn.microsoft.com/en-us/dotnet/fundamentals/diagnostics/runtime-thread-events
+    pub const CORECLR_JIT_TO_NATIVE_METHOD_MAP_KEYWORD: u64 = 0x20000;
+    pub const CORECLR_GC_SAMPLED_OBJECT_ALLOCATION_HIGH_KEYWORD: u64 = 0x200000; // https://medium.com/criteo-engineering/build-your-own-net-memory-profiler-in-c-allocations-1-2-9c9f0c86cefd
+    pub const CORECLR_GC_HEAP_AND_TYPE_NAMES: u64 = 0x1000000;
+    pub const CORECLR_GC_SAMPLED_OBJECT_ALLOCATION_LOW_KEYWORD: u64 = 0x2000000;
+    pub const CORECLR_STACK_KEYWORD: u64 = 0x40000000; // https://learn.microsoft.com/en-us/dotnet/framework/performance/stack-etw-event (note: says .NET Framework, but applies to CoreCLR also)
+    pub const CORECLR_COMPILATION_KEYWORD: u64 = 0x1000000000;
+    pub const CORECLR_COMPILATION_DIAGNOSTIC_KEYWORD: u64 = 0x2000000000;
+    pub const CORECLR_TYPE_DIAGNOSTIC_KEYWORD: u64 = 0x8000000000;
+}
+
 // String is type name
 #[derive(Debug, Clone)]
 pub struct CoreClrGcAllocMarker(pub String, usize);
@@ -232,28 +254,8 @@ pub fn coreclr_xperf_args(props: &ElevatedRecordingProps) -> Vec<String> {
     //
     // Also enabling the rundown keyword causes a bunch of DCStart/DCEnd events to be generated,
     // which is only useful if we're tracing an already running process.
-    const CORECLR_GC_KEYWORD: u64 = 0x1; // https://learn.microsoft.com/en-us/dotnet/fundamentals/diagnostics/runtime-garbage-collection-events
-    const CORECLR_GC_HANDLE_KEYWORD: u64 = 0x2;
-    const CORECLR_BINDER_KEYWORD: u64 = 0x4; // https://learn.microsoft.com/en-us/dotnet/fundamentals/diagnostics/runtime-loader-binder-events
-    const CORECLR_LOADER_KEYWORD: u64 = 0x8; // https://learn.microsoft.com/en-us/dotnet/fundamentals/diagnostics/runtime-loader-binder-events
-    const CORECLR_JIT_KEYWORD: u64 = 0x10; // https://learn.microsoft.com/en-us/dotnet/fundamentals/diagnostics/runtime-method-events
-    const CORECLR_NGEN_KEYWORD: u64 = 0x20; // https://learn.microsoft.com/en-us/dotnet/fundamentals/diagnostics/runtime-method-events
-    const CORECLR_INTEROP_KEYWORD: u64 = 0x2000; // https://learn.microsoft.com/en-us/dotnet/fundamentals/diagnostics/runtime-interop-events
-    const CORECLR_CONTENTION_KEYWORD: u64 = 0x4000;
-    const CORECLR_EXCEPTION_KEYWORD: u64 = 0x8000; // https://learn.microsoft.com/en-us/dotnet/fundamentals/diagnostics/runtime-exception-events
-    const CORECLR_THREADING_KEYWORD: u64 = 0x10000; // https://learn.microsoft.com/en-us/dotnet/fundamentals/diagnostics/runtime-thread-events
-    const CORECLR_JIT_TO_NATIVE_METHOD_MAP_KEYWORD: u64 = 0x20000;
-    const CORECLR_GC_SAMPLED_OBJECT_ALLOCATION_HIGH_KEYWORD: u64 = 0x200000; // https://medium.com/criteo-engineering/build-your-own-net-memory-profiler-in-c-allocations-1-2-9c9f0c86cefd
-    const CORECLR_GC_HEAP_AND_TYPE_NAMES: u64 = 0x1000000;
-    const CORECLR_GC_SAMPLED_OBJECT_ALLOCATION_LOW_KEYWORD: u64 = 0x2000000;
-    const CORECLR_STACK_KEYWORD: u64 = 0x40000000; // https://learn.microsoft.com/en-us/dotnet/framework/performance/stack-etw-event (note: says .NET Framework, but applies to CoreCLR also)
-    const CORECLR_COMPILATION_KEYWORD: u64 = 0x1000000000;
-    const CORECLR_COMPILATION_DIAGNOSTIC_KEYWORD: u64 = 0x2000000000;
-    const CORECLR_TYPE_DIAGNOSTIC_KEYWORD: u64 = 0x8000000000;
-
-    const CORECLR_RUNDOWN_START_KEYWORD: u64 = 0x00000040;
-
     // if STACK is enabled, then every CoreCLR event will also generate a stack event right afterwards
+    use constants::*;
     let mut info_keywords = CORECLR_LOADER_KEYWORD | CORECLR_STACK_KEYWORD | CORECLR_GC_KEYWORD;
     let mut verbose_keywords = CORECLR_JIT_KEYWORD | CORECLR_NGEN_KEYWORD;
     // if we're attaching, ask for a rundown of method info at the start of collection
@@ -301,31 +303,33 @@ pub fn coreclr_xperf_args(props: &ElevatedRecordingProps) -> Vec<String> {
 
 pub fn handle_coreclr_event(
     context: &mut ProfileContext,
+    core_clr_context: &mut CoreClrContext,
     s: &TypedEvent,
     parser: &mut Parser,
-    timestamp_converter: &TimestampConverter,
 ) {
-    let timestamp_raw = s.timestamp() as u64;
-    let timestamp = timestamp_converter.convert_time(timestamp_raw);
-
     if !context.is_interesting_process(s.process_id(), None, None) {
         return;
     }
 
-    let Some(dotnet_event) = s
-        .name()
-        .strip_prefix("Microsoft-Windows-DotNETRuntime/")
-        .or(s
-            .name()
-            .strip_prefix("Microsoft-Windows-DotNETRuntimeRundown/"))
-    else {
-        panic!("Unexpected event {}", s.name())
-    };
+    let timestamp_raw = s.timestamp() as u64;
+
+    let mut name_parts = s.name().splitn(3, '/');
+    let provider = name_parts.next().unwrap();
+    let task = name_parts.next().unwrap();
+    let opcode = name_parts.next().unwrap();
+
+    match provider {
+        "Microsoft-Windows-DotNETRuntime" | "Microsoft-Windows-DotNETRuntimeRundown" => {}
+        _ => {
+            panic!("Unexpected event {}", s.name())
+        }
+    }
 
     let process_id = s.process_id();
     let thread_id = s.thread_id();
     let process_handle = context.get_process_handle(process_id).unwrap();
     let thread_handle = context.get_thread_handle(thread_id).unwrap();
+    let timestamp = context.convert_timestamp(timestamp_raw);
 
     // TODO -- we may need to use the rundown provider if we trace running processes
     // https://learn.microsoft.com/en-us/dotnet/framework/performance/clr-etw-providers
@@ -341,19 +345,13 @@ pub fn handle_coreclr_event(
     // If we get a non-stackwalk event followed by a non-stackwalk event for a given thread,
     // clear out any marker that may have been created to make sure the stackwalk doesn't
     // get attached to the wrong thing.
-    if dotnet_event != "CLRStack/CLRStackWalk" {
-        context
-            .coreclr_context
-            .borrow_mut()
-            .remove_last_event_for_thread(thread_handle);
+    if (task, opcode) != ("CLRStack", "CLRStackWalk") {
+        core_clr_context.remove_last_event_for_thread(thread_handle);
     }
 
-    #[allow(clippy::if_same_then_else)]
-    if let Some(method_event) = dotnet_event
-        .strip_prefix("CLRMethod/")
-        .or(dotnet_event.strip_prefix("CLRMethodRundown/"))
-    {
-        match method_event {
+    match (task, opcode) {
+        ("CLRMethod" | "CLRMethodRundown", method_event) => {
+            match method_event {
             // there's MethodDCStart & MethodDCStartVerbose & MethodLoad
             // difference between *Verbose and not, is Verbose includes the names
 
@@ -394,7 +392,7 @@ pub fn handle_coreclr_event(
 
                 // Not that useful for CoreCLR
                 //let mh = context.add_thread_marker(s.thread_id(), timestamp, CategoryHandle::OTHER, "JitFunctionAdd", JitFunctionAddMarker(method_name.to_owned()));
-                //context.coreclr_context.borrow_mut().set_last_event_for_thread(thread_handle, mh);
+                //core_clr_context.set_last_event_for_thread(thread_handle, mh);
 
                 let category = context.get_category(KnownCategory::CoreClrJit);
                 let info = LibMappingInfo::new_jit_function(process_jit_info.lib_handle, category.into(), None);
@@ -431,266 +429,264 @@ pub fn handle_coreclr_event(
                 handled = true;
             }
         }
-    } else if dotnet_event == "Type/BulkType" {
-        //         <template tid="BulkType">
-        // <data name="Count" inType="win:UInt32"    />
-        // <data name="ClrInstanceID" inType="win:UInt16" />
-        // <struct name="Values" count="Count" >
-        // <data name="TypeID" inType="win:UInt64" outType="win:HexInt64" />
-        // <data name="ModuleID" inType="win:UInt64" outType="win:HexInt64" />
-        // <data name="TypeNameID" inType="win:UInt32" />
-        // <data name="Flags" inType="win:UInt32" map="TypeFlagsMap"/>
-        // <data name="CorElementType"  inType="win:UInt8" />
-        // <data name="Name" inType="win:UnicodeString" />
-        // <data name="TypeParameterCount" inType="win:UInt32" />
-        // <data name="TypeParameters"  count="TypeParameterCount"  inType="win:UInt64" outType="win:HexInt64" />
-        // </struct>
-        // <UserData>
-        // <Type xmlns="myNs">
-        // <Count> %1 </Count>
-        // <ClrInstanceID> %2 </ClrInstanceID>
-        // </Type>
-        // </UserData>
-        //let count: u32 = parser.parse("Count");
+        }
+        ("Type", "BulkType") => {
+            //         <template tid="BulkType">
+            // <data name="Count" inType="win:UInt32"    />
+            // <data name="ClrInstanceID" inType="win:UInt16" />
+            // <struct name="Values" count="Count" >
+            // <data name="TypeID" inType="win:UInt64" outType="win:HexInt64" />
+            // <data name="ModuleID" inType="win:UInt64" outType="win:HexInt64" />
+            // <data name="TypeNameID" inType="win:UInt32" />
+            // <data name="Flags" inType="win:UInt32" map="TypeFlagsMap"/>
+            // <data name="CorElementType"  inType="win:UInt8" />
+            // <data name="Name" inType="win:UnicodeString" />
+            // <data name="TypeParameterCount" inType="win:UInt32" />
+            // <data name="TypeParameters"  count="TypeParameterCount"  inType="win:UInt64" outType="win:HexInt64" />
+            // </struct>
+            // <UserData>
+            // <Type xmlns="myNs">
+            // <Count> %1 </Count>
+            // <ClrInstanceID> %2 </ClrInstanceID>
+            // </Type>
+            // </UserData>
+            //let count: u32 = parser.parse("Count");
 
-        // uint32 + uint16 at the front (Count and ClrInstanceID), then struct of values. We don't need a Vec<u8> copy.
-        //let values: Vec<u8> = parser.parse("Values");
-        //let values = &s.user_buffer()[6..];
+            // uint32 + uint16 at the front (Count and ClrInstanceID), then struct of values. We don't need a Vec<u8> copy.
+            //let values: Vec<u8> = parser.parse("Values");
+            //let values = &s.user_buffer()[6..];
 
-        //eprintln!("Type/BulkType count: {} user_buffer size: {} values len: {}", count, s.user_buffer().len(), values.len());
-    } else if dotnet_event == "CLRStack/CLRStackWalk" {
-        // If the STACK keyword is enabled, we get a CLRStackWalk following each CLR event that supports stacks. Not every event
-        // does. The info about which does and doesn't is here: https://github.com/dotnet/runtime/blob/main/src/coreclr/vm/ClrEtwAllMeta.lst
-        // Current dotnet (8.0.x) seems to have a bug where `MethodJitMemoryAllocatedForCode` events will fire a stackwalk,
-        // but the event itself doesn't end up in the trace. (https://github.com/dotnet/runtime/issues/102004)
+            //eprintln!("Type/BulkType count: {} user_buffer size: {} values len: {}", count, s.user_buffer().len(), values.len());
+        }
+        ("CLRStack", "CLRStackWalk") => {
+            // If the STACK keyword is enabled, we get a CLRStackWalk following each CLR event that supports stacks. Not every event
+            // does. The info about which does and doesn't is here: https://github.com/dotnet/runtime/blob/main/src/coreclr/vm/ClrEtwAllMeta.lst
+            // Current dotnet (8.0.x) seems to have a bug where `MethodJitMemoryAllocatedForCode` events will fire a stackwalk,
+            // but the event itself doesn't end up in the trace. (https://github.com/dotnet/runtime/issues/102004)
 
-        // if we don't have anything to attach this stack to, just skip it
-        let Some(marker) = context
-            .get_coreclr_context()
-            .remove_last_event_for_thread(thread_handle)
-        else {
-            return;
-        };
+            // if we don't have anything to attach this stack to, just skip it
+            let Some(marker) = core_clr_context.remove_last_event_for_thread(thread_handle) else {
+                return;
+            };
 
-        // "Stack" is explicitly declared as length 2 in the manifest, so the first two addresses are in here, rest
-        // are in user data buffer.
-        let first_addresses: Vec<u8> = parser.parse("Stack");
-        let stack: Vec<StackFrame> = first_addresses
-            .chunks_exact(8)
-            .chain(parser.buffer.chunks_exact(8))
-            .map(|chunk| u64::from_le_bytes(chunk.try_into().unwrap()))
-            .enumerate()
-            .map(|(i, addr)| {
-                if i == 0 {
-                    StackFrame::InstructionPointer(addr, context.stack_mode_for_address(addr))
-                } else {
-                    StackFrame::ReturnAddress(addr, context.stack_mode_for_address(addr))
-                }
-            })
-            .collect();
-        let stack_index = context.unresolved_stack_handle_for_stack(&stack);
-
-        //eprintln!("event: StackWalk stack: {:?}", stack);
-
-        // Note: we don't add these as actual samples, and instead just attach them to the marker.
-        // If we added them as samples, it would throw off the profile counting, because they arrive
-        // in between regular interval samples. In the future, maybe we can support fractional samples
-        // somehow (fractional weight), but for now, we just attach them to the marker.
-
-        context
-            .get_process_mut(process_id)
-            .unwrap()
-            .unresolved_samples
-            .attach_stack_to_marker(thread_handle, timestamp, timestamp_raw, stack_index, marker);
-        handled = true;
-    } else if let Some(gc_event) = dotnet_event.strip_prefix("GarbageCollection/") {
-        let gc_category = context.get_category(KnownCategory::CoreClrGc);
-        match gc_event {
-            "GCSampledObjectAllocation" => {
-                // If High/Low flags are set, then we get one of these for every alloc. Otherwise only
-                // when a threshold is hit. (100kb) The count and size are aggregates in that case.
-                let type_id: u64 = parser.parse("TypeID"); // TODO: convert to str, with bulk type data
-                                                           //let address: u64 = parser.parse("Address");
-                let object_count: u32 = parser.parse("ObjectCountForTypeSample");
-                let total_size: u64 = parser.parse("TotalSizeForTypeSample");
-
-                let mh = context.profile.borrow_mut().add_marker(
-                    thread_handle,
-                    gc_category,
-                    "GC Alloc",
-                    CoreClrGcAllocMarker(format!("0x{:x}", type_id), total_size as usize),
-                    MarkerTiming::Instant(timestamp),
-                );
-                context
-                    .coreclr_context
-                    .borrow_mut()
-                    .set_last_event_for_thread(thread_handle, mh);
-                handled = true;
-            }
-            "Triggered" => {
-                let reason: u32 = parser.parse("Reason");
-
-                let reason_str = match reason {
-                    0x0 => "AllocSmall",
-                    0x1 => "Induced",
-                    0x2 => "LowMemory",
-                    0x3 => "Empty",
-                    0x4 => "AllocLarge",
-                    0x5 => "OutOfSpaceSmallObjectHeap",
-                    0x6 => "OutOfSpaceLargeObjectHeap",
-                    0x7 => "nducedNoForce",
-                    0x8 => "Stress",
-                    0x9 => "InducedLowMemory",
-                    _ => {
-                        eprintln!("Unknown CLR GC Triggered reason: {}", reason);
-                        "Unknown"
+            // "Stack" is explicitly declared as length 2 in the manifest, so the first two addresses are in here, rest
+            // are in user data buffer.
+            let first_addresses: Vec<u8> = parser.parse("Stack");
+            let stack: Vec<StackFrame> = first_addresses
+                .chunks_exact(8)
+                .chain(parser.buffer.chunks_exact(8))
+                .map(|chunk| u64::from_le_bytes(chunk.try_into().unwrap()))
+                .enumerate()
+                .map(|(i, addr)| {
+                    if i == 0 {
+                        StackFrame::InstructionPointer(addr, context.stack_mode_for_address(addr))
+                    } else {
+                        StackFrame::ReturnAddress(addr, context.stack_mode_for_address(addr))
                     }
-                };
+                })
+                .collect();
+            let stack_index = context.unresolved_stack_handle_for_stack(&stack);
 
-                let mh = context.profile.borrow_mut().add_marker(
-                    thread_handle,
-                    gc_category,
-                    "GC Trigger",
-                    CoreClrGcEventMarker(format!("GC Trigger: {}", reason_str)),
-                    MarkerTiming::Instant(timestamp),
-                );
-                context
-                    .coreclr_context
-                    .borrow_mut()
-                    .set_last_event_for_thread(thread_handle, mh);
-                handled = true;
-            }
-            "GCSuspendEEBegin" => {
-                // Reason, Count
-                let count: u32 = parser.parse("Count");
-                let reason: u32 = parser.parse("Reason");
+            //eprintln!("event: StackWalk stack: {:?}", stack);
 
-                let reason_str = match reason {
-                    0x0 => "Other",
-                    0x1 => "GC",
-                    0x2 => "AppDomain shutdown",
-                    0x3 => "Code pitching",
-                    0x4 => "Shutdown",
-                    0x5 => "Debugger",
-                    0x6 => "GC Prep",
-                    0x7 => "Debugger sweep",
-                    _ => {
-                        eprintln!("Unknown CLR GCSuspendEEBegin reason: {}", reason);
-                        "Unknown reason"
-                    }
-                };
+            // Note: we don't add these as actual samples, and instead just attach them to the marker.
+            // If we added them as samples, it would throw off the profile counting, because they arrive
+            // in between regular interval samples. In the future, maybe we can support fractional samples
+            // somehow (fractional weight), but for now, we just attach them to the marker.
 
-                context.coreclr_context.borrow_mut().save_gc_marker(
+            context
+                .get_process_mut(process_id)
+                .unwrap()
+                .unresolved_samples
+                .attach_stack_to_marker(
                     thread_handle,
                     timestamp,
-                    "GCSuspendEE",
-                    "GC Suspended Thread".to_owned(),
-                    format!("Suspended: {}", reason_str),
+                    timestamp_raw,
+                    stack_index,
+                    marker,
                 );
-                handled = true;
-            }
-            "GCSuspendEEEnd" | "GCRestartEEBegin" => {
-                // don't care -- we only care about SuspendBegin and RestartEnd
-                handled = true;
-            }
-            "GCRestartEEEnd" => {
-                if let Some(info) = context
-                    .coreclr_context
-                    .borrow_mut()
-                    .remove_gc_marker(thread_handle, "GCSuspendEE")
-                {
-                    context.profile.borrow_mut().add_marker(
+            handled = true;
+        }
+        ("GarbageCollection", gc_event) => {
+            let gc_category = context.get_category(KnownCategory::CoreClrGc);
+            match gc_event {
+                "GCSampledObjectAllocation" => {
+                    // If High/Low flags are set, then we get one of these for every alloc. Otherwise only
+                    // when a threshold is hit. (100kb) The count and size are aggregates in that case.
+                    let type_id: u64 = parser.parse("TypeID"); // TODO: convert to str, with bulk type data
+                                                               //let address: u64 = parser.parse("Address");
+                    let object_count: u32 = parser.parse("ObjectCountForTypeSample");
+                    let total_size: u64 = parser.parse("TotalSizeForTypeSample");
+
+                    let mh = context.profile.borrow_mut().add_marker(
                         thread_handle,
                         gc_category,
-                        &info.name,
-                        CoreClrGcEventMarker(info.description),
-                        MarkerTiming::Interval(info.start, timestamp),
+                        "GC Alloc",
+                        CoreClrGcAllocMarker(format!("0x{:x}", type_id), total_size as usize),
+                        MarkerTiming::Instant(timestamp),
                     );
+                    core_clr_context.set_last_event_for_thread(thread_handle, mh);
+                    handled = true;
                 }
-                handled = true;
-            }
-            "win:Start" => {
-                let count: u32 = parser.parse("Count");
-                let depth: u32 = parser.parse("Depth");
-                let reason: u32 = parser.parse("Reason");
-                let gc_type: u32 = parser.parse("Type");
+                "Triggered" => {
+                    let reason: u32 = parser.parse("Reason");
 
-                let reason_str = match reason {
-                    0x0 => "Small object heap allocation",
-                    0x1 => "Induced",
-                    0x2 => "Low memory",
-                    0x3 => "Empty",
-                    0x4 => "Large object heap allocation",
-                    0x5 => "Out of space (for small object heap)",
-                    0x6 => "Out of space (for large object heap)",
-                    0x7 => "Induced but not forced as blocking",
-                    _ => {
-                        eprintln!("Unknown CLR GCStart reason: {}", reason);
-                        "Unknown reason"
-                    }
-                };
+                    let reason_str = match reason {
+                        0x0 => "AllocSmall",
+                        0x1 => "Induced",
+                        0x2 => "LowMemory",
+                        0x3 => "Empty",
+                        0x4 => "AllocLarge",
+                        0x5 => "OutOfSpaceSmallObjectHeap",
+                        0x6 => "OutOfSpaceLargeObjectHeap",
+                        0x7 => "nducedNoForce",
+                        0x8 => "Stress",
+                        0x9 => "InducedLowMemory",
+                        _ => {
+                            eprintln!("Unknown CLR GC Triggered reason: {}", reason);
+                            "Unknown"
+                        }
+                    };
 
-                let gc_type_str = match gc_type {
-                    0x0 => "Blocking GC",
-                    0x1 => "Background GC",
-                    0x2 => "Blocking GC during background GC",
-                    _ => {
-                        eprintln!("Unknown CLR GCStart type: {}", gc_type);
-                        "Unknown type"
-                    }
-                };
-
-                // TODO: use gc_type_str as the name
-                context.coreclr_context.borrow_mut().save_gc_marker(
-                    thread_handle,
-                    timestamp,
-                    "GC",
-                    "GC".to_owned(),
-                    format!(
-                        "{}: {} (GC #{}, gen{})",
-                        gc_type_str, reason_str, count, depth
-                    ),
-                );
-                handled = true;
-            }
-            "win:Stop" => {
-                //let count: u32 = parser.parse("Count");
-                //let depth: u32 = parser.parse("Depth");
-                if let Some(info) = context
-                    .coreclr_context
-                    .borrow_mut()
-                    .remove_gc_marker(thread_handle, "GC")
-                {
-                    context.profile.borrow_mut().add_marker(
+                    let mh = context.profile.borrow_mut().add_marker(
                         thread_handle,
                         gc_category,
-                        &info.name,
-                        CoreClrGcEventMarker(info.description),
-                        MarkerTiming::Interval(info.start, timestamp),
+                        "GC Trigger",
+                        CoreClrGcEventMarker(format!("GC Trigger: {}", reason_str)),
+                        MarkerTiming::Instant(timestamp),
                     );
+                    core_clr_context.set_last_event_for_thread(thread_handle, mh);
+                    handled = true;
                 }
-                handled = true;
-            }
-            "SetGCHandle" => {
-                // TODO
-            }
-            "DestroyGCHandle" => {
-                // TODO
-            }
-            "GCFinalizersBegin" | "GCFinalizersEnd" | "FinalizeObject" => {
-                // TODO: create an interval
-                handled = true;
-            }
-            "GCCreateSegment" | "GCFreeSegment" | "GCDynamicEvent" | "GCHeapStats" | _ => {
-                // don't care
-                handled = true;
+                "GCSuspendEEBegin" => {
+                    // Reason, Count
+                    let count: u32 = parser.parse("Count");
+                    let reason: u32 = parser.parse("Reason");
+
+                    let reason_str = match reason {
+                        0x0 => "Other",
+                        0x1 => "GC",
+                        0x2 => "AppDomain shutdown",
+                        0x3 => "Code pitching",
+                        0x4 => "Shutdown",
+                        0x5 => "Debugger",
+                        0x6 => "GC Prep",
+                        0x7 => "Debugger sweep",
+                        _ => {
+                            eprintln!("Unknown CLR GCSuspendEEBegin reason: {}", reason);
+                            "Unknown reason"
+                        }
+                    };
+
+                    core_clr_context.save_gc_marker(
+                        thread_handle,
+                        timestamp,
+                        "GCSuspendEE",
+                        "GC Suspended Thread".to_owned(),
+                        format!("Suspended: {}", reason_str),
+                    );
+                    handled = true;
+                }
+                "GCSuspendEEEnd" | "GCRestartEEBegin" => {
+                    // don't care -- we only care about SuspendBegin and RestartEnd
+                    handled = true;
+                }
+                "GCRestartEEEnd" => {
+                    if let Some(info) =
+                        core_clr_context.remove_gc_marker(thread_handle, "GCSuspendEE")
+                    {
+                        context.profile.borrow_mut().add_marker(
+                            thread_handle,
+                            gc_category,
+                            &info.name,
+                            CoreClrGcEventMarker(info.description),
+                            MarkerTiming::Interval(info.start, timestamp),
+                        );
+                    }
+                    handled = true;
+                }
+                "win:Start" => {
+                    let count: u32 = parser.parse("Count");
+                    let depth: u32 = parser.parse("Depth");
+                    let reason: u32 = parser.parse("Reason");
+                    let gc_type: u32 = parser.parse("Type");
+
+                    let reason_str = match reason {
+                        0x0 => "Small object heap allocation",
+                        0x1 => "Induced",
+                        0x2 => "Low memory",
+                        0x3 => "Empty",
+                        0x4 => "Large object heap allocation",
+                        0x5 => "Out of space (for small object heap)",
+                        0x6 => "Out of space (for large object heap)",
+                        0x7 => "Induced but not forced as blocking",
+                        _ => {
+                            eprintln!("Unknown CLR GCStart reason: {}", reason);
+                            "Unknown reason"
+                        }
+                    };
+
+                    let gc_type_str = match gc_type {
+                        0x0 => "Blocking GC",
+                        0x1 => "Background GC",
+                        0x2 => "Blocking GC during background GC",
+                        _ => {
+                            eprintln!("Unknown CLR GCStart type: {}", gc_type);
+                            "Unknown type"
+                        }
+                    };
+
+                    // TODO: use gc_type_str as the name
+                    core_clr_context.save_gc_marker(
+                        thread_handle,
+                        timestamp,
+                        "GC",
+                        "GC".to_owned(),
+                        format!(
+                            "{}: {} (GC #{}, gen{})",
+                            gc_type_str, reason_str, count, depth
+                        ),
+                    );
+                    handled = true;
+                }
+                "win:Stop" => {
+                    //let count: u32 = parser.parse("Count");
+                    //let depth: u32 = parser.parse("Depth");
+                    if let Some(info) = core_clr_context.remove_gc_marker(thread_handle, "GC") {
+                        context.profile.borrow_mut().add_marker(
+                            thread_handle,
+                            gc_category,
+                            &info.name,
+                            CoreClrGcEventMarker(info.description),
+                            MarkerTiming::Interval(info.start, timestamp),
+                        );
+                    }
+                    handled = true;
+                }
+                "SetGCHandle" => {
+                    // TODO
+                }
+                "DestroyGCHandle" => {
+                    // TODO
+                }
+                "GCFinalizersBegin" | "GCFinalizersEnd" | "FinalizeObject" => {
+                    // TODO: create an interval
+                    handled = true;
+                }
+                "GCCreateSegment" | "GCFreeSegment" | "GCDynamicEvent" | "GCHeapStats" | _ => {
+                    // don't care
+                    handled = true;
+                }
             }
         }
-    } else if dotnet_event.starts_with("CLRRuntimeInformation/") {
-        handled = true;
-    } else if dotnet_event.starts_with("CLRLoader/") {
-        // AppDomain, Assembly, Module Load/Unload
-        handled = true;
+        ("CLRRuntimeInformation", _) => {
+            handled = true;
+        }
+        ("CLRLoader", _) => {
+            // AppDomain, Assembly, Module Load/Unload
+            handled = true;
+        }
+        _ => {}
     }
 
     if !handled {
@@ -706,10 +702,7 @@ pub fn handle_coreclr_event(
             SimpleMarker(text),
         );
 
-        context
-            .coreclr_context
-            .borrow_mut()
-            .set_last_event_for_thread(thread_handle, mh);
+        core_clr_context.set_last_event_for_thread(thread_handle, mh);
         //eprintln!("Unhandled .NET event: tid {} {} {:?}", s.thread_id(), dotnet_event, mh.unwrap());
     }
 }

--- a/samply/src/windows/etw_gecko.rs
+++ b/samply/src/windows/etw_gecko.rs
@@ -66,681 +66,681 @@ pub fn profile_pid_from_etl_file(context: &mut ProfileContext, etl_file: &Path) 
 
     let result = open_trace(etl_file, |e| {
         event_count += 1;
-        let s = schema_locator.event_schema(e);
+        let Ok(s) = schema_locator.event_schema(e) else {
+            return;
+        };
 
-        if let Ok(s) = s {
-            let mut parser = Parser::create(&s);
-            let timestamp_raw = e.EventHeader.TimeStamp as u64;
-            let timestamp = timestamp_converter.convert_time(timestamp_raw);
+        let mut parser = Parser::create(&s);
+        let timestamp_raw = e.EventHeader.TimeStamp as u64;
+        let timestamp = timestamp_converter.convert_time(timestamp_raw);
 
-            //eprintln!("{}", s.name());
-            match s.name() {
-                "MSNT_SystemTrace/EventTrace/Header" => {
-                    timer_resolution = parser.parse("TimerResolution");
-                    let perf_freq: u64 = parser.parse("PerfFreq");
-                    let clock_type: u32 = parser.parse("ReservedFlags");
-                    if clock_type != 1 {
-                        log::warn!("QPC not used as clock");
-                        event_timestamps_are_qpc = false;
-                    } else {
-                        event_timestamps_are_qpc = true;
-                    }
-                    let events_lost: u32 = parser.parse("EventsLost");
-                    if events_lost != 0 {
-                        log::warn!("{} events lost", events_lost);
-                    }
+        //eprintln!("{}", s.name());
+        match s.name() {
+            "MSNT_SystemTrace/EventTrace/Header" => {
+                timer_resolution = parser.parse("TimerResolution");
+                let perf_freq: u64 = parser.parse("PerfFreq");
+                let clock_type: u32 = parser.parse("ReservedFlags");
+                if clock_type != 1 {
+                    log::warn!("QPC not used as clock");
+                    event_timestamps_are_qpc = false;
+                } else {
+                    event_timestamps_are_qpc = true;
+                }
+                let events_lost: u32 = parser.parse("EventsLost");
+                if events_lost != 0 {
+                    log::warn!("{} events lost", events_lost);
+                }
 
-                    timestamp_converter = TimestampConverter {
-                        reference_raw: e.EventHeader.TimeStamp as u64,
-                        raw_to_ns_factor: 1000 * 1000 * 1000 / perf_freq,
-                    };
+                timestamp_converter = TimestampConverter {
+                    reference_raw: e.EventHeader.TimeStamp as u64,
+                    raw_to_ns_factor: 1000 * 1000 * 1000 / perf_freq,
+                };
 
-                    if log::log_enabled!(log::Level::Info) {
-                        for i in 0..s.property_count() {
-                            let property = s.property(i);
-                            print_property(&mut parser, &property, false);
-                        }
+                if log::log_enabled!(log::Level::Info) {
+                    for i in 0..s.property_count() {
+                        let property = s.property(i);
+                        print_property(&mut parser, &property, false);
                     }
                 }
-                "MSNT_SystemTrace/PerfInfo/CollectionStart" => {
-                    let interval_raw: u32 = parser.parse("NewInterval");
-                    let interval_nanos = interval_raw as u64 * 100;
-                    let interval = SamplingInterval::from_nanos(interval_nanos);
-                    log::info!("Sample rate {}ms", interval.as_secs_f64() * 1000.);
-                    context.profile.borrow_mut().set_interval(interval);
-                    context.context_switch_handler.replace(ContextSwitchHandler::new(interval_raw as u64));
-                }
-                "MSNT_SystemTrace/Thread/SetName" => {
-                    let thread_id: u32 = parser.parse("ThreadId");
-                    let thread_name: String = parser.parse("ThreadName");
+            }
+            "MSNT_SystemTrace/PerfInfo/CollectionStart" => {
+                let interval_raw: u32 = parser.parse("NewInterval");
+                let interval_nanos = interval_raw as u64 * 100;
+                let interval = SamplingInterval::from_nanos(interval_nanos);
+                log::info!("Sample rate {}ms", interval.as_secs_f64() * 1000.);
+                context.profile.borrow_mut().set_interval(interval);
+                context.context_switch_handler.replace(ContextSwitchHandler::new(interval_raw as u64));
+            }
+            "MSNT_SystemTrace/Thread/SetName" => {
+                let thread_id: u32 = parser.parse("ThreadId");
+                let thread_name: String = parser.parse("ThreadName");
 
+                if !thread_name.is_empty() {
+                    context.set_thread_name(thread_id, &thread_name);
+                }
+            }
+            "MSNT_SystemTrace/Thread/Start" |
+            "MSNT_SystemTrace/Thread/DCStart" => {
+                let thread_id: u32 = parser.parse("TThreadId");
+                let process_id: u32 = parser.parse("ProcessId");
+
+                if !context.is_interesting_process(process_id, None, None) {
+                    return;
+                }
+
+                // if there's an existing thread, remove it, assume we dropped an end thread event
+                context.remove_thread(thread_id, Some(timestamp));
+                context.add_thread(process_id, thread_id, timestamp);
+
+                let thread_name: Option<String> = parser.try_parse("ThreadName").ok();
+                if let Some(thread_name) = thread_name {
                     if !thread_name.is_empty() {
                         context.set_thread_name(thread_id, &thread_name);
                     }
                 }
-                "MSNT_SystemTrace/Thread/Start" |
-                "MSNT_SystemTrace/Thread/DCStart" => {
-                    let thread_id: u32 = parser.parse("TThreadId");
-                    let process_id: u32 = parser.parse("ProcessId");
+            }
+            "MSNT_SystemTrace/Thread/End" |
+            "MSNT_SystemTrace/Thread/DCEnd" => {
+                let thread_id: u32 = parser.parse("TThreadId");
 
-                    if !context.is_interesting_process(process_id, None, None) {
-                        return;
-                    }
+                context.remove_thread(thread_id, Some(timestamp));
+            }
+            "MSNT_SystemTrace/Process/Start" |
+            "MSNT_SystemTrace/Process/DCStart" => {
+                let process_id: u32 = parser.parse("ProcessId");
+                let parent_id: u32 = parser.parse("ParentId");
+                let image_file_name: String = parser.parse("ImageFileName");
 
-                    // if there's an existing thread, remove it, assume we dropped an end thread event
-                    context.remove_thread(thread_id, Some(timestamp));
-                    context.add_thread(process_id, thread_id, timestamp);
+                // note: the event's e.EventHeader.process_id here is the parent (i.e. the process that spawned
+                // a new one. The process_id in ProcessId is the new process id.
 
-                    let thread_name: Option<String> = parser.try_parse("ThreadName").ok();
-                    if let Some(thread_name) = thread_name {
-                        if !thread_name.is_empty() {
-                            context.set_thread_name(thread_id, &thread_name);
-                        }
-                    }
+                if !context.is_interesting_process(process_id, Some(parent_id), Some(&image_file_name)) {
+                    return;
                 }
-                "MSNT_SystemTrace/Thread/End" |
-                "MSNT_SystemTrace/Thread/DCEnd" => {
-                    let thread_id: u32 = parser.parse("TThreadId");
 
-                    context.remove_thread(thread_id, Some(timestamp));
-                }
-                "MSNT_SystemTrace/Process/Start" |
-                "MSNT_SystemTrace/Process/DCStart" => {
-                    let process_id: u32 = parser.parse("ProcessId");
-                    let parent_id: u32 = parser.parse("ParentId");
-                    let image_file_name: String = parser.parse("ImageFileName");
+                context.add_process(process_id, parent_id, &context.map_device_path(&image_file_name), timestamp);
+            }
+            "MSNT_SystemTrace/Process/End" |
+            "MSNT_SystemTrace/Process/DCEnd" => {
+                //let process_id: u32 = parser.parse("ProcessId");
+                //context.end_process(...);
+            }
+            "MSNT_SystemTrace/StackWalk/Stack" => {
+                let thread_id: u32 = parser.parse("StackThread");
+                let process_id: u32 = parser.parse("StackProcess");
+                // The EventTimeStamp here indicates thea ccurate time the stack was collected, and
+                // not the time the ETW event was emitted (which is in the header). Use it instead.
+                let timestamp_raw: u64 = parser.parse("EventTimeStamp");
+                let timestamp = timestamp_converter.convert_time(timestamp_raw);
 
-                    // note: the event's e.EventHeader.process_id here is the parent (i.e. the process that spawned
-                    // a new one. The process_id in ProcessId is the new process id.
+                if !context.threads.contains_key(&thread_id) { return }
 
-                    if !context.is_interesting_process(process_id, Some(parent_id), Some(&image_file_name)) {
-                        return;
-                    }
+                // eprint!("{} {} {}", thread_id, e.EventHeader.TimeStamp, timestamp);
 
-                    context.add_process(process_id, parent_id, &context.map_device_path(&image_file_name), timestamp);
-                }
-                "MSNT_SystemTrace/Process/End" |
-                "MSNT_SystemTrace/Process/DCEnd" => {
-                    //let process_id: u32 = parser.parse("ProcessId");
-                    //context.end_process(...);
-                }
-                "MSNT_SystemTrace/StackWalk/Stack" => {
-                    let thread_id: u32 = parser.parse("StackThread");
-                    let process_id: u32 = parser.parse("StackProcess");
-                    // The EventTimeStamp here indicates thea ccurate time the stack was collected, and
-                    // not the time the ETW event was emitted (which is in the header). Use it instead.
-                    let timestamp_raw: u64 = parser.parse("EventTimeStamp");
-                    let timestamp = timestamp_converter.convert_time(timestamp_raw);
+                if is_arm64 {
+                    // On ARM64, this seems to be simpler -- stacks come in with full kernel and user frames.
+                    // At least, I've never seen a kernel stack come in separately.
+                    // TODO -- is this because I can't use PROFILE events in the VM?
 
-                    if !context.threads.contains_key(&thread_id) { return }
-
-                    // eprint!("{} {} {}", thread_id, e.EventHeader.TimeStamp, timestamp);
-
-                    if is_arm64 {
-                        // On ARM64, this seems to be simpler -- stacks come in with full kernel and user frames.
-                        // At least, I've never seen a kernel stack come in separately.
-                        // TODO -- is this because I can't use PROFILE events in the VM?
-
-                        // Iterate over the stack addresses, starting with the instruction pointer
-                        let stack: Vec<StackFrame> = parser.buffer.chunks_exact(8) // iterate over 8 byte items
-                            .map(|a| u64::from_ne_bytes(a.try_into().unwrap())) // parse into u64
-                            .enumerate()
-                            .map(|(i, addr)| {
-                                if i == 0 {
-                                    StackFrame::InstructionPointer(addr, context.stack_mode_for_address(addr))
-                                } else {
-                                    StackFrame::ReturnAddress(addr, context.stack_mode_for_address(addr))
-                                }
-                            })
-                            .collect();
-
-                        let cpu_delta_raw = context.context_switch_handler.borrow_mut().consume_cpu_delta(&mut context.get_thread_mut(thread_id).unwrap().context_switch_data);
-                        let cpu_delta = CpuDelta::from_nanos(cpu_delta_raw * timestamp_converter.raw_to_ns_factor);
-                        context.add_sample(process_id, thread_id, timestamp, timestamp_raw, cpu_delta, 1, stack);
-                        return;
-                    }
-
-                    assert!(is_x86);
-
-                    let mut stack: Vec<StackFrame> = Vec::with_capacity(parser.buffer.len() / 8);
-                    let mut address_iter = parser.buffer.chunks_exact(8).map(|a| u64::from_ne_bytes(a.try_into().unwrap()));
-                    let Some(first_frame_address) = address_iter.next() else { return };
-                    let first_frame_stack_mode = context.stack_mode_for_address(first_frame_address);
-                    stack.push(StackFrame::InstructionPointer(first_frame_address, first_frame_stack_mode));
-                    for frame_address in address_iter {
-                        let stack_mode = context.stack_mode_for_address(frame_address);
-                        stack.push(StackFrame::ReturnAddress(frame_address, stack_mode));
-                    }
-
-                    if first_frame_stack_mode == StackMode::Kernel {
-                        let mut thread = context.get_thread_mut(thread_id).unwrap();
-                        if let Some(pending_stack ) = thread.pending_stacks.iter_mut().rev().find(|s| s.timestamp == timestamp_raw) {
-                            if let Some(kernel_stack) = pending_stack.kernel_stack.as_mut() {
-                                log::warn!("Multiple kernel stacks for timestamp {timestamp_raw} on thread {thread_id}");
-                                kernel_stack.extend(&stack);
+                    // Iterate over the stack addresses, starting with the instruction pointer
+                    let stack: Vec<StackFrame> = parser.buffer.chunks_exact(8) // iterate over 8 byte items
+                        .map(|a| u64::from_ne_bytes(a.try_into().unwrap())) // parse into u64
+                        .enumerate()
+                        .map(|(i, addr)| {
+                            if i == 0 {
+                                StackFrame::InstructionPointer(addr, context.stack_mode_for_address(addr))
                             } else {
-                                pending_stack.kernel_stack = Some(stack);
+                                StackFrame::ReturnAddress(addr, context.stack_mode_for_address(addr))
                             }
-                        }
-                        return;
-                    }
+                        })
+                        .collect();
 
-                    // We now know that we have a user stack. User stacks always come last. Consume
-                    // the pending stack with matching timestamp.
-
-                    // the number of pending stacks at or before our timestamp
-                    let num_pending_stacks = context.get_thread(thread_id).unwrap()
-                        .pending_stacks.iter().take_while(|s| s.timestamp <= timestamp_raw).count();
-
-                    let pending_stacks: VecDeque<_> = context.get_thread_mut(thread_id).unwrap().pending_stacks.drain(..num_pending_stacks).collect();
-
-                    // Use this user stack for all pending stacks from this thread.
-                    for pending_stack in pending_stacks {
-                        let PendingStack {
-                            timestamp,
-                            kernel_stack,
-                            off_cpu_sample_group,
-                            on_cpu_sample_cpu_delta,
-                        } = pending_stack;
-
-                        if let Some(off_cpu_sample_group) = off_cpu_sample_group {
-                            let OffCpuSampleGroup { begin_timestamp, end_timestamp, sample_count } = off_cpu_sample_group;
-
-                            let cpu_delta_raw = {
-                                let mut thread = context.get_thread_mut(thread_id).unwrap();
-                                context.context_switch_handler.borrow_mut().consume_cpu_delta(&mut thread.context_switch_data)
-                            };
-                            let cpu_delta = CpuDelta::from_nanos(cpu_delta_raw * timestamp_converter.raw_to_ns_factor);
-
-                            // Add a sample at the beginning of the paused range.
-                            // This "first sample" will carry any leftover accumulated running time ("cpu delta").
-                            context.add_sample(process_id, thread_id, timestamp_converter.convert_time(begin_timestamp), begin_timestamp, cpu_delta, 1, stack.clone());
-
-                            if sample_count > 1 {
-                                // Emit a "rest sample" with a CPU delta of zero covering the rest of the paused range.
-                                let weight = i32::try_from(sample_count - 1).unwrap_or(0);
-                                context.add_sample(process_id, thread_id, timestamp_converter.convert_time(end_timestamp), end_timestamp, CpuDelta::ZERO, weight, stack.clone());
-                            }
-                        }
-
-                        if let Some(cpu_delta) = on_cpu_sample_cpu_delta {
-                            let timestamp_cvt = timestamp_converter.convert_time(timestamp);
-                            if let Some(mut combined_stack) = kernel_stack {
-                                combined_stack.extend_from_slice(&stack[..]);
-                                context.add_sample(process_id, thread_id, timestamp_cvt, timestamp, cpu_delta, 1, combined_stack);
-                            } else {
-                                context.add_sample(process_id, thread_id, timestamp_cvt, timestamp, cpu_delta, 1, stack.clone());
-                            }
-                            stack_sample_count += 1;
-                        }
-                    }
+                    let cpu_delta_raw = context.context_switch_handler.borrow_mut().consume_cpu_delta(&mut context.get_thread_mut(thread_id).unwrap().context_switch_data);
+                    let cpu_delta = CpuDelta::from_nanos(cpu_delta_raw * timestamp_converter.raw_to_ns_factor);
+                    context.add_sample(process_id, thread_id, timestamp, timestamp_raw, cpu_delta, 1, stack);
+                    return;
                 }
-                "MSNT_SystemTrace/PerfInfo/SampleProf" => {
-                    let thread_id: u32 = parser.parse("ThreadId");
 
-                    sample_count += 1;
+                assert!(is_x86);
 
-                    let Some(mut thread) = context.get_thread_mut(thread_id) else { return };
-
-                    let off_cpu_sample_group = context.context_switch_handler.borrow_mut().handle_on_cpu_sample(timestamp_raw, &mut thread.context_switch_data);
-                    let delta = context.context_switch_handler.borrow_mut().consume_cpu_delta(&mut thread.context_switch_data);
-                    let cpu_delta = CpuDelta::from_nanos(delta * timestamp_converter.raw_to_ns_factor);
-                    thread.pending_stacks.push_back(PendingStack { timestamp: timestamp_raw, kernel_stack: None, off_cpu_sample_group, on_cpu_sample_cpu_delta: Some(cpu_delta) });
+                let mut stack: Vec<StackFrame> = Vec::with_capacity(parser.buffer.len() / 8);
+                let mut address_iter = parser.buffer.chunks_exact(8).map(|a| u64::from_ne_bytes(a.try_into().unwrap()));
+                let Some(first_frame_address) = address_iter.next() else { return };
+                let first_frame_stack_mode = context.stack_mode_for_address(first_frame_address);
+                stack.push(StackFrame::InstructionPointer(first_frame_address, first_frame_stack_mode));
+                for frame_address in address_iter {
+                    let stack_mode = context.stack_mode_for_address(frame_address);
+                    stack.push(StackFrame::ReturnAddress(frame_address, stack_mode));
                 }
-                "MSNT_SystemTrace/PageFault/DemandZeroFault" => {
-                    if !demand_zero_faults { return }
 
-                    let thread_id: u32 = s.thread_id();
-                    //println!("sample {}", thread_id);
-                    sample_count += 1;
-
-                    let Some(mut thread) = context.get_thread_mut(thread_id) else { return };
-
-                    thread.pending_stacks.push_back(PendingStack { timestamp: timestamp_raw, kernel_stack: None, off_cpu_sample_group: None, on_cpu_sample_cpu_delta: Some(CpuDelta::from_millis(1.0)) });
-                }
-                "MSNT_SystemTrace/PageFault/VirtualAlloc" |
-                "MSNT_SystemTrace/PageFault/VirtualFree" => {
-                    if !context.is_interesting_process(e.EventHeader.ProcessId, None, None) {
-                        return;
-                    }
-
-                    let thread_id = e.EventHeader.ThreadId;
-
-                    let Some(memory_usage_counter) = context.get_or_create_memory_usage_counter(thread_id) else { return };
-                    let Some(thread_handle) = context.get_thread(thread_id).map(|t| t.handle) else { return };
-
-                    let region_size: u64 = parser.parse("RegionSize");
-
-                    let is_free = s.name() == "MSNT_SystemTrace/PageFault/VirtualFree";
-                    let delta_size = if is_free { -(region_size as f64) } else { region_size as f64 };
-                    let op_name = if is_free { "VirtualFree" } else { "VirtualAlloc" };
-
-                    //println!("{} VirtualFree({}) = {}", e.EventHeader.ProcessId, region_size, counter.value);
-
-                    let text = event_properties_to_string(&s, &mut parser, None);
-                    context.profile.borrow_mut().add_counter_sample(memory_usage_counter, timestamp, delta_size, 1);
-                    context.profile.borrow_mut().add_marker(thread_handle, CategoryHandle::OTHER, op_name, SimpleMarker(text), MarkerTiming::Instant(timestamp));
-                }
-                "KernelTraceControl/ImageID/" => {
-                    // KernelTraceControl/ImageID/ and KernelTraceControl/ImageID/DbgID_RSDS are synthesized during merge from
-                    // from MSNT_SystemTrace/Image/Load but don't contain the full path of the binary, or the full debug info in one go.
-                    // We go through "ImageID/" to capture pid/address + the original filename, then expect to see a "DbgID_RSDS" event
-                    // with pdb and debug info. We link those up through the "libs" hash, and then finally add them to the process
-                    // in Image/Load.
-
-                    let process_id = s.process_id(); // there isn't a ProcessId field here
-                    if !context.is_interesting_process(process_id, None, None) && process_id != 0 {
-                        return
-                    }
-
-                    let image_base: u64 = parser.try_parse("ImageBase").unwrap();
-                    let image_timestamp = parser.try_parse("TimeDateStamp").unwrap();
-                    let image_size: u32 = parser.try_parse("ImageSize").unwrap();
-                    let image_path: String = parser.try_parse("OriginalFileName").unwrap();
-                    //eprintln!("ImageID pid: {} 0x{:x} {} {} {}", process_id, image_base, image_path, image_size, image_timestamp);
-                    // "libs" is used as a cache to store the image path and size until we get the DbgID_RSDS event
-                    if libs.contains_key(&(process_id, image_base)) {
-                        // I see odd entries like this with no corresponding DbgID_RSDS:
-                        //   ImageID pid: 3156 0xf70000 com.docker.cli.exe 49819648 0
-                        // they all come from something docker-related. So don't panic on the duplicate.
-                        //panic!("libs already contains key 0x{:x} for pid {}", image_base, process_id);
-                    }
-                    libs.insert((process_id, image_base), (image_path, image_size, image_timestamp));
-                }
-                "KernelTraceControl/ImageID/DbgID_RSDS" => {
-                    let process_id = parser.try_parse("ProcessId").unwrap();
-                    if !context.is_interesting_process(process_id, None, None) && process_id != 0 {
-                        return
-                    }
-
-                    let image_base: u64 = parser.try_parse("ImageBase").unwrap();
-                    let guid: GUID = parser.try_parse("GuidSig").unwrap();
-                    let age: u32 = parser.try_parse("Age").unwrap();
-                    let debug_id = DebugId::from_parts(Uuid::from_fields(guid.data1, guid.data2, guid.data3, &guid.data4), age);
-                    let pdb_path: String = parser.try_parse("PdbFileName").unwrap();
-                    //let pdb_path = Path::new(&pdb_path);
-                    let Some((ref path, image_size, timestamp)) = libs.remove(&(process_id, image_base)) else {
-                        log::warn!("DbID_RSDS for image at 0x{:x} for pid {}, but has no entry in libs", image_base, process_id);
-                        return
-                    };
-                    //eprintln!("DbgID_RSDS pid: {} 0x{:x} {} {} {} {}", process_id, image_base, path, debug_id, pdb_path, age);
-                    let code_id = Some(format!("{timestamp:08X}{image_size:x}"));
-                    let name = Path::new(path).file_name().unwrap().to_str().unwrap().to_owned();
-                    let debug_name = Path::new(&pdb_path).file_name().map(|f| f.to_str().unwrap().to_owned()).unwrap_or(name.clone());
-                    let info = LibraryInfo {
-                        name,
-                        debug_name,
-                        path: path.clone(),
-                        code_id,
-                        symbol_table: None,
-                        debug_path: pdb_path,
-                        debug_id,
-                        arch: Some(context.arch.to_owned()),
-                    };
-                    if process_id == 0 || image_base >= context.kernel_min {
-                        if let Some(oldinfo) = kernel_pending_libraries.get(&image_base) {
-                            assert_eq!(*oldinfo, info);
+                if first_frame_stack_mode == StackMode::Kernel {
+                    let mut thread = context.get_thread_mut(thread_id).unwrap();
+                    if let Some(pending_stack ) = thread.pending_stacks.iter_mut().rev().find(|s| s.timestamp == timestamp_raw) {
+                        if let Some(kernel_stack) = pending_stack.kernel_stack.as_mut() {
+                            log::warn!("Multiple kernel stacks for timestamp {timestamp_raw} on thread {thread_id}");
+                            kernel_stack.extend(&stack);
                         } else {
-                            kernel_pending_libraries.insert(image_base, info);
+                            pending_stack.kernel_stack = Some(stack);
                         }
-                    } else if let Some(mut process) = context.get_process_mut(process_id) {
-                        process.pending_libraries.insert(image_base, info);
-                    } else {
-                        log::warn!("No process for pid {process_id}");
                     }
-
+                    return;
                 }
-                "MSNT_SystemTrace/Image/Load" | "MSNT_SystemTrace/Image/DCStart" => {
-                    // KernelTraceControl/ImageID/ and KernelTraceControl/ImageID/DbgID_RSDS are synthesized from MSNT_SystemTrace/Image/Load
-                    // but don't contain the full path of the binary. We go through a bit of a dance to store the information from those events
-                    // in pending_libraries and deal with it here. We assume that the KernelTraceControl events come before the Image/Load event.
 
-                    // the ProcessId field doesn't necessarily match s.process_id();
-                    let process_id = parser.try_parse("ProcessId").unwrap();
-                    if !context.is_interesting_process(process_id, None, None) && process_id != 0 {
-                        return
+                // We now know that we have a user stack. User stacks always come last. Consume
+                // the pending stack with matching timestamp.
+
+                // the number of pending stacks at or before our timestamp
+                let num_pending_stacks = context.get_thread(thread_id).unwrap()
+                    .pending_stacks.iter().take_while(|s| s.timestamp <= timestamp_raw).count();
+
+                let pending_stacks: VecDeque<_> = context.get_thread_mut(thread_id).unwrap().pending_stacks.drain(..num_pending_stacks).collect();
+
+                // Use this user stack for all pending stacks from this thread.
+                for pending_stack in pending_stacks {
+                    let PendingStack {
+                        timestamp,
+                        kernel_stack,
+                        off_cpu_sample_group,
+                        on_cpu_sample_cpu_delta,
+                    } = pending_stack;
+
+                    if let Some(off_cpu_sample_group) = off_cpu_sample_group {
+                        let OffCpuSampleGroup { begin_timestamp, end_timestamp, sample_count } = off_cpu_sample_group;
+
+                        let cpu_delta_raw = {
+                            let mut thread = context.get_thread_mut(thread_id).unwrap();
+                            context.context_switch_handler.borrow_mut().consume_cpu_delta(&mut thread.context_switch_data)
+                        };
+                        let cpu_delta = CpuDelta::from_nanos(cpu_delta_raw * timestamp_converter.raw_to_ns_factor);
+
+                        // Add a sample at the beginning of the paused range.
+                        // This "first sample" will carry any leftover accumulated running time ("cpu delta").
+                        context.add_sample(process_id, thread_id, timestamp_converter.convert_time(begin_timestamp), begin_timestamp, cpu_delta, 1, stack.clone());
+
+                        if sample_count > 1 {
+                            // Emit a "rest sample" with a CPU delta of zero covering the rest of the paused range.
+                            let weight = i32::try_from(sample_count - 1).unwrap_or(0);
+                            context.add_sample(process_id, thread_id, timestamp_converter.convert_time(end_timestamp), end_timestamp, CpuDelta::ZERO, weight, stack.clone());
+                        }
                     }
 
-                    let image_base: u64 = parser.try_parse("ImageBase").unwrap();
-                    let image_size: u64 = parser.try_parse("ImageSize").unwrap();
-
-                    let path: String = parser.try_parse("FileName").unwrap();
-                    let path = context.map_device_path(&path);
-
-                    let info = if process_id == 0 {
-                        kernel_pending_libraries.remove(&image_base)
-                    } else if let Some(mut process) = context.get_process_mut(process_id) {
-                        process.pending_libraries.remove(&image_base)
-                    } else {
-                        log::warn!("Received {} for unknown pid {process_id}", s.name());
-                        return;
-                    };
-
-                    // If the file doesn't exist on disk we won't have KernelTraceControl/ImageID events
-                    // This happens for the ghost drivers mentioned here: https://devblogs.microsoft.com/oldnewthing/20160913-00/?p=94305
-                    let Some(mut info) = info else {
-                        return
-                    };
-
-                    info.path = path;
-
-                    // attempt to categorize the library based on the path
-                    let path_lower = info.path.to_lowercase();
-                    let debug_path_lower = info.debug_path.to_lowercase();
-
-                    let known_category = if debug_path_lower.contains(".ni.pdb") {
-                        KnownCategory::CoreClrR2r
-                    } else if path_lower.contains("windows\\system32") || path_lower.contains("windows\\winsxs") {
-                        KnownCategory::System
-                    } else {
-                        KnownCategory::Unknown
-                    };
-
-                    let lib_handle = context.profile.borrow_mut().add_lib(info);
-                    if process_id == 0 || image_base >= context.kernel_min {
-                        context.profile.borrow_mut().add_kernel_lib_mapping(lib_handle, image_base, image_base + image_size, 0);
-                        return
+                    if let Some(cpu_delta) = on_cpu_sample_cpu_delta {
+                        let timestamp_cvt = timestamp_converter.convert_time(timestamp);
+                        if let Some(mut combined_stack) = kernel_stack {
+                            combined_stack.extend_from_slice(&stack[..]);
+                            context.add_sample(process_id, thread_id, timestamp_cvt, timestamp, cpu_delta, 1, combined_stack);
+                        } else {
+                            context.add_sample(process_id, thread_id, timestamp_cvt, timestamp, cpu_delta, 1, stack.clone());
+                        }
+                        stack_sample_count += 1;
                     }
-
-
-                    let info = if known_category != KnownCategory::Unknown {
-                        let category = context.get_category(known_category);
-                        LibMappingInfo::new_lib_with_category(lib_handle, category.into())
-                    } else {
-                        LibMappingInfo::new_lib(lib_handle)
-                    };
-
-                    context.get_process_mut(process_id).unwrap().regular_lib_mapping_ops.push(timestamp_raw, LibMappingOp::Add(LibMappingAdd {
-                            start_avma: image_base,
-                            end_avma: image_base + image_size,
-                            relative_address_at_start: 0,
-                            info,
-                        }));
                 }
-                "Microsoft-Windows-DxgKrnl/VSyncDPC/Info " => {
-                    #[derive(Debug, Clone)]
-                    pub struct VSyncMarker;
+            }
+            "MSNT_SystemTrace/PerfInfo/SampleProf" => {
+                let thread_id: u32 = parser.parse("ThreadId");
 
-                    impl ProfilerMarker for VSyncMarker {
-                        const MARKER_TYPE_NAME: &'static str = "Vsync";
+                sample_count += 1;
 
-                        fn json_marker_data(&self) -> Value {
-                            json!({
-                                "type": Self::MARKER_TYPE_NAME,
-                                "name": ""
-                            })
-                        }
+                let Some(mut thread) = context.get_thread_mut(thread_id) else { return };
 
-                        fn schema() -> MarkerSchema {
-                            MarkerSchema {
-                                type_name: Self::MARKER_TYPE_NAME,
-                                locations: vec![MarkerLocation::MarkerChart, MarkerLocation::MarkerTable, MarkerLocation::TimelineOverview],
-                                chart_label: Some("{marker.data.name}"),
-                                tooltip_label: None,
-                                table_label: Some("{marker.name} - {marker.data.name}"),
-                                fields: vec![MarkerSchemaField::Dynamic(MarkerDynamicField {
-                                    key: "name",
-                                    label: "Details",
-                                    format: MarkerFieldFormat::String,
-                                    searchable: false,
-                                })],
-                            }
-                        }
+                let off_cpu_sample_group = context.context_switch_handler.borrow_mut().handle_on_cpu_sample(timestamp_raw, &mut thread.context_switch_data);
+                let delta = context.context_switch_handler.borrow_mut().consume_cpu_delta(&mut thread.context_switch_data);
+                let cpu_delta = CpuDelta::from_nanos(delta * timestamp_converter.raw_to_ns_factor);
+                thread.pending_stacks.push_back(PendingStack { timestamp: timestamp_raw, kernel_stack: None, off_cpu_sample_group, on_cpu_sample_cpu_delta: Some(cpu_delta) });
+            }
+            "MSNT_SystemTrace/PageFault/DemandZeroFault" => {
+                if !demand_zero_faults { return }
+
+                let thread_id: u32 = s.thread_id();
+                //println!("sample {}", thread_id);
+                sample_count += 1;
+
+                let Some(mut thread) = context.get_thread_mut(thread_id) else { return };
+
+                thread.pending_stacks.push_back(PendingStack { timestamp: timestamp_raw, kernel_stack: None, off_cpu_sample_group: None, on_cpu_sample_cpu_delta: Some(CpuDelta::from_millis(1.0)) });
+            }
+            "MSNT_SystemTrace/PageFault/VirtualAlloc" |
+            "MSNT_SystemTrace/PageFault/VirtualFree" => {
+                if !context.is_interesting_process(e.EventHeader.ProcessId, None, None) {
+                    return;
+                }
+
+                let thread_id = e.EventHeader.ThreadId;
+
+                let Some(memory_usage_counter) = context.get_or_create_memory_usage_counter(thread_id) else { return };
+                let Some(thread_handle) = context.get_thread(thread_id).map(|t| t.handle) else { return };
+
+                let region_size: u64 = parser.parse("RegionSize");
+
+                let is_free = s.name() == "MSNT_SystemTrace/PageFault/VirtualFree";
+                let delta_size = if is_free { -(region_size as f64) } else { region_size as f64 };
+                let op_name = if is_free { "VirtualFree" } else { "VirtualAlloc" };
+
+                //println!("{} VirtualFree({}) = {}", e.EventHeader.ProcessId, region_size, counter.value);
+
+                let text = event_properties_to_string(&s, &mut parser, None);
+                context.profile.borrow_mut().add_counter_sample(memory_usage_counter, timestamp, delta_size, 1);
+                context.profile.borrow_mut().add_marker(thread_handle, CategoryHandle::OTHER, op_name, SimpleMarker(text), MarkerTiming::Instant(timestamp));
+            }
+            "KernelTraceControl/ImageID/" => {
+                // KernelTraceControl/ImageID/ and KernelTraceControl/ImageID/DbgID_RSDS are synthesized during merge from
+                // from MSNT_SystemTrace/Image/Load but don't contain the full path of the binary, or the full debug info in one go.
+                // We go through "ImageID/" to capture pid/address + the original filename, then expect to see a "DbgID_RSDS" event
+                // with pdb and debug info. We link those up through the "libs" hash, and then finally add them to the process
+                // in Image/Load.
+
+                let process_id = s.process_id(); // there isn't a ProcessId field here
+                if !context.is_interesting_process(process_id, None, None) && process_id != 0 {
+                    return
+                }
+
+                let image_base: u64 = parser.try_parse("ImageBase").unwrap();
+                let image_timestamp = parser.try_parse("TimeDateStamp").unwrap();
+                let image_size: u32 = parser.try_parse("ImageSize").unwrap();
+                let image_path: String = parser.try_parse("OriginalFileName").unwrap();
+                //eprintln!("ImageID pid: {} 0x{:x} {} {} {}", process_id, image_base, image_path, image_size, image_timestamp);
+                // "libs" is used as a cache to store the image path and size until we get the DbgID_RSDS event
+                if libs.contains_key(&(process_id, image_base)) {
+                    // I see odd entries like this with no corresponding DbgID_RSDS:
+                    //   ImageID pid: 3156 0xf70000 com.docker.cli.exe 49819648 0
+                    // they all come from something docker-related. So don't panic on the duplicate.
+                    //panic!("libs already contains key 0x{:x} for pid {}", image_base, process_id);
+                }
+                libs.insert((process_id, image_base), (image_path, image_size, image_timestamp));
+            }
+            "KernelTraceControl/ImageID/DbgID_RSDS" => {
+                let process_id = parser.try_parse("ProcessId").unwrap();
+                if !context.is_interesting_process(process_id, None, None) && process_id != 0 {
+                    return
+                }
+
+                let image_base: u64 = parser.try_parse("ImageBase").unwrap();
+                let guid: GUID = parser.try_parse("GuidSig").unwrap();
+                let age: u32 = parser.try_parse("Age").unwrap();
+                let debug_id = DebugId::from_parts(Uuid::from_fields(guid.data1, guid.data2, guid.data3, &guid.data4), age);
+                let pdb_path: String = parser.try_parse("PdbFileName").unwrap();
+                //let pdb_path = Path::new(&pdb_path);
+                let Some((ref path, image_size, timestamp)) = libs.remove(&(process_id, image_base)) else {
+                    log::warn!("DbID_RSDS for image at 0x{:x} for pid {}, but has no entry in libs", image_base, process_id);
+                    return
+                };
+                //eprintln!("DbgID_RSDS pid: {} 0x{:x} {} {} {} {}", process_id, image_base, path, debug_id, pdb_path, age);
+                let code_id = Some(format!("{timestamp:08X}{image_size:x}"));
+                let name = Path::new(path).file_name().unwrap().to_str().unwrap().to_owned();
+                let debug_name = Path::new(&pdb_path).file_name().map(|f| f.to_str().unwrap().to_owned()).unwrap_or(name.clone());
+                let info = LibraryInfo {
+                    name,
+                    debug_name,
+                    path: path.clone(),
+                    code_id,
+                    symbol_table: None,
+                    debug_path: pdb_path,
+                    debug_id,
+                    arch: Some(context.arch.to_owned()),
+                };
+                if process_id == 0 || image_base >= context.kernel_min {
+                    if let Some(oldinfo) = kernel_pending_libraries.get(&image_base) {
+                        assert_eq!(*oldinfo, info);
+                    } else {
+                        kernel_pending_libraries.insert(image_base, info);
+                    }
+                } else if let Some(mut process) = context.get_process_mut(process_id) {
+                    process.pending_libraries.insert(image_base, info);
+                } else {
+                    log::warn!("No process for pid {process_id}");
+                }
+
+            }
+            "MSNT_SystemTrace/Image/Load" | "MSNT_SystemTrace/Image/DCStart" => {
+                // KernelTraceControl/ImageID/ and KernelTraceControl/ImageID/DbgID_RSDS are synthesized from MSNT_SystemTrace/Image/Load
+                // but don't contain the full path of the binary. We go through a bit of a dance to store the information from those events
+                // in pending_libraries and deal with it here. We assume that the KernelTraceControl events come before the Image/Load event.
+
+                // the ProcessId field doesn't necessarily match s.process_id();
+                let process_id = parser.try_parse("ProcessId").unwrap();
+                if !context.is_interesting_process(process_id, None, None) && process_id != 0 {
+                    return
+                }
+
+                let image_base: u64 = parser.try_parse("ImageBase").unwrap();
+                let image_size: u64 = parser.try_parse("ImageSize").unwrap();
+
+                let path: String = parser.try_parse("FileName").unwrap();
+                let path = context.map_device_path(&path);
+
+                let info = if process_id == 0 {
+                    kernel_pending_libraries.remove(&image_base)
+                } else if let Some(mut process) = context.get_process_mut(process_id) {
+                    process.pending_libraries.remove(&image_base)
+                } else {
+                    log::warn!("Received {} for unknown pid {process_id}", s.name());
+                    return;
+                };
+
+                // If the file doesn't exist on disk we won't have KernelTraceControl/ImageID events
+                // This happens for the ghost drivers mentioned here: https://devblogs.microsoft.com/oldnewthing/20160913-00/?p=94305
+                let Some(mut info) = info else {
+                    return
+                };
+
+                info.path = path;
+
+                // attempt to categorize the library based on the path
+                let path_lower = info.path.to_lowercase();
+                let debug_path_lower = info.debug_path.to_lowercase();
+
+                let known_category = if debug_path_lower.contains(".ni.pdb") {
+                    KnownCategory::CoreClrR2r
+                } else if path_lower.contains("windows\\system32") || path_lower.contains("windows\\winsxs") {
+                    KnownCategory::System
+                } else {
+                    KnownCategory::Unknown
+                };
+
+                let lib_handle = context.profile.borrow_mut().add_lib(info);
+                if process_id == 0 || image_base >= context.kernel_min {
+                    context.profile.borrow_mut().add_kernel_lib_mapping(lib_handle, image_base, image_base + image_size, 0);
+                    return
+                }
+
+
+                let info = if known_category != KnownCategory::Unknown {
+                    let category = context.get_category(known_category);
+                    LibMappingInfo::new_lib_with_category(lib_handle, category.into())
+                } else {
+                    LibMappingInfo::new_lib(lib_handle)
+                };
+
+                context.get_process_mut(process_id).unwrap().regular_lib_mapping_ops.push(timestamp_raw, LibMappingOp::Add(LibMappingAdd {
+                        start_avma: image_base,
+                        end_avma: image_base + image_size,
+                        relative_address_at_start: 0,
+                        info,
+                    }));
+            }
+            "Microsoft-Windows-DxgKrnl/VSyncDPC/Info " => {
+                #[derive(Debug, Clone)]
+                pub struct VSyncMarker;
+
+                impl ProfilerMarker for VSyncMarker {
+                    const MARKER_TYPE_NAME: &'static str = "Vsync";
+
+                    fn json_marker_data(&self) -> Value {
+                        json!({
+                            "type": Self::MARKER_TYPE_NAME,
+                            "name": ""
+                        })
                     }
 
-                    let gpu_thread = gpu_thread.get_or_insert_with(|| {
-                        let gpu = context.profile.borrow_mut().add_process("GPU", 1, profile_start_instant);
-                        context.profile.borrow_mut().add_thread(gpu, 1, profile_start_instant, false)
-                    });
-                    context.profile.borrow_mut().add_marker(*gpu_thread,
+                    fn schema() -> MarkerSchema {
+                        MarkerSchema {
+                            type_name: Self::MARKER_TYPE_NAME,
+                            locations: vec![MarkerLocation::MarkerChart, MarkerLocation::MarkerTable, MarkerLocation::TimelineOverview],
+                            chart_label: Some("{marker.data.name}"),
+                            tooltip_label: None,
+                            table_label: Some("{marker.name} - {marker.data.name}"),
+                            fields: vec![MarkerSchemaField::Dynamic(MarkerDynamicField {
+                                key: "name",
+                                label: "Details",
+                                format: MarkerFieldFormat::String,
+                                searchable: false,
+                            })],
+                        }
+                    }
+                }
+
+                let gpu_thread = gpu_thread.get_or_insert_with(|| {
+                    let gpu = context.profile.borrow_mut().add_process("GPU", 1, profile_start_instant);
+                    context.profile.borrow_mut().add_thread(gpu, 1, profile_start_instant, false)
+                });
+                context.profile.borrow_mut().add_marker(*gpu_thread,
+                    CategoryHandle::OTHER,
+                    "Vsync",
+                    VSyncMarker{},
+                    MarkerTiming::Instant(timestamp)
+                );
+            }
+            "MSNT_SystemTrace/Thread/CSwitch" => {
+                let new_thread: u32 = parser.parse("NewThreadId");
+                let old_thread: u32 = parser.parse("OldThreadId");
+                // println!("CSwitch {} -> {} @ {} on {}", old_thread, new_thread, e.EventHeader.TimeStamp, unsafe { e.BufferContext.Anonymous.ProcessorIndex });
+
+                if let Some(mut old_thread) = context.get_thread_mut(old_thread) {
+                    context.context_switch_handler.borrow_mut().handle_switch_out(timestamp_raw, &mut old_thread.context_switch_data);
+                }
+                if let Some(mut new_thread) = context.get_thread_mut(new_thread) {
+                    let off_cpu_sample_group = context.context_switch_handler.borrow_mut().handle_switch_in(timestamp_raw, &mut new_thread.context_switch_data);
+                    if let Some(off_cpu_sample_group) = off_cpu_sample_group {
+                        new_thread.pending_stacks.push_back(PendingStack { timestamp: timestamp_raw, kernel_stack: None, off_cpu_sample_group: Some(off_cpu_sample_group), on_cpu_sample_cpu_delta: None });
+                    }
+                }
+            }
+            "MSNT_SystemTrace/Thread/ReadyThread" => {
+                // these events can give us the unblocking stack
+                let _thread_id: u32 = parser.parse("TThreadId");
+            }
+            "V8.js/MethodLoad/" |
+            "Microsoft-JScript/MethodRuntime/MethodDCStart" |
+            "Microsoft-JScript/MethodRuntime/MethodLoad" => {
+                let process_id = s.process_id();
+
+                let method_name: String = parser.parse("MethodName");
+                let method_start_address: Address = parser.parse("MethodStartAddress");
+                let method_size: u64 = parser.parse("MethodSize");
+                // let source_id: u64 = parser.parse("SourceID");
+
+                context.ensure_process_jit_info(process_id);
+                let Some(process) = context.get_process_mut(process_id) else { return; };
+                let mut process_jit_info = context.get_process_jit_info(process_id);
+
+                let start_address = method_start_address.as_u64();
+                let relative_address = process_jit_info.next_relative_address;
+                process_jit_info.next_relative_address += method_size as u32;
+
+                if let Some(main_thread) = process.main_thread_handle {
+                    context.profile.borrow_mut().add_marker(
+                        main_thread,
                         CategoryHandle::OTHER,
-                        "Vsync",
-                        VSyncMarker{},
-                        MarkerTiming::Instant(timestamp)
+                        "JitFunctionAdd",
+                        JitFunctionAddMarker(method_name.to_owned()),
+                        MarkerTiming::Instant(timestamp),
                     );
                 }
-                "MSNT_SystemTrace/Thread/CSwitch" => {
-                    let new_thread: u32 = parser.parse("NewThreadId");
-                    let old_thread: u32 = parser.parse("OldThreadId");
-                    // println!("CSwitch {} -> {} @ {} on {}", old_thread, new_thread, e.EventHeader.TimeStamp, unsafe { e.BufferContext.Anonymous.ProcessorIndex });
 
-                    if let Some(mut old_thread) = context.get_thread_mut(old_thread) {
-                        context.context_switch_handler.borrow_mut().handle_switch_out(timestamp_raw, &mut old_thread.context_switch_data);
-                    }
-                    if let Some(mut new_thread) = context.get_thread_mut(new_thread) {
-                        let off_cpu_sample_group = context.context_switch_handler.borrow_mut().handle_switch_in(timestamp_raw, &mut new_thread.context_switch_data);
-                        if let Some(off_cpu_sample_group) = off_cpu_sample_group {
-                            new_thread.pending_stacks.push_back(PendingStack { timestamp: timestamp_raw, kernel_stack: None, off_cpu_sample_group: Some(off_cpu_sample_group), on_cpu_sample_cpu_delta: None });
+                let (category, js_frame) = context.js_category_manager.borrow_mut().classify_jit_symbol(&method_name, &mut context.profile.borrow_mut());
+                let info = LibMappingInfo::new_jit_function(process_jit_info.lib_handle, category, js_frame);
+                process_jit_info.jit_mapping_ops.push(e.EventHeader.TimeStamp as u64, LibMappingOp::Add(LibMappingAdd {
+                    start_avma: start_address,
+                    end_avma: start_address + method_size,
+                    relative_address_at_start: relative_address,
+                    info
+                }));
+                process_jit_info.symbols.push(Symbol {
+                    address: relative_address,
+                    size: Some(method_size as u32),
+                    name: method_name,
+                });
+            }
+            "V8.js/SourceLoad/" /*|
+            "Microsoft-JScript/MethodRuntime/MethodDCStart" |
+            "Microsoft-JScript/MethodRuntime/MethodLoad"*/ => {
+                let source_id: u64 = parser.parse("SourceID");
+                let url: String = parser.parse("Url");
+                //if s.process_id() == 6736 { dbg!(s.process_id(), &method_name, method_start_address, method_size); }
+                jscript_sources.insert(source_id, url);
+                //dbg!(s.process_id(), jscript_symbols.keys());
+
+            }
+            "Microsoft-Windows-Direct3D11/ID3D11VideoContext_SubmitDecoderBuffers/win:Start" => {
+                let mut parser = Parser::create(&s);
+                let thread_id = s.thread_id();
+                let Some(mut thread) = context.get_thread_mut(thread_id) else { return };
+                let text = event_properties_to_string(&s, &mut parser, None);
+                thread.pending_markers.insert(s.name().to_owned(), PendingMarker { text, start: timestamp });
+            }
+            "Microsoft-Windows-Direct3D11/ID3D11VideoContext_SubmitDecoderBuffers/win:Stop" => {
+                let mut parser = Parser::create(&s);
+                let thread_id = s.thread_id();
+                let Some(mut thread) = context.get_thread_mut(thread_id) else { return };
+
+                let mut text = event_properties_to_string(&s, &mut parser, None);
+                let timing = if let Some(pending) = thread.pending_markers.remove("Microsoft-Windows-Direct3D11/ID3D11VideoContext_SubmitDecoderBuffers/win:Start") {
+                    text = pending.text;
+                    MarkerTiming::Interval(pending.start, timestamp)
+                } else {
+                    MarkerTiming::IntervalEnd(timestamp)
+                };
+
+                let category = context.get_category(KnownCategory::D3DVideoSubmitDecoderBuffers);
+                context.profile.borrow_mut().add_marker(thread.handle, category, s.name().split_once('/').unwrap().1, SimpleMarker(text), timing);
+            }
+            marker_name if marker_name.starts_with("Mozilla.FirefoxTraceLogger/") =>  {
+                let Some(marker_name) = marker_name.strip_prefix("Mozilla.FirefoxTraceLogger/").and_then(|s| s.strip_suffix("/Info")) else { return };
+
+                let thread_id = e.EventHeader.ThreadId;
+                let Some(thread) = context.get_thread(thread_id) else { return };
+
+                let text = event_properties_to_string(&s, &mut parser, Some(&["MarkerName", "StartTime", "EndTime", "Phase", "InnerWindowId", "CategoryPair"]));
+
+                /// From https://searchfox.org/mozilla-central/rev/0e7394a77cdbe1df5e04a1d4171d6da67b57fa17/mozglue/baseprofiler/public/BaseProfilerMarkersPrerequisites.h#355-360
+                const PHASE_INSTANT: u8 = 0;
+                const PHASE_INTERVAL: u8 = 1;
+                const PHASE_INTERVAL_START: u8 = 2;
+                const PHASE_INTERVAL_END: u8 = 3;
+
+                // We ignore e.EventHeader.TimeStamp and instead take the timestamp from the fields.
+                let start_time_qpc: u64 = parser.try_parse("StartTime").unwrap();
+                let end_time_qpc: u64 = parser.try_parse("EndTime").unwrap();
+                assert!(event_timestamps_are_qpc, "Inconsistent timestamp formats! ETW traces with Firefox events should be captured with QPC timestamps (-ClockType PerfCounter) so that ETW sample timestamps are compatible with the QPC timestamps in Firefox ETW trace events, so that the markers appear in the right place.");
+                let (phase, instant_time_qpc): (u8, u64) = match parser.try_parse("Phase") {
+                    Ok(phase) => (phase, start_time_qpc),
+                    Err(_) => {
+                        // Before the landing of https://bugzilla.mozilla.org/show_bug.cgi?id=1882640 ,
+                        // Firefox ETW trace events didn't have phase information, so we need to
+                        // guess a phase based on the timestamps.
+                        if start_time_qpc != 0 && end_time_qpc != 0 {
+                            (PHASE_INTERVAL, 0)
+                        } else if start_time_qpc != 0 {
+                            (PHASE_INSTANT, start_time_qpc)
+                        } else {
+                            (PHASE_INSTANT, end_time_qpc)
                         }
                     }
+                };
+                let timing = match phase {
+                    PHASE_INSTANT => MarkerTiming::Instant(timestamp_converter.convert_time(instant_time_qpc)),
+                    PHASE_INTERVAL => MarkerTiming::Interval(timestamp_converter.convert_time(start_time_qpc), timestamp_converter.convert_time(end_time_qpc)),
+                    PHASE_INTERVAL_START => MarkerTiming::IntervalStart(timestamp_converter.convert_time(start_time_qpc)),
+                    PHASE_INTERVAL_END => MarkerTiming::IntervalEnd(timestamp_converter.convert_time(end_time_qpc)),
+                    _ => panic!("Unexpected marker phase {phase}"),
+                };
+
+                if marker_name == "UserTiming" {
+                    let name: String = parser.try_parse("name").unwrap();
+                    context.profile.borrow_mut().add_marker(thread.handle, CategoryHandle::OTHER, "UserTiming", UserTimingMarker(name), timing);
+                } else if marker_name == "SimpleMarker" || marker_name == "Text" || marker_name == "tracing" {
+                    let marker_name: String = parser.try_parse("MarkerName").unwrap();
+                    context.profile.borrow_mut().add_marker(thread.handle, CategoryHandle::OTHER, &marker_name, SimpleMarker(text.clone()), timing);
+                } else {
+                    context.profile.borrow_mut().add_marker(thread.handle, CategoryHandle::OTHER, marker_name, SimpleMarker(text.clone()), timing);
                 }
-                "MSNT_SystemTrace/Thread/ReadyThread" => {
-                    // these events can give us the unblocking stack
-                    let _thread_id: u32 = parser.parse("TThreadId");
-                }
-                "V8.js/MethodLoad/" |
-                "Microsoft-JScript/MethodRuntime/MethodDCStart" |
-                "Microsoft-JScript/MethodRuntime/MethodLoad" => {
-                    let process_id = s.process_id();
-
-                    let method_name: String = parser.parse("MethodName");
-                    let method_start_address: Address = parser.parse("MethodStartAddress");
-                    let method_size: u64 = parser.parse("MethodSize");
-                    // let source_id: u64 = parser.parse("SourceID");
-
-                    context.ensure_process_jit_info(process_id);
-                    let Some(process) = context.get_process_mut(process_id) else { return; };
-                    let mut process_jit_info = context.get_process_jit_info(process_id);
-
-                    let start_address = method_start_address.as_u64();
-                    let relative_address = process_jit_info.next_relative_address;
-                    process_jit_info.next_relative_address += method_size as u32;
-
-                    if let Some(main_thread) = process.main_thread_handle {
-                        context.profile.borrow_mut().add_marker(
-                            main_thread,
-                            CategoryHandle::OTHER,
-                            "JitFunctionAdd",
-                            JitFunctionAddMarker(method_name.to_owned()),
-                            MarkerTiming::Instant(timestamp),
-                        );
-                    }
-
-                    let (category, js_frame) = context.js_category_manager.borrow_mut().classify_jit_symbol(&method_name, &mut context.profile.borrow_mut());
-                    let info = LibMappingInfo::new_jit_function(process_jit_info.lib_handle, category, js_frame);
-                    process_jit_info.jit_mapping_ops.push(e.EventHeader.TimeStamp as u64, LibMappingOp::Add(LibMappingAdd {
-                        start_avma: start_address,
-                        end_avma: start_address + method_size,
-                        relative_address_at_start: relative_address,
-                        info
-                    }));
-                    process_jit_info.symbols.push(Symbol {
-                        address: relative_address,
-                        size: Some(method_size as u32),
-                        name: method_name,
-                    });
-                }
-                "V8.js/SourceLoad/" /*|
-                "Microsoft-JScript/MethodRuntime/MethodDCStart" |
-                "Microsoft-JScript/MethodRuntime/MethodLoad"*/ => {
-                    let source_id: u64 = parser.parse("SourceID");
-                    let url: String = parser.parse("Url");
-                    //if s.process_id() == 6736 { dbg!(s.process_id(), &method_name, method_start_address, method_size); }
-                    jscript_sources.insert(source_id, url);
-                    //dbg!(s.process_id(), jscript_symbols.keys());
-
-                }
-                "Microsoft-Windows-Direct3D11/ID3D11VideoContext_SubmitDecoderBuffers/win:Start" => {
-                    let mut parser = Parser::create(&s);
-                    let thread_id = s.thread_id();
-                    let Some(mut thread) = context.get_thread_mut(thread_id) else { return };
-                    let text = event_properties_to_string(&s, &mut parser, None);
-                    thread.pending_markers.insert(s.name().to_owned(), PendingMarker { text, start: timestamp });
-                }
-                "Microsoft-Windows-Direct3D11/ID3D11VideoContext_SubmitDecoderBuffers/win:Stop" => {
-                    let mut parser = Parser::create(&s);
-                    let thread_id = s.thread_id();
-                    let Some(mut thread) = context.get_thread_mut(thread_id) else { return };
-
-                    let mut text = event_properties_to_string(&s, &mut parser, None);
-                    let timing = if let Some(pending) = thread.pending_markers.remove("Microsoft-Windows-Direct3D11/ID3D11VideoContext_SubmitDecoderBuffers/win:Start") {
-                        text = pending.text;
-                        MarkerTiming::Interval(pending.start, timestamp)
-                    } else {
-                        MarkerTiming::IntervalEnd(timestamp)
-                    };
-
-                    let category = context.get_category(KnownCategory::D3DVideoSubmitDecoderBuffers);
-                    context.profile.borrow_mut().add_marker(thread.handle, category, s.name().split_once('/').unwrap().1, SimpleMarker(text), timing);
-                }
-                marker_name if marker_name.starts_with("Mozilla.FirefoxTraceLogger/") =>  {
-                    let Some(marker_name) = marker_name.strip_prefix("Mozilla.FirefoxTraceLogger/").and_then(|s| s.strip_suffix("/Info")) else { return };
-
-                    let thread_id = e.EventHeader.ThreadId;
-                    let Some(thread) = context.get_thread(thread_id) else { return };
-
-                    let text = event_properties_to_string(&s, &mut parser, Some(&["MarkerName", "StartTime", "EndTime", "Phase", "InnerWindowId", "CategoryPair"]));
-
-                    /// From https://searchfox.org/mozilla-central/rev/0e7394a77cdbe1df5e04a1d4171d6da67b57fa17/mozglue/baseprofiler/public/BaseProfilerMarkersPrerequisites.h#355-360
-                    const PHASE_INSTANT: u8 = 0;
-                    const PHASE_INTERVAL: u8 = 1;
-                    const PHASE_INTERVAL_START: u8 = 2;
-                    const PHASE_INTERVAL_END: u8 = 3;
-
-                    // We ignore e.EventHeader.TimeStamp and instead take the timestamp from the fields.
-                    let start_time_qpc: u64 = parser.try_parse("StartTime").unwrap();
-                    let end_time_qpc: u64 = parser.try_parse("EndTime").unwrap();
-                    assert!(event_timestamps_are_qpc, "Inconsistent timestamp formats! ETW traces with Firefox events should be captured with QPC timestamps (-ClockType PerfCounter) so that ETW sample timestamps are compatible with the QPC timestamps in Firefox ETW trace events, so that the markers appear in the right place.");
-                    let (phase, instant_time_qpc): (u8, u64) = match parser.try_parse("Phase") {
-                        Ok(phase) => (phase, start_time_qpc),
-                        Err(_) => {
-                            // Before the landing of https://bugzilla.mozilla.org/show_bug.cgi?id=1882640 ,
-                            // Firefox ETW trace events didn't have phase information, so we need to
-                            // guess a phase based on the timestamps.
-                            if start_time_qpc != 0 && end_time_qpc != 0 {
-                                (PHASE_INTERVAL, 0)
-                            } else if start_time_qpc != 0 {
-                                (PHASE_INSTANT, start_time_qpc)
-                            } else {
-                                (PHASE_INSTANT, end_time_qpc)
-                            }
-                        }
-                    };
-                    let timing = match phase {
-                        PHASE_INSTANT => MarkerTiming::Instant(timestamp_converter.convert_time(instant_time_qpc)),
-                        PHASE_INTERVAL => MarkerTiming::Interval(timestamp_converter.convert_time(start_time_qpc), timestamp_converter.convert_time(end_time_qpc)),
-                        PHASE_INTERVAL_START => MarkerTiming::IntervalStart(timestamp_converter.convert_time(start_time_qpc)),
-                        PHASE_INTERVAL_END => MarkerTiming::IntervalEnd(timestamp_converter.convert_time(end_time_qpc)),
-                        _ => panic!("Unexpected marker phase {phase}"),
-                    };
-
-                    if marker_name == "UserTiming" {
-                        let name: String = parser.try_parse("name").unwrap();
-                        context.profile.borrow_mut().add_marker(thread.handle, CategoryHandle::OTHER, "UserTiming", UserTimingMarker(name), timing);
-                    } else if marker_name == "SimpleMarker" || marker_name == "Text" || marker_name == "tracing" {
-                        let marker_name: String = parser.try_parse("MarkerName").unwrap();
-                        context.profile.borrow_mut().add_marker(thread.handle, CategoryHandle::OTHER, &marker_name, SimpleMarker(text.clone()), timing);
-                    } else {
-                        context.profile.borrow_mut().add_marker(thread.handle, CategoryHandle::OTHER, marker_name, SimpleMarker(text.clone()), timing);
+            }
+            "MetaData/EventInfo" | "Process/Terminate" => {
+                // ignore
+            }
+            marker_name if marker_name.starts_with("Google.Chrome/") => {
+                let Some(marker_name) = marker_name.strip_prefix("Google.Chrome/").and_then(|s| s.strip_suffix("/Info")) else { return };
+                // a bitfield of keywords
+                bitflags! {
+                    #[derive(PartialEq, Eq)]
+                    pub struct KeywordNames: u64 {
+                        const benchmark = 0x1;
+                        const blink = 0x2;
+                        const browser = 0x4;
+                        const cc = 0x8;
+                        const evdev = 0x10;
+                        const gpu = 0x20;
+                        const input = 0x40;
+                        const netlog = 0x80;
+                        const sequence_manager = 0x100;
+                        const toplevel = 0x200;
+                        const v8 = 0x400;
+                        const disabled_by_default_cc_debug = 0x800;
+                        const disabled_by_default_cc_debug_picture = 0x1000;
+                        const disabled_by_default_toplevel_flow = 0x2000;
+                        const startup = 0x4000;
+                        const latency = 0x8000;
+                        const blink_user_timing = 0x10000;
+                        const media = 0x20000;
+                        const loading = 0x40000;
+                        const base = 0x80000;
+                        const devtools_timeline = 0x100000;
+                        const unused_bit_21 = 0x200000;
+                        const unused_bit_22 = 0x400000;
+                        const unused_bit_23 = 0x800000;
+                        const unused_bit_24 = 0x1000000;
+                        const unused_bit_25 = 0x2000000;
+                        const unused_bit_26 = 0x4000000;
+                        const unused_bit_27 = 0x8000000;
+                        const unused_bit_28 = 0x10000000;
+                        const unused_bit_29 = 0x20000000;
+                        const unused_bit_30 = 0x40000000;
+                        const unused_bit_31 = 0x80000000;
+                        const unused_bit_32 = 0x100000000;
+                        const unused_bit_33 = 0x200000000;
+                        const unused_bit_34 = 0x400000000;
+                        const unused_bit_35 = 0x800000000;
+                        const unused_bit_36 = 0x1000000000;
+                        const unused_bit_37 = 0x2000000000;
+                        const unused_bit_38 = 0x4000000000;
+                        const unused_bit_39 = 0x8000000000;
+                        const unused_bit_40 = 0x10000000000;
+                        const unused_bit_41 = 0x20000000000;
+                        const navigation = 0x40000000000;
+                        const ServiceWorker = 0x80000000000;
+                        const edge_webview = 0x100000000000;
+                        const diagnostic_event = 0x200000000000;
+                        const __OTHER_EVENTS = 0x400000000000;
+                        const __DISABLED_OTHER_EVENTS = 0x800000000000;
                     }
                 }
-                "MetaData/EventInfo" | "Process/Terminate" => {
-                    // ignore
+
+                let thread_id = e.EventHeader.ThreadId;
+                let phase: String = parser.try_parse("Phase").unwrap();
+
+                let Some(thread) = context.get_thread(thread_id)  else { return };
+                let text = event_properties_to_string(&s, &mut parser, Some(&["Timestamp", "Phase", "Duration"]));
+
+                // We ignore e.EventHeader.TimeStamp and instead take the timestamp from the fields.
+                let timestamp_raw: u64 = parser.try_parse("Timestamp").unwrap();
+                let timestamp = timestamp_converter.convert_us(timestamp_raw);
+
+                let timing = match phase.as_str() {
+                    "Begin" => MarkerTiming::IntervalStart(timestamp),
+                    "End" => MarkerTiming::IntervalEnd(timestamp),
+                    _ => MarkerTiming::Instant(timestamp),
+                };
+                let keyword = KeywordNames::from_bits(e.EventHeader.EventDescriptor.Keyword).unwrap();
+                if keyword == KeywordNames::blink_user_timing {
+                    context.profile.borrow_mut().add_marker(thread.handle, CategoryHandle::OTHER, "UserTiming", UserTimingMarker(marker_name.to_owned()), timing);
+                } else {
+                    context.profile.borrow_mut().add_marker(thread.handle, CategoryHandle::OTHER, marker_name, SimpleMarker(text.clone()), timing);
                 }
-                marker_name if marker_name.starts_with("Google.Chrome/") => {
-                    let Some(marker_name) = marker_name.strip_prefix("Google.Chrome/").and_then(|s| s.strip_suffix("/Info")) else { return };
-                    // a bitfield of keywords
-                    bitflags! {
-                        #[derive(PartialEq, Eq)]
-                        pub struct KeywordNames: u64 {
-                            const benchmark = 0x1;
-                            const blink = 0x2;
-                            const browser = 0x4;
-                            const cc = 0x8;
-                            const evdev = 0x10;
-                            const gpu = 0x20;
-                            const input = 0x40;
-                            const netlog = 0x80;
-                            const sequence_manager = 0x100;
-                            const toplevel = 0x200;
-                            const v8 = 0x400;
-                            const disabled_by_default_cc_debug = 0x800;
-                            const disabled_by_default_cc_debug_picture = 0x1000;
-                            const disabled_by_default_toplevel_flow = 0x2000;
-                            const startup = 0x4000;
-                            const latency = 0x8000;
-                            const blink_user_timing = 0x10000;
-                            const media = 0x20000;
-                            const loading = 0x40000;
-                            const base = 0x80000;
-                            const devtools_timeline = 0x100000;
-                            const unused_bit_21 = 0x200000;
-                            const unused_bit_22 = 0x400000;
-                            const unused_bit_23 = 0x800000;
-                            const unused_bit_24 = 0x1000000;
-                            const unused_bit_25 = 0x2000000;
-                            const unused_bit_26 = 0x4000000;
-                            const unused_bit_27 = 0x8000000;
-                            const unused_bit_28 = 0x10000000;
-                            const unused_bit_29 = 0x20000000;
-                            const unused_bit_30 = 0x40000000;
-                            const unused_bit_31 = 0x80000000;
-                            const unused_bit_32 = 0x100000000;
-                            const unused_bit_33 = 0x200000000;
-                            const unused_bit_34 = 0x400000000;
-                            const unused_bit_35 = 0x800000000;
-                            const unused_bit_36 = 0x1000000000;
-                            const unused_bit_37 = 0x2000000000;
-                            const unused_bit_38 = 0x4000000000;
-                            const unused_bit_39 = 0x8000000000;
-                            const unused_bit_40 = 0x10000000000;
-                            const unused_bit_41 = 0x20000000000;
-                            const navigation = 0x40000000000;
-                            const ServiceWorker = 0x80000000000;
-                            const edge_webview = 0x100000000000;
-                            const diagnostic_event = 0x200000000000;
-                            const __OTHER_EVENTS = 0x400000000000;
-                            const __DISABLED_OTHER_EVENTS = 0x800000000000;
-                        }
-                    }
+            }
+            dotnet_event if dotnet_event.starts_with("Microsoft-Windows-DotNETRuntime") => {
+                // Note: No "/" at end of event name, because we want DotNETRuntimeRundown as well
+                coreclr::handle_coreclr_event(context, &s, &mut parser, &timestamp_converter);
+            }
+            _ => {
+                let thread_id = e.EventHeader.ThreadId;
+                let Some(thread) = context.get_thread(thread_id) else { return };
 
-                    let thread_id = e.EventHeader.ThreadId;
-                    let phase: String = parser.try_parse("Phase").unwrap();
-
-                    let Some(thread) = context.get_thread(thread_id)  else { return };
-                    let text = event_properties_to_string(&s, &mut parser, Some(&["Timestamp", "Phase", "Duration"]));
-
-                    // We ignore e.EventHeader.TimeStamp and instead take the timestamp from the fields.
-                    let timestamp_raw: u64 = parser.try_parse("Timestamp").unwrap();
-                    let timestamp = timestamp_converter.convert_us(timestamp_raw);
-
-                    let timing = match phase.as_str() {
-                        "Begin" => MarkerTiming::IntervalStart(timestamp),
-                        "End" => MarkerTiming::IntervalEnd(timestamp),
-                        _ => MarkerTiming::Instant(timestamp),
-                    };
-                    let keyword = KeywordNames::from_bits(e.EventHeader.EventDescriptor.Keyword).unwrap();
-                    if keyword == KeywordNames::blink_user_timing {
-                        context.profile.borrow_mut().add_marker(thread.handle, CategoryHandle::OTHER, "UserTiming", UserTimingMarker(marker_name.to_owned()), timing);
-                    } else {
-                        context.profile.borrow_mut().add_marker(thread.handle, CategoryHandle::OTHER, marker_name, SimpleMarker(text.clone()), timing);
-                    }
-                }
-                dotnet_event if dotnet_event.starts_with("Microsoft-Windows-DotNETRuntime") => {
-                    // Note: No "/" at end of event name, because we want DotNETRuntimeRundown as well
-                    coreclr::handle_coreclr_event(context, &s, &mut parser, &timestamp_converter);
-                }
-                _ => {
-                    let thread_id = e.EventHeader.ThreadId;
-                    let Some(thread) = context.get_thread(thread_id) else { return };
-
-                    let text = event_properties_to_string(&s, &mut parser, None);
-                    let timing = MarkerTiming::Instant(timestamp);
-                    // this used to create a new category based on provider_name, just lump them together for now
-                    let category = context.get_category(KnownCategory::Unknown);
-                    context.profile.borrow_mut().add_marker(thread.handle, category, s.name().split_once('/').unwrap().1, SimpleMarker(text), timing);
-                    //println!("unhandled {}", s.name())
-                }
+                let text = event_properties_to_string(&s, &mut parser, None);
+                let timing = MarkerTiming::Instant(timestamp);
+                // this used to create a new category based on provider_name, just lump them together for now
+                let category = context.get_category(KnownCategory::Unknown);
+                context.profile.borrow_mut().add_marker(thread.handle, category, s.name().split_once('/').unwrap().1, SimpleMarker(text), timing);
+                //println!("unhandled {}", s.name())
             }
         }
     });

--- a/samply/src/windows/etw_gecko.rs
+++ b/samply/src/windows/etw_gecko.rs
@@ -16,7 +16,7 @@ use crate::windows::coreclr;
 use crate::windows::profile_context::KnownCategory;
 
 pub fn profile_pid_from_etl_file(context: &mut ProfileContext, etl_file: &Path) {
-    let is_arm64 = context.arch == "arm64";
+    let is_arm64 = context.is_arm64();
 
     let mut schema_locator = SchemaLocator::new();
     add_custom_schemas(&mut schema_locator);

--- a/samply/src/windows/etw_gecko.rs
+++ b/samply/src/windows/etw_gecko.rs
@@ -43,7 +43,7 @@ pub fn profile_pid_from_etl_file(context: &mut ProfileContext, etl_file: &Path) 
         //eprintln!("{}", s.name());
         match s.name() {
             "MSNT_SystemTrace/EventTrace/Header" => {
-                let timer_resolution: u32 = parser.parse("TimerResolution");
+                let _timer_resolution: u32 = parser.parse("TimerResolution");
                 let perf_freq: u64 = parser.parse("PerfFreq");
                 let clock_type: u32 = parser.parse("ReservedFlags");
                 let events_lost: u32 = parser.parse("EventsLost");
@@ -51,7 +51,7 @@ pub fn profile_pid_from_etl_file(context: &mut ProfileContext, etl_file: &Path) 
                     log::warn!("{} events lost", events_lost);
                 }
 
-                context.handle_header(timestamp_raw, timer_resolution, perf_freq, clock_type);
+                context.handle_header(timestamp_raw, perf_freq, clock_type);
 
                 if log::log_enabled!(log::Level::Info) {
                     for i in 0..s.property_count() {
@@ -131,7 +131,6 @@ pub fn profile_pid_from_etl_file(context: &mut ProfileContext, etl_file: &Path) 
                         referenced_timestamp_raw,
                         pid,
                         tid,
-                        stack_len,
                         stack_address_iter,
                     );
                 } else {

--- a/samply/src/windows/etw_gecko.rs
+++ b/samply/src/windows/etw_gecko.rs
@@ -1,7 +1,5 @@
-use std::collections::{HashMap, VecDeque};
 use std::convert::TryInto;
 use std::path::Path;
-use std::sync::Arc;
 use std::time::Instant;
 
 use debugid::DebugId;
@@ -10,58 +8,28 @@ use etw_reader::schema::SchemaLocator;
 use etw_reader::{
     add_custom_schemas, event_properties_to_string, open_trace, print_property, GUID,
 };
-use fxprof_processed_profile::{
-    debugid, CategoryHandle, CpuDelta, LibraryInfo, MarkerDynamicField, MarkerFieldFormat,
-    MarkerLocation, MarkerSchema, MarkerSchemaField, MarkerTiming, ProfilerMarker,
-    SamplingInterval, Symbol, SymbolTable, Timestamp,
-};
-use serde_json::{json, Value};
+use fxprof_processed_profile::debugid;
 use uuid::Uuid;
 
 use super::profile_context::ProfileContext;
-use crate::shared::context_switch::{ContextSwitchHandler, OffCpuSampleGroup};
-use crate::shared::jit_function_add_marker::JitFunctionAddMarker;
-use crate::shared::lib_mappings::{LibMappingAdd, LibMappingInfo, LibMappingOp};
-use crate::shared::process_sample_data::{ProcessSampleData, SimpleMarker, UserTimingMarker};
-use crate::shared::timestamp_converter::TimestampConverter;
-use crate::shared::types::{StackFrame, StackMode};
-use crate::windows::chrome_etw_flags::KeywordNames;
 use crate::windows::coreclr;
-use crate::windows::firefox_etw_flags::{
-    PHASE_INSTANT, PHASE_INTERVAL, PHASE_INTERVAL_END, PHASE_INTERVAL_START,
-};
-use crate::windows::profile_context::{KnownCategory, PendingMarker, PendingStack};
+use crate::windows::profile_context::KnownCategory;
 
 pub fn profile_pid_from_etl_file(context: &mut ProfileContext, etl_file: &Path) {
-    let profile_start_instant = Timestamp::from_nanos_since_reference(0);
-
-    let arch = &context.arch;
-    let is_x86 = arch == "x86" || arch == "x86_64";
-    let is_arm64 = arch == "arm64";
+    let is_arm64 = context.arch == "arm64";
 
     let mut schema_locator = SchemaLocator::new();
     add_custom_schemas(&mut schema_locator);
-    let mut kernel_pending_libraries: HashMap<u64, LibraryInfo> = HashMap::new();
-
-    let mut libs: HashMap<(u32, u64), (String, u32, u32)> = HashMap::new();
 
     let processing_start_timestamp = Instant::now();
 
     let demand_zero_faults = false; //pargs.contains("--demand-zero-faults");
 
-    let mut sample_count = 0;
-    let mut stack_sample_count = 0;
-    let mut timer_resolution: u32 = 0; // Resolution of the hardware timer, in units of 100 nanoseconds.
     let mut event_count = 0;
-    let mut gpu_thread = None;
-    let mut jscript_sources: HashMap<u64, String> = HashMap::new();
+
+    let mut core_clr_context = coreclr::CoreClrContext::new();
 
     // Make a dummy TimestampConverter. Once we've parsed the header, this will have correct values.
-    let mut timestamp_converter = TimestampConverter {
-        reference_raw: 0,
-        raw_to_ns_factor: 1,
-    };
-    let mut event_timestamps_are_qpc = false;
 
     let result = open_trace(etl_file, |e| {
         event_count += 1;
@@ -71,29 +39,19 @@ pub fn profile_pid_from_etl_file(context: &mut ProfileContext, etl_file: &Path) 
 
         let mut parser = Parser::create(&s);
         let timestamp_raw = e.EventHeader.TimeStamp as u64;
-        let timestamp = timestamp_converter.convert_time(timestamp_raw);
 
         //eprintln!("{}", s.name());
         match s.name() {
             "MSNT_SystemTrace/EventTrace/Header" => {
-                timer_resolution = parser.parse("TimerResolution");
+                let timer_resolution: u32 = parser.parse("TimerResolution");
                 let perf_freq: u64 = parser.parse("PerfFreq");
                 let clock_type: u32 = parser.parse("ReservedFlags");
-                if clock_type != 1 {
-                    log::warn!("QPC not used as clock");
-                    event_timestamps_are_qpc = false;
-                } else {
-                    event_timestamps_are_qpc = true;
-                }
                 let events_lost: u32 = parser.parse("EventsLost");
                 if events_lost != 0 {
                     log::warn!("{} events lost", events_lost);
                 }
 
-                timestamp_converter = TimestampConverter {
-                    reference_raw: e.EventHeader.TimeStamp as u64,
-                    raw_to_ns_factor: 1000 * 1000 * 1000 / perf_freq,
-                };
+                context.handle_header(timestamp_raw, timer_resolution, perf_freq, clock_type);
 
                 if log::log_enabled!(log::Level::Info) {
                     for i in 0..s.property_count() {
@@ -104,222 +62,115 @@ pub fn profile_pid_from_etl_file(context: &mut ProfileContext, etl_file: &Path) 
             }
             "MSNT_SystemTrace/PerfInfo/CollectionStart" => {
                 let interval_raw: u32 = parser.parse("NewInterval");
-                let interval_nanos = interval_raw as u64 * 100;
-                let interval = SamplingInterval::from_nanos(interval_nanos);
-                log::info!("Sample rate {}ms", interval.as_secs_f64() * 1000.);
-                context.profile.borrow_mut().set_interval(interval);
-                context.context_switch_handler.replace(ContextSwitchHandler::new(interval_raw as u64));
+                context.handle_collection_start(interval_raw);
             }
             "MSNT_SystemTrace/Thread/SetName" => {
-                let thread_id: u32 = parser.parse("ThreadId");
+                let tid: u32 = parser.parse("ThreadId");
                 let thread_name: String = parser.parse("ThreadName");
-
-                if !thread_name.is_empty() {
-                    context.set_thread_name(thread_id, &thread_name);
-                }
+                context.handle_thread_set_name(timestamp_raw, tid, thread_name);
             }
-            "MSNT_SystemTrace/Thread/Start" |
             "MSNT_SystemTrace/Thread/DCStart" => {
-                let thread_id: u32 = parser.parse("TThreadId");
-                let process_id: u32 = parser.parse("ProcessId");
-
-                if !context.is_interesting_process(process_id, None, None) {
-                    return;
-                }
-
-                // if there's an existing thread, remove it, assume we dropped an end thread event
-                context.remove_thread(thread_id, Some(timestamp));
-                context.add_thread(process_id, thread_id, timestamp);
-
+                let tid: u32 = parser.parse("TThreadId");
+                let pid: u32 = parser.parse("ProcessId");
                 let thread_name: Option<String> = parser.try_parse("ThreadName").ok();
-                if let Some(thread_name) = thread_name {
-                    if !thread_name.is_empty() {
-                        context.set_thread_name(thread_id, &thread_name);
-                    }
-                }
+                context.handle_thread_dcstart(timestamp_raw, tid, pid, thread_name)
             }
-            "MSNT_SystemTrace/Thread/End" |
+            "MSNT_SystemTrace/Thread/Start" => {
+                let tid: u32 = parser.parse("TThreadId");
+                let pid: u32 = parser.parse("ProcessId");
+                let thread_name: Option<String> = parser.try_parse("ThreadName").ok();
+                context.handle_thread_start(timestamp_raw, tid, pid, thread_name);
+            }
+            "MSNT_SystemTrace/Thread/End" => {
+                let thread_id: u32 = parser.parse("TThreadId");
+                context.handle_thread_end(timestamp_raw, thread_id);
+            }
             "MSNT_SystemTrace/Thread/DCEnd" => {
                 let thread_id: u32 = parser.parse("TThreadId");
-
-                context.remove_thread(thread_id, Some(timestamp));
+                context.handle_thread_dcend(timestamp_raw, thread_id);
             }
-            "MSNT_SystemTrace/Process/Start" |
             "MSNT_SystemTrace/Process/DCStart" => {
-                let process_id: u32 = parser.parse("ProcessId");
-                let parent_id: u32 = parser.parse("ParentId");
-                let image_file_name: String = parser.parse("ImageFileName");
-
                 // note: the event's e.EventHeader.process_id here is the parent (i.e. the process that spawned
                 // a new one. The process_id in ProcessId is the new process id.
-
-                if !context.is_interesting_process(process_id, Some(parent_id), Some(&image_file_name)) {
-                    return;
-                }
-
-                context.add_process(process_id, parent_id, &context.map_device_path(&image_file_name), timestamp);
+                // XXXmstange then what about "ParentId"? Is it the same as e.EventHeader.process_id?
+                let pid: u32 = parser.parse("ProcessId");
+                let parent_pid: u32 = parser.parse("ParentId");
+                let image_file_name: String = parser.parse("ImageFileName");
+                context.handle_process_dcstart(timestamp_raw, pid, parent_pid, image_file_name);
             }
-            "MSNT_SystemTrace/Process/End" |
+            "MSNT_SystemTrace/Process/Start" => {
+                // note: the event's e.EventHeader.process_id here is the parent (i.e. the process that spawned
+                // a new one. The process_id in ProcessId is the new process id.
+                // XXXmstange then what about "ParentId"? Is it the same as e.EventHeader.process_id?
+                let pid: u32 = parser.parse("ProcessId");
+                let parent_pid: u32 = parser.parse("ParentId");
+                let image_file_name: String = parser.parse("ImageFileName");
+                context.handle_process_start(timestamp_raw, pid, parent_pid, image_file_name);
+            }
+            "MSNT_SystemTrace/Process/End" => {
+                let pid: u32 = parser.parse("ProcessId");
+                context.handle_process_end(timestamp_raw, pid);
+            }
             "MSNT_SystemTrace/Process/DCEnd" => {
-                //let process_id: u32 = parser.parse("ProcessId");
-                //context.end_process(...);
+                let pid: u32 = parser.parse("ProcessId");
+                context.handle_process_dcend(timestamp_raw, pid);
             }
             "MSNT_SystemTrace/StackWalk/Stack" => {
-                let thread_id: u32 = parser.parse("StackThread");
-                let process_id: u32 = parser.parse("StackProcess");
+                let tid: u32 = parser.parse("StackThread");
+                let pid: u32 = parser.parse("StackProcess");
                 // The EventTimeStamp here indicates thea ccurate time the stack was collected, and
                 // not the time the ETW event was emitted (which is in the header). Use it instead.
-                let timestamp_raw: u64 = parser.parse("EventTimeStamp");
-                let timestamp = timestamp_converter.convert_time(timestamp_raw);
-
-                if !context.threads.contains_key(&thread_id) { return }
-
-                // eprint!("{} {} {}", thread_id, e.EventHeader.TimeStamp, timestamp);
-
+                let referenced_timestamp_raw: u64 = parser.parse("EventTimeStamp");
+                let stack_len = parser.buffer.len() / 8;
+                let stack_address_iter = parser
+                    .buffer
+                    .chunks_exact(8)
+                    .map(|a| u64::from_ne_bytes(a.try_into().unwrap()));
                 if is_arm64 {
-                    // On ARM64, this seems to be simpler -- stacks come in with full kernel and user frames.
-                    // At least, I've never seen a kernel stack come in separately.
-                    // TODO -- is this because I can't use PROFILE events in the VM?
-
-                    // Iterate over the stack addresses, starting with the instruction pointer
-                    let stack: Vec<StackFrame> = parser.buffer.chunks_exact(8) // iterate over 8 byte items
-                        .map(|a| u64::from_ne_bytes(a.try_into().unwrap())) // parse into u64
-                        .enumerate()
-                        .map(|(i, addr)| {
-                            if i == 0 {
-                                StackFrame::InstructionPointer(addr, context.stack_mode_for_address(addr))
-                            } else {
-                                StackFrame::ReturnAddress(addr, context.stack_mode_for_address(addr))
-                            }
-                        })
-                        .collect();
-
-                    let cpu_delta_raw = context.context_switch_handler.borrow_mut().consume_cpu_delta(&mut context.get_thread_mut(thread_id).unwrap().context_switch_data);
-                    let cpu_delta = CpuDelta::from_nanos(cpu_delta_raw * timestamp_converter.raw_to_ns_factor);
-                    context.add_sample(process_id, thread_id, timestamp, timestamp_raw, cpu_delta, 1, stack);
-                    return;
-                }
-
-                assert!(is_x86);
-
-                let mut stack: Vec<StackFrame> = Vec::with_capacity(parser.buffer.len() / 8);
-                let mut address_iter = parser.buffer.chunks_exact(8).map(|a| u64::from_ne_bytes(a.try_into().unwrap()));
-                let Some(first_frame_address) = address_iter.next() else { return };
-                let first_frame_stack_mode = context.stack_mode_for_address(first_frame_address);
-                stack.push(StackFrame::InstructionPointer(first_frame_address, first_frame_stack_mode));
-                for frame_address in address_iter {
-                    let stack_mode = context.stack_mode_for_address(frame_address);
-                    stack.push(StackFrame::ReturnAddress(frame_address, stack_mode));
-                }
-
-                if first_frame_stack_mode == StackMode::Kernel {
-                    let mut thread = context.get_thread_mut(thread_id).unwrap();
-                    if let Some(pending_stack ) = thread.pending_stacks.iter_mut().rev().find(|s| s.timestamp == timestamp_raw) {
-                        if let Some(kernel_stack) = pending_stack.kernel_stack.as_mut() {
-                            log::warn!("Multiple kernel stacks for timestamp {timestamp_raw} on thread {thread_id}");
-                            kernel_stack.extend(&stack);
-                        } else {
-                            pending_stack.kernel_stack = Some(stack);
-                        }
-                    }
-                    return;
-                }
-
-                // We now know that we have a user stack. User stacks always come last. Consume
-                // the pending stack with matching timestamp.
-
-                // the number of pending stacks at or before our timestamp
-                let num_pending_stacks = context.get_thread(thread_id).unwrap()
-                    .pending_stacks.iter().take_while(|s| s.timestamp <= timestamp_raw).count();
-
-                let pending_stacks: VecDeque<_> = context.get_thread_mut(thread_id).unwrap().pending_stacks.drain(..num_pending_stacks).collect();
-
-                // Use this user stack for all pending stacks from this thread.
-                for pending_stack in pending_stacks {
-                    let PendingStack {
-                        timestamp,
-                        kernel_stack,
-                        off_cpu_sample_group,
-                        on_cpu_sample_cpu_delta,
-                    } = pending_stack;
-
-                    if let Some(off_cpu_sample_group) = off_cpu_sample_group {
-                        let OffCpuSampleGroup { begin_timestamp, end_timestamp, sample_count } = off_cpu_sample_group;
-
-                        let cpu_delta_raw = {
-                            let mut thread = context.get_thread_mut(thread_id).unwrap();
-                            context.context_switch_handler.borrow_mut().consume_cpu_delta(&mut thread.context_switch_data)
-                        };
-                        let cpu_delta = CpuDelta::from_nanos(cpu_delta_raw * timestamp_converter.raw_to_ns_factor);
-
-                        // Add a sample at the beginning of the paused range.
-                        // This "first sample" will carry any leftover accumulated running time ("cpu delta").
-                        context.add_sample(process_id, thread_id, timestamp_converter.convert_time(begin_timestamp), begin_timestamp, cpu_delta, 1, stack.clone());
-
-                        if sample_count > 1 {
-                            // Emit a "rest sample" with a CPU delta of zero covering the rest of the paused range.
-                            let weight = i32::try_from(sample_count - 1).unwrap_or(0);
-                            context.add_sample(process_id, thread_id, timestamp_converter.convert_time(end_timestamp), end_timestamp, CpuDelta::ZERO, weight, stack.clone());
-                        }
-                    }
-
-                    if let Some(cpu_delta) = on_cpu_sample_cpu_delta {
-                        let timestamp_cvt = timestamp_converter.convert_time(timestamp);
-                        if let Some(mut combined_stack) = kernel_stack {
-                            combined_stack.extend_from_slice(&stack[..]);
-                            context.add_sample(process_id, thread_id, timestamp_cvt, timestamp, cpu_delta, 1, combined_stack);
-                        } else {
-                            context.add_sample(process_id, thread_id, timestamp_cvt, timestamp, cpu_delta, 1, stack.clone());
-                        }
-                        stack_sample_count += 1;
-                    }
+                    context.handle_stack_arm64(
+                        referenced_timestamp_raw,
+                        pid,
+                        tid,
+                        stack_len,
+                        stack_address_iter,
+                    );
+                } else {
+                    context.handle_stack_x86(
+                        referenced_timestamp_raw,
+                        pid,
+                        tid,
+                        stack_len,
+                        stack_address_iter,
+                    );
                 }
             }
             "MSNT_SystemTrace/PerfInfo/SampleProf" => {
-                let thread_id: u32 = parser.parse("ThreadId");
-
-                sample_count += 1;
-
-                let Some(mut thread) = context.get_thread_mut(thread_id) else { return };
-
-                let off_cpu_sample_group = context.context_switch_handler.borrow_mut().handle_on_cpu_sample(timestamp_raw, &mut thread.context_switch_data);
-                let delta = context.context_switch_handler.borrow_mut().consume_cpu_delta(&mut thread.context_switch_data);
-                let cpu_delta = CpuDelta::from_nanos(delta * timestamp_converter.raw_to_ns_factor);
-                thread.pending_stacks.push_back(PendingStack { timestamp: timestamp_raw, kernel_stack: None, off_cpu_sample_group, on_cpu_sample_cpu_delta: Some(cpu_delta) });
+                let tid: u32 = parser.parse("ThreadId");
+                context.handle_sample(timestamp_raw, tid);
             }
             "MSNT_SystemTrace/PageFault/DemandZeroFault" => {
-                if !demand_zero_faults { return }
-
-                let thread_id: u32 = s.thread_id();
-                //println!("sample {}", thread_id);
-                sample_count += 1;
-
-                let Some(mut thread) = context.get_thread_mut(thread_id) else { return };
-
-                thread.pending_stacks.push_back(PendingStack { timestamp: timestamp_raw, kernel_stack: None, off_cpu_sample_group: None, on_cpu_sample_cpu_delta: Some(CpuDelta::from_millis(1.0)) });
-            }
-            "MSNT_SystemTrace/PageFault/VirtualAlloc" |
-            "MSNT_SystemTrace/PageFault/VirtualFree" => {
-                if !context.is_interesting_process(e.EventHeader.ProcessId, None, None) {
+                if !demand_zero_faults {
                     return;
                 }
 
-                let thread_id = e.EventHeader.ThreadId;
-
-                let Some(memory_usage_counter) = context.get_or_create_memory_usage_counter(thread_id) else { return };
-                let Some(thread_handle) = context.get_thread(thread_id).map(|t| t.handle) else { return };
-
-                let region_size: u64 = parser.parse("RegionSize");
-
+                let tid: u32 = s.thread_id();
+                context.handle_sample(timestamp_raw, tid);
+            }
+            "MSNT_SystemTrace/PageFault/VirtualAlloc"
+            | "MSNT_SystemTrace/PageFault/VirtualFree" => {
                 let is_free = s.name() == "MSNT_SystemTrace/PageFault/VirtualFree";
-                let delta_size = if is_free { -(region_size as f64) } else { region_size as f64 };
-                let op_name = if is_free { "VirtualFree" } else { "VirtualAlloc" };
-
-                //println!("{} VirtualFree({}) = {}", e.EventHeader.ProcessId, region_size, counter.value);
-
+                let pid = e.EventHeader.ProcessId;
+                let tid = e.EventHeader.ThreadId;
+                let region_size: u64 = parser.parse("RegionSize");
                 let text = event_properties_to_string(&s, &mut parser, None);
-                context.profile.borrow_mut().add_counter_sample(memory_usage_counter, timestamp, delta_size, 1);
-                context.profile.borrow_mut().add_marker(thread_handle, CategoryHandle::OTHER, op_name, SimpleMarker(text), MarkerTiming::Instant(timestamp));
+                context.handle_virtual_alloc_free(
+                    timestamp_raw,
+                    is_free,
+                    pid,
+                    tid,
+                    region_size,
+                    text,
+                );
             }
             "KernelTraceControl/ImageID/" => {
                 // KernelTraceControl/ImageID/ and KernelTraceControl/ImageID/DbgID_RSDS are synthesized during merge from
@@ -328,67 +179,24 @@ pub fn profile_pid_from_etl_file(context: &mut ProfileContext, etl_file: &Path) 
                 // with pdb and debug info. We link those up through the "libs" hash, and then finally add them to the process
                 // in Image/Load.
 
-                let process_id = s.process_id(); // there isn't a ProcessId field here
-                if !context.is_interesting_process(process_id, None, None) && process_id != 0 {
-                    return
-                }
-
+                let pid = s.process_id(); // there isn't a ProcessId field here
                 let image_base: u64 = parser.try_parse("ImageBase").unwrap();
-                let image_timestamp = parser.try_parse("TimeDateStamp").unwrap();
+                let image_timestamp: u32 = parser.try_parse("TimeDateStamp").unwrap();
                 let image_size: u32 = parser.try_parse("ImageSize").unwrap();
                 let image_path: String = parser.try_parse("OriginalFileName").unwrap();
-                //eprintln!("ImageID pid: {} 0x{:x} {} {} {}", process_id, image_base, image_path, image_size, image_timestamp);
-                // "libs" is used as a cache to store the image path and size until we get the DbgID_RSDS event
-                if libs.contains_key(&(process_id, image_base)) {
-                    // I see odd entries like this with no corresponding DbgID_RSDS:
-                    //   ImageID pid: 3156 0xf70000 com.docker.cli.exe 49819648 0
-                    // they all come from something docker-related. So don't panic on the duplicate.
-                    //panic!("libs already contains key 0x{:x} for pid {}", image_base, process_id);
-                }
-                libs.insert((process_id, image_base), (image_path, image_size, image_timestamp));
+                context.handle_image_id(pid, image_base, image_timestamp, image_size, image_path);
             }
             "KernelTraceControl/ImageID/DbgID_RSDS" => {
-                let process_id = parser.try_parse("ProcessId").unwrap();
-                if !context.is_interesting_process(process_id, None, None) && process_id != 0 {
-                    return
-                }
-
+                let pid = parser.try_parse("ProcessId").unwrap();
                 let image_base: u64 = parser.try_parse("ImageBase").unwrap();
                 let guid: GUID = parser.try_parse("GuidSig").unwrap();
                 let age: u32 = parser.try_parse("Age").unwrap();
-                let debug_id = DebugId::from_parts(Uuid::from_fields(guid.data1, guid.data2, guid.data3, &guid.data4), age);
+                let debug_id = DebugId::from_parts(
+                    Uuid::from_fields(guid.data1, guid.data2, guid.data3, &guid.data4),
+                    age,
+                );
                 let pdb_path: String = parser.try_parse("PdbFileName").unwrap();
-                //let pdb_path = Path::new(&pdb_path);
-                let Some((ref path, image_size, timestamp)) = libs.remove(&(process_id, image_base)) else {
-                    log::warn!("DbID_RSDS for image at 0x{:x} for pid {}, but has no entry in libs", image_base, process_id);
-                    return
-                };
-                //eprintln!("DbgID_RSDS pid: {} 0x{:x} {} {} {} {}", process_id, image_base, path, debug_id, pdb_path, age);
-                let code_id = Some(format!("{timestamp:08X}{image_size:x}"));
-                let name = Path::new(path).file_name().unwrap().to_str().unwrap().to_owned();
-                let debug_name = Path::new(&pdb_path).file_name().map(|f| f.to_str().unwrap().to_owned()).unwrap_or(name.clone());
-                let info = LibraryInfo {
-                    name,
-                    debug_name,
-                    path: path.clone(),
-                    code_id,
-                    symbol_table: None,
-                    debug_path: pdb_path,
-                    debug_id,
-                    arch: Some(context.arch.to_owned()),
-                };
-                if process_id == 0 || image_base >= context.kernel_min {
-                    if let Some(oldinfo) = kernel_pending_libraries.get(&image_base) {
-                        assert_eq!(*oldinfo, info);
-                    } else {
-                        kernel_pending_libraries.insert(image_base, info);
-                    }
-                } else if let Some(mut process) = context.get_process_mut(process_id) {
-                    process.pending_libraries.insert(image_base, info);
-                } else {
-                    log::warn!("No process for pid {process_id}");
-                }
-
+                context.handle_image_debug_id(pid, image_base, debug_id, pdb_path);
             }
             "MSNT_SystemTrace/Image/Load" | "MSNT_SystemTrace/Image/DCStart" => {
                 // KernelTraceControl/ImageID/ and KernelTraceControl/ImageID/DbgID_RSDS are synthesized from MSNT_SystemTrace/Image/Load
@@ -396,290 +204,147 @@ pub fn profile_pid_from_etl_file(context: &mut ProfileContext, etl_file: &Path) 
                 // in pending_libraries and deal with it here. We assume that the KernelTraceControl events come before the Image/Load event.
 
                 // the ProcessId field doesn't necessarily match s.process_id();
-                let process_id = parser.try_parse("ProcessId").unwrap();
-                if !context.is_interesting_process(process_id, None, None) && process_id != 0 {
-                    return
-                }
-
+                let pid = parser.try_parse("ProcessId").unwrap();
                 let image_base: u64 = parser.try_parse("ImageBase").unwrap();
                 let image_size: u64 = parser.try_parse("ImageSize").unwrap();
-
                 let path: String = parser.try_parse("FileName").unwrap();
-                let path = context.map_device_path(&path);
-
-                let info = if process_id == 0 {
-                    kernel_pending_libraries.remove(&image_base)
-                } else if let Some(mut process) = context.get_process_mut(process_id) {
-                    process.pending_libraries.remove(&image_base)
-                } else {
-                    log::warn!("Received {} for unknown pid {process_id}", s.name());
-                    return;
-                };
-
-                // If the file doesn't exist on disk we won't have KernelTraceControl/ImageID events
-                // This happens for the ghost drivers mentioned here: https://devblogs.microsoft.com/oldnewthing/20160913-00/?p=94305
-                let Some(mut info) = info else {
-                    return
-                };
-
-                info.path = path;
-
-                // attempt to categorize the library based on the path
-                let path_lower = info.path.to_lowercase();
-                let debug_path_lower = info.debug_path.to_lowercase();
-
-                let known_category = if debug_path_lower.contains(".ni.pdb") {
-                    KnownCategory::CoreClrR2r
-                } else if path_lower.contains("windows\\system32") || path_lower.contains("windows\\winsxs") {
-                    KnownCategory::System
-                } else {
-                    KnownCategory::Unknown
-                };
-
-                let lib_handle = context.profile.borrow_mut().add_lib(info);
-                if process_id == 0 || image_base >= context.kernel_min {
-                    context.profile.borrow_mut().add_kernel_lib_mapping(lib_handle, image_base, image_base + image_size, 0);
-                    return
-                }
-
-
-                let info = if known_category != KnownCategory::Unknown {
-                    let category = context.get_category(known_category);
-                    LibMappingInfo::new_lib_with_category(lib_handle, category.into())
-                } else {
-                    LibMappingInfo::new_lib(lib_handle)
-                };
-
-                context.get_process_mut(process_id).unwrap().regular_lib_mapping_ops.push(timestamp_raw, LibMappingOp::Add(LibMappingAdd {
-                        start_avma: image_base,
-                        end_avma: image_base + image_size,
-                        relative_address_at_start: 0,
-                        info,
-                    }));
+                context.handle_image_load(timestamp_raw, pid, image_base, image_size, path);
             }
             "Microsoft-Windows-DxgKrnl/VSyncDPC/Info " => {
-                #[derive(Debug, Clone)]
-                pub struct VSyncMarker;
-
-                impl ProfilerMarker for VSyncMarker {
-                    const MARKER_TYPE_NAME: &'static str = "Vsync";
-
-                    fn json_marker_data(&self) -> Value {
-                        json!({
-                            "type": Self::MARKER_TYPE_NAME,
-                            "name": ""
-                        })
-                    }
-
-                    fn schema() -> MarkerSchema {
-                        MarkerSchema {
-                            type_name: Self::MARKER_TYPE_NAME,
-                            locations: vec![MarkerLocation::MarkerChart, MarkerLocation::MarkerTable, MarkerLocation::TimelineOverview],
-                            chart_label: Some("{marker.data.name}"),
-                            tooltip_label: None,
-                            table_label: Some("{marker.name} - {marker.data.name}"),
-                            fields: vec![MarkerSchemaField::Dynamic(MarkerDynamicField {
-                                key: "name",
-                                label: "Details",
-                                format: MarkerFieldFormat::String,
-                                searchable: false,
-                            })],
-                        }
-                    }
-                }
-
-                let gpu_thread = gpu_thread.get_or_insert_with(|| {
-                    let gpu = context.profile.borrow_mut().add_process("GPU", 1, profile_start_instant);
-                    context.profile.borrow_mut().add_thread(gpu, 1, profile_start_instant, false)
-                });
-                context.profile.borrow_mut().add_marker(*gpu_thread,
-                    CategoryHandle::OTHER,
-                    "Vsync",
-                    VSyncMarker{},
-                    MarkerTiming::Instant(timestamp)
-                );
+                context.handle_vsync(timestamp_raw);
             }
             "MSNT_SystemTrace/Thread/CSwitch" => {
-                let new_thread: u32 = parser.parse("NewThreadId");
-                let old_thread: u32 = parser.parse("OldThreadId");
-                // println!("CSwitch {} -> {} @ {} on {}", old_thread, new_thread, e.EventHeader.TimeStamp, unsafe { e.BufferContext.Anonymous.ProcessorIndex });
-
-                if let Some(mut old_thread) = context.get_thread_mut(old_thread) {
-                    context.context_switch_handler.borrow_mut().handle_switch_out(timestamp_raw, &mut old_thread.context_switch_data);
-                }
-                if let Some(mut new_thread) = context.get_thread_mut(new_thread) {
-                    let off_cpu_sample_group = context.context_switch_handler.borrow_mut().handle_switch_in(timestamp_raw, &mut new_thread.context_switch_data);
-                    if let Some(off_cpu_sample_group) = off_cpu_sample_group {
-                        new_thread.pending_stacks.push_back(PendingStack { timestamp: timestamp_raw, kernel_stack: None, off_cpu_sample_group: Some(off_cpu_sample_group), on_cpu_sample_cpu_delta: None });
-                    }
-                }
+                let old_tid: u32 = parser.parse("OldThreadId");
+                let new_tid: u32 = parser.parse("NewThreadId");
+                context.handle_cswitch(timestamp_raw, old_tid, new_tid);
             }
             "MSNT_SystemTrace/Thread/ReadyThread" => {
                 // these events can give us the unblocking stack
                 let _thread_id: u32 = parser.parse("TThreadId");
             }
-            "V8.js/MethodLoad/" |
-            "Microsoft-JScript/MethodRuntime/MethodDCStart" |
-            "Microsoft-JScript/MethodRuntime/MethodLoad" => {
-                let process_id = s.process_id();
-
+            "V8.js/MethodLoad/"
+            | "Microsoft-JScript/MethodRuntime/MethodDCStart"
+            | "Microsoft-JScript/MethodRuntime/MethodLoad" => {
+                let pid = s.process_id();
                 let method_name: String = parser.parse("MethodName");
                 let method_start_address: Address = parser.parse("MethodStartAddress");
                 let method_size: u64 = parser.parse("MethodSize");
                 // let source_id: u64 = parser.parse("SourceID");
-
-                context.ensure_process_jit_info(process_id);
-                let Some(process) = context.get_process_mut(process_id) else { return; };
-                let mut process_jit_info = context.get_process_jit_info(process_id);
-
-                let start_address = method_start_address.as_u64();
-                let relative_address = process_jit_info.next_relative_address;
-                process_jit_info.next_relative_address += method_size as u32;
-
-                if let Some(main_thread) = process.main_thread_handle {
-                    context.profile.borrow_mut().add_marker(
-                        main_thread,
-                        CategoryHandle::OTHER,
-                        "JitFunctionAdd",
-                        JitFunctionAddMarker(method_name.to_owned()),
-                        MarkerTiming::Instant(timestamp),
-                    );
-                }
-
-                let (category, js_frame) = context.js_category_manager.borrow_mut().classify_jit_symbol(&method_name, &mut context.profile.borrow_mut());
-                let info = LibMappingInfo::new_jit_function(process_jit_info.lib_handle, category, js_frame);
-                process_jit_info.jit_mapping_ops.push(e.EventHeader.TimeStamp as u64, LibMappingOp::Add(LibMappingAdd {
-                    start_avma: start_address,
-                    end_avma: start_address + method_size,
-                    relative_address_at_start: relative_address,
-                    info
-                }));
-                process_jit_info.symbols.push(Symbol {
-                    address: relative_address,
-                    size: Some(method_size as u32),
-                    name: method_name,
-                });
+                context.handle_js_method_load(
+                    timestamp_raw,
+                    pid,
+                    method_name,
+                    method_start_address.as_u64(),
+                    method_size,
+                );
             }
-            "V8.js/SourceLoad/" /*|
+            /*"V8.js/SourceLoad/" |
             "Microsoft-JScript/MethodRuntime/MethodDCStart" |
-            "Microsoft-JScript/MethodRuntime/MethodLoad"*/ => {
+            "Microsoft-JScript/MethodRuntime/MethodLoad" => {
                 let source_id: u64 = parser.parse("SourceID");
                 let url: String = parser.parse("Url");
-                //if s.process_id() == 6736 { dbg!(s.process_id(), &method_name, method_start_address, method_size); }
                 jscript_sources.insert(source_id, url);
                 //dbg!(s.process_id(), jscript_symbols.keys());
-
-            }
+            }*/
             "Microsoft-Windows-Direct3D11/ID3D11VideoContext_SubmitDecoderBuffers/win:Start" => {
-                let mut parser = Parser::create(&s);
-                let thread_id = s.thread_id();
-                let Some(mut thread) = context.get_thread_mut(thread_id) else { return };
+                let tid = s.thread_id();
                 let text = event_properties_to_string(&s, &mut parser, None);
-                thread.pending_markers.insert(s.name().to_owned(), PendingMarker { text, start: timestamp });
+                context.handle_freeform_marker_start(
+                    timestamp_raw,
+                    tid,
+                    s.name().strip_suffix("/win:Start").unwrap(),
+                    text,
+                );
             }
             "Microsoft-Windows-Direct3D11/ID3D11VideoContext_SubmitDecoderBuffers/win:Stop" => {
-                let mut parser = Parser::create(&s);
-                let thread_id = s.thread_id();
-                let Some(mut thread) = context.get_thread_mut(thread_id) else { return };
-
-                let mut text = event_properties_to_string(&s, &mut parser, None);
-                let timing = if let Some(pending) = thread.pending_markers.remove("Microsoft-Windows-Direct3D11/ID3D11VideoContext_SubmitDecoderBuffers/win:Start") {
-                    text = pending.text;
-                    MarkerTiming::Interval(pending.start, timestamp)
-                } else {
-                    MarkerTiming::IntervalEnd(timestamp)
-                };
-
-                let category = context.get_category(KnownCategory::D3DVideoSubmitDecoderBuffers);
-                context.profile.borrow_mut().add_marker(thread.handle, category, s.name().split_once('/').unwrap().1, SimpleMarker(text), timing);
+                let tid = s.thread_id();
+                let text = event_properties_to_string(&s, &mut parser, None);
+                context.handle_freeform_marker_end(
+                    timestamp_raw,
+                    tid,
+                    s.name().strip_suffix("/win:Start").unwrap(),
+                    text,
+                    KnownCategory::D3DVideoSubmitDecoderBuffers,
+                );
             }
-            marker_name if marker_name.starts_with("Mozilla.FirefoxTraceLogger/") =>  {
-                let Some(marker_name) = marker_name.strip_prefix("Mozilla.FirefoxTraceLogger/").and_then(|s| s.strip_suffix("/Info")) else { return };
-
-                let thread_id = e.EventHeader.ThreadId;
-                let Some(thread) = context.get_thread(thread_id) else { return };
-
-                let text = event_properties_to_string(&s, &mut parser, Some(&["MarkerName", "StartTime", "EndTime", "Phase", "InnerWindowId", "CategoryPair"]));
-
+            marker_name if marker_name.starts_with("Mozilla.FirefoxTraceLogger/") => {
+                let Some(marker_name) = marker_name
+                    .strip_prefix("Mozilla.FirefoxTraceLogger/")
+                    .and_then(|s| s.strip_suffix("/Info"))
+                else {
+                    return;
+                };
+                let tid = e.EventHeader.ThreadId;
                 // We ignore e.EventHeader.TimeStamp and instead take the timestamp from the fields.
                 let start_time_qpc: u64 = parser.try_parse("StartTime").unwrap();
                 let end_time_qpc: u64 = parser.try_parse("EndTime").unwrap();
-                assert!(event_timestamps_are_qpc, "Inconsistent timestamp formats! ETW traces with Firefox events should be captured with QPC timestamps (-ClockType PerfCounter) so that ETW sample timestamps are compatible with the QPC timestamps in Firefox ETW trace events, so that the markers appear in the right place.");
-                let (phase, instant_time_qpc): (u8, u64) = match parser.try_parse("Phase") {
-                    Ok(phase) => (phase, start_time_qpc),
-                    Err(_) => {
-                        // Before the landing of https://bugzilla.mozilla.org/show_bug.cgi?id=1882640 ,
-                        // Firefox ETW trace events didn't have phase information, so we need to
-                        // guess a phase based on the timestamps.
-                        if start_time_qpc != 0 && end_time_qpc != 0 {
-                            (PHASE_INTERVAL, 0)
-                        } else if start_time_qpc != 0 {
-                            (PHASE_INSTANT, start_time_qpc)
-                        } else {
-                            (PHASE_INSTANT, end_time_qpc)
-                        }
-                    }
-                };
-                let timing = match phase {
-                    PHASE_INSTANT => MarkerTiming::Instant(timestamp_converter.convert_time(instant_time_qpc)),
-                    PHASE_INTERVAL => MarkerTiming::Interval(timestamp_converter.convert_time(start_time_qpc), timestamp_converter.convert_time(end_time_qpc)),
-                    PHASE_INTERVAL_START => MarkerTiming::IntervalStart(timestamp_converter.convert_time(start_time_qpc)),
-                    PHASE_INTERVAL_END => MarkerTiming::IntervalEnd(timestamp_converter.convert_time(end_time_qpc)),
-                    _ => panic!("Unexpected marker phase {phase}"),
-                };
-
-                if marker_name == "UserTiming" {
-                    let name: String = parser.try_parse("name").unwrap();
-                    context.profile.borrow_mut().add_marker(thread.handle, CategoryHandle::OTHER, "UserTiming", UserTimingMarker(name), timing);
-                } else if marker_name == "SimpleMarker" || marker_name == "Text" || marker_name == "tracing" {
-                    let marker_name: String = parser.try_parse("MarkerName").unwrap();
-                    context.profile.borrow_mut().add_marker(thread.handle, CategoryHandle::OTHER, &marker_name, SimpleMarker(text.clone()), timing);
-                } else {
-                    context.profile.borrow_mut().add_marker(thread.handle, CategoryHandle::OTHER, marker_name, SimpleMarker(text.clone()), timing);
-                }
+                let phase: Option<u8> = parser.try_parse("Phase").ok();
+                let maybe_user_timing_name: Option<String> = parser.try_parse("name").ok();
+                let maybe_explicit_marker_name: Option<String> =
+                    parser.try_parse("MarkerName").ok();
+                let text = event_properties_to_string(
+                    &s,
+                    &mut parser,
+                    Some(&[
+                        "MarkerName",
+                        "StartTime",
+                        "EndTime",
+                        "Phase",
+                        "InnerWindowId",
+                        "CategoryPair",
+                    ]),
+                );
+                context.handle_firefox_marker(
+                    tid,
+                    marker_name,
+                    start_time_qpc,
+                    end_time_qpc,
+                    phase,
+                    maybe_user_timing_name,
+                    maybe_explicit_marker_name,
+                    text,
+                );
             }
             "MetaData/EventInfo" | "Process/Terminate" => {
                 // ignore
             }
             marker_name if marker_name.starts_with("Google.Chrome/") => {
-                let Some(marker_name) = marker_name.strip_prefix("Google.Chrome/").and_then(|s| s.strip_suffix("/Info")) else { return };
-                // a bitfield of keywords
-                let thread_id = e.EventHeader.ThreadId;
-                let phase: String = parser.try_parse("Phase").unwrap();
-
-                let Some(thread) = context.get_thread(thread_id)  else { return };
-                let text = event_properties_to_string(&s, &mut parser, Some(&["Timestamp", "Phase", "Duration"]));
-
+                let Some(marker_name) = marker_name
+                    .strip_prefix("Google.Chrome/")
+                    .and_then(|s| s.strip_suffix("/Info"))
+                else {
+                    return;
+                };
+                let tid = e.EventHeader.ThreadId;
                 // We ignore e.EventHeader.TimeStamp and instead take the timestamp from the fields.
                 let timestamp_raw: u64 = parser.try_parse("Timestamp").unwrap();
-                let timestamp = timestamp_converter.convert_us(timestamp_raw);
-
-                let timing = match phase.as_str() {
-                    "Begin" => MarkerTiming::IntervalStart(timestamp),
-                    "End" => MarkerTiming::IntervalEnd(timestamp),
-                    _ => MarkerTiming::Instant(timestamp),
-                };
-                let keyword = KeywordNames::from_bits(e.EventHeader.EventDescriptor.Keyword).unwrap();
-                if keyword == KeywordNames::blink_user_timing {
-                    context.profile.borrow_mut().add_marker(thread.handle, CategoryHandle::OTHER, "UserTiming", UserTimingMarker(marker_name.to_owned()), timing);
-                } else {
-                    context.profile.borrow_mut().add_marker(thread.handle, CategoryHandle::OTHER, marker_name, SimpleMarker(text.clone()), timing);
-                }
+                let phase: String = parser.try_parse("Phase").unwrap();
+                let keyword_bitfield = e.EventHeader.EventDescriptor.Keyword; // a bitfield of keywords
+                let text = event_properties_to_string(
+                    &s,
+                    &mut parser,
+                    Some(&["Timestamp", "Phase", "Duration"]),
+                );
+                context.handle_chrome_marker(
+                    tid,
+                    marker_name,
+                    timestamp_raw,
+                    &phase,
+                    keyword_bitfield,
+                    text,
+                );
             }
             dotnet_event if dotnet_event.starts_with("Microsoft-Windows-DotNETRuntime") => {
                 // Note: No "/" at end of event name, because we want DotNETRuntimeRundown as well
-                coreclr::handle_coreclr_event(context, &s, &mut parser, &timestamp_converter);
+                coreclr::handle_coreclr_event(context, &mut core_clr_context, &s, &mut parser);
             }
             _ => {
-                let thread_id = e.EventHeader.ThreadId;
-                let Some(thread) = context.get_thread(thread_id) else { return };
-
-                let text = event_properties_to_string(&s, &mut parser, None);
-                let timing = MarkerTiming::Instant(timestamp);
-                // this used to create a new category based on provider_name, just lump them together for now
-                let category = context.get_category(KnownCategory::Unknown);
-                context.profile.borrow_mut().add_marker(thread.handle, category, s.name().split_once('/').unwrap().1, SimpleMarker(text), timing);
-                //println!("unhandled {}", s.name())
+                let tid = e.EventHeader.ThreadId;
+                if context.has_thread(tid) {
+                    let task_and_op = s.name().split_once('/').unwrap().1;
+                    let text = event_properties_to_string(&s, &mut parser, None);
+                    context.handle_unknown_event(timestamp_raw, tid, task_and_op, text);
+                }
             }
         }
     });
@@ -689,61 +354,8 @@ pub fn profile_pid_from_etl_file(context: &mut ProfileContext, etl_file: &Path) 
         std::process::exit(1);
     }
 
-    // Push queued samples into the profile.
-    // We queue them so that we can get symbolicated JIT function names. To get symbolicated JIT function names,
-    // we have to call profile.add_sample after we call profile.set_lib_symbol_table, and we don't have the
-    // complete JIT symbol table before we've seen all JIT symbols.
-    // (This is a rather weak justification. The better justification is that this is consistent with what
-    // samply does on Linux and macOS, where the queued samples also want to respect JIT function names from
-    // a /tmp/perf-1234.map file, and this file may not exist until the profiled process finishes.)
-    let mut stack_frame_scratch_buf = Vec::new();
-    for (process_id, process) in context.processes.iter() {
-        let process = process.borrow_mut();
-        let jitdump_lib_mapping_op_queues = match context.process_jit_infos.remove(process_id) {
-            Some(jit_info) => {
-                let jit_info = jit_info.into_inner();
-                context.profile.borrow_mut().set_lib_symbol_table(
-                    jit_info.lib_handle,
-                    Arc::new(SymbolTable::new(jit_info.symbols)),
-                );
-                vec![jit_info.jit_mapping_ops]
-            }
-            None => Vec::new(),
-        };
-
-        let process_sample_data = ProcessSampleData::new(
-            process.unresolved_samples.clone(),
-            process.regular_lib_mapping_ops.clone(),
-            jitdump_lib_mapping_op_queues,
-            None,
-            Vec::new(),
-        );
-        //main_thread_handle.unwrap_or_else(|| panic!("process no main thread {:?}", process_id)));
-        let user_category = context.get_category(KnownCategory::User).into();
-        let kernel_category = context.get_category(KnownCategory::Kernel).into();
-        process_sample_data.flush_samples_to_profile(
-            &mut context.profile.borrow_mut(),
-            user_category,
-            kernel_category,
-            &mut stack_frame_scratch_buf,
-            &context.unresolved_stacks.borrow(),
-        )
-    }
-
-    /*if merge_threads {
-        profile.add_thread(global_thread);
-    } else {
-        for (_, thread) in threads.drain() { profile.add_thread(thread.builder); }
-    }*/
-
     log::info!(
         "Took {} seconds",
         (Instant::now() - processing_start_timestamp).as_secs_f32()
-    );
-    log::info!(
-        "{} events, {} samples, {} stack-samples",
-        event_count,
-        sample_count,
-        stack_sample_count
     );
 }

--- a/samply/src/windows/firefox_etw_flags.rs
+++ b/samply/src/windows/firefox_etw_flags.rs
@@ -1,0 +1,5 @@
+// From https://searchfox.org/mozilla-central/rev/0e7394a77cdbe1df5e04a1d4171d6da67b57fa17/mozglue/baseprofiler/public/BaseProfilerMarkersPrerequisites.h#355-360
+pub const PHASE_INSTANT: u8 = 0;
+pub const PHASE_INTERVAL: u8 = 1;
+pub const PHASE_INTERVAL_START: u8 = 2;
+pub const PHASE_INTERVAL_END: u8 = 3;

--- a/samply/src/windows/import.rs
+++ b/samply/src/windows/import.rs
@@ -26,18 +26,19 @@ pub fn convert_etl_file_to_profile(
         interval_8khz, // recording_props.interval.into(),
     );
 
-    let arch = get_native_arch(); // TODO: Detect from file if reading from file
+    let arch = get_native_arch(); // TODO: Detect arch from file
 
     let mut context = ProfileContext::new(profile, arch, included_processes);
 
     etw_gecko::profile_pid_from_etl_file(&mut context, filename);
 
+    let profile = context.finish();
+
     // write the profile to a json file
     let file = File::create(output_filename).unwrap();
     let writer = BufWriter::new(file);
     {
-        let profile = context.profile.borrow();
-        to_writer(writer, &*profile).expect("Couldn't write JSON");
+        to_writer(writer, &profile).expect("Couldn't write JSON");
     }
 }
 

--- a/samply/src/windows/mod.rs
+++ b/samply/src/windows/mod.rs
@@ -1,7 +1,9 @@
+mod chrome_etw_flags;
 mod console;
 mod coreclr;
 mod elevated_helper;
 mod etw_gecko;
+mod firefox_etw_flags;
 mod gfx;
 pub mod import;
 mod profile_context;

--- a/samply/src/windows/profile_context.rs
+++ b/samply/src/windows/profile_context.rs
@@ -1,5 +1,3 @@
-#![allow(unused)]
-
 use std::cell::{Ref, RefCell, RefMut};
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::{Path, PathBuf};

--- a/samply/src/windows/profile_context.rs
+++ b/samply/src/windows/profile_context.rs
@@ -131,16 +131,15 @@ pub enum KnownCategory {
 }
 
 pub struct ProfileContext {
-    pub profile: RefCell<Profile>,
+    profile: RefCell<Profile>,
 
     // state -- keep track of the processes etc we've seen as we're processing,
     // and their associated handles in the json profile
-    pub processes: HashMap<u32, RefCell<ProcessState>>,
-    pub threads: HashMap<u32, RefCell<ThreadState>>,
-    pub memory_usage: HashMap<u32, RefCell<MemoryUsage>>,
-    pub process_jit_infos: HashMap<u32, RefCell<ProcessJitInfo>>,
+    processes: HashMap<u32, RefCell<ProcessState>>,
+    threads: HashMap<u32, RefCell<ThreadState>>,
+    process_jit_infos: HashMap<u32, RefCell<ProcessJitInfo>>,
 
-    pub unresolved_stacks: RefCell<UnresolvedStacks>,
+    unresolved_stacks: RefCell<UnresolvedStacks>,
 
     // track VM alloc/frees per thread? counter may be inaccurate because memory
     // can be allocated on one thread and freed on another
@@ -159,8 +158,8 @@ pub struct ProfileContext {
     // default categories
     categories: RefCell<HashMap<KnownCategory, CategoryHandle>>,
 
-    pub js_category_manager: RefCell<JitCategoryManager>,
-    pub context_switch_handler: RefCell<ContextSwitchHandler>,
+    js_category_manager: RefCell<JitCategoryManager>,
+    context_switch_handler: RefCell<ContextSwitchHandler>,
 
     // cache of device mappings
     device_mappings: HashMap<String, String>, // map of \Device\HarddiskVolume4 -> C:\
@@ -168,12 +167,12 @@ pub struct ProfileContext {
     // the minimum address for kernel drivers, so that we can assign kernel_category to the frame
     // TODO why is this needed -- kernel libs are at global addresses, why do I need to indicate
     // this per-frame; shouldn't there be some kernel override?
-    pub kernel_min: u64,
+    kernel_min: u64,
 
     // architecture to record in the trace. will be the system architecture for now.
     // TODO no idea how to handle "I'm on aarch64 windows but I'm recording a win64 process".
     // I have no idea how stack traces work in that case anyway, so this is probably moot.
-    pub arch: String,
+    arch: String,
 
     sample_count: usize,
     stack_sample_count: usize,
@@ -202,7 +201,6 @@ impl ProfileContext {
             profile: RefCell::new(profile),
             processes: HashMap::new(),
             threads: HashMap::new(),
-            memory_usage: HashMap::new(),
             process_jit_infos: HashMap::new(),
             unresolved_stacks: RefCell::new(UnresolvedStacks::default()),
             gpu_thread_handle: None,
@@ -239,6 +237,10 @@ impl ProfileContext {
         (KnownCategory::CoreClrGc, "CoreCLR GC", CategoryColor::Red),
         (KnownCategory::Unknown, "Other", CategoryColor::DarkGray),
     ];
+
+    pub fn is_arm64(&self) -> bool {
+        self.arch == "arm64"
+    }
 
     pub fn get_category(&self, category: KnownCategory) -> CategoryHandle {
         let category = if category == KnownCategory::Default {

--- a/samply/src/windows/profile_context.rs
+++ b/samply/src/windows/profile_context.rs
@@ -3,26 +3,39 @@
 use std::cell::{Ref, RefCell, RefMut};
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use debugid::DebugId;
+use etw_reader::etw_types::EventRecord;
+use etw_reader::parser::{Parser, TryParse};
+use etw_reader::print_property;
+use etw_reader::schema::TypedEvent;
 use fxprof_processed_profile::{
     CategoryColor, CategoryHandle, CounterHandle, CpuDelta, FrameFlags, FrameInfo, LibraryHandle,
-    LibraryInfo, MarkerHandle, MarkerTiming, ProcessHandle, Profile, ProfilerMarker, Symbol,
-    ThreadHandle, Timestamp,
+    LibraryInfo, MarkerDynamicField, MarkerFieldFormat, MarkerHandle, MarkerLocation, MarkerSchema,
+    MarkerSchemaField, MarkerTiming, ProcessHandle, Profile, ProfilerMarker, SamplingInterval,
+    Symbol, SymbolTable, ThreadHandle, Timestamp,
 };
+use serde_json::{json, Value};
 use uuid::Uuid;
 
-use super::coreclr::CoreClrContext;
+use super::chrome_etw_flags::KeywordNames;
 use super::winutils;
 use crate::shared::context_switch::{
     ContextSwitchHandler, OffCpuSampleGroup, ThreadContextSwitchData,
 };
 use crate::shared::included_processes::IncludedProcesses;
 use crate::shared::jit_category_manager::JitCategoryManager;
-use crate::shared::lib_mappings::LibMappingOpQueue;
+use crate::shared::jit_function_add_marker::JitFunctionAddMarker;
+use crate::shared::lib_mappings::{LibMappingAdd, LibMappingInfo, LibMappingOp, LibMappingOpQueue};
+use crate::shared::process_sample_data::{ProcessSampleData, SimpleMarker, UserTimingMarker};
+use crate::shared::timestamp_converter::TimestampConverter;
 use crate::shared::types::{StackFrame, StackMode};
 use crate::shared::unresolved_samples::{
     SampleOrMarker, UnresolvedSamples, UnresolvedStackHandle, UnresolvedStacks,
+};
+use crate::windows::firefox_etw_flags::{
+    PHASE_INSTANT, PHASE_INTERVAL, PHASE_INTERVAL_END, PHASE_INTERVAL_START,
 };
 
 /// An on- or off-cpu-sample for which the user stack is not known yet.
@@ -166,6 +179,8 @@ pub struct ProfileContext {
     // some special threads
     gpu_thread_handle: Option<ThreadHandle>,
 
+    libs_with_pending_debugid: HashMap<(u32, u64), (String, u32, u32)>,
+    kernel_pending_libraries: HashMap<u64, LibraryInfo>,
     libs: HashMap<String, LibraryHandle>,
 
     // These are the processes + their descendants that we want to write into
@@ -191,7 +206,15 @@ pub struct ProfileContext {
     // I have no idea how stack traces work in that case anyway, so this is probably moot.
     pub arch: String,
 
-    pub coreclr_context: RefCell<CoreClrContext>,
+    sample_count: usize,
+    stack_sample_count: usize,
+    /// Resolution of the hardware timer, in units of 100 nanoseconds.
+    timer_resolution: u32,
+    event_count: usize,
+    jscript_sources: HashMap<u64, String>,
+
+    timestamp_converter: TimestampConverter,
+    event_timestamps_are_qpc: bool,
 }
 
 impl ProfileContext {
@@ -221,6 +244,8 @@ impl ProfileContext {
             other_thread_handle: None,
             gpu_thread_handle: None,
             per_thread_memory: false,
+            libs_with_pending_debugid: HashMap::new(),
+            kernel_pending_libraries: HashMap::new(),
             libs: HashMap::new(),
             included_processes,
             categories: RefCell::new(HashMap::new()),
@@ -229,8 +254,22 @@ impl ProfileContext {
             device_mappings: winutils::get_dos_device_mappings(),
             kernel_min,
             arch: arch.to_string(),
-            coreclr_context: RefCell::new(CoreClrContext::new()),
+            sample_count: 0,
+            stack_sample_count: 0,
+            timer_resolution: 0, // Will be filled once we process the header
+            event_count: 0,
+            jscript_sources: HashMap::new(),
+            // Dummy, will be replaced once we see the header
+            timestamp_converter: TimestampConverter {
+                reference_raw: 0,
+                raw_to_ns_factor: 1,
+            },
+            event_timestamps_are_qpc: false,
         }
+    }
+
+    pub fn convert_timestamp(&self, timestamp_raw: u64) -> Timestamp {
+        self.timestamp_converter.convert_time(timestamp_raw)
     }
 
     #[rustfmt::skip]
@@ -377,6 +416,10 @@ impl ProfileContext {
     pub fn get_process_for_thread_mut(&self, tid: u32) -> Option<RefMut<'_, ProcessState>> {
         let pid = self.threads.get(&tid)?.borrow().process_id;
         self.processes.get(&pid).map(|p| p.borrow_mut())
+    }
+
+    pub fn has_thread(&self, tid: u32) -> bool {
+        self.threads.contains_key(&tid)
     }
 
     pub fn get_thread(&self, tid: u32) -> Option<Ref<'_, ThreadState>> {
@@ -618,8 +661,953 @@ impl ProfileContext {
             .add_marker(thread_handle, category, name, marker, timing)
     }
 
-    pub fn get_coreclr_context(&self) -> RefMut<CoreClrContext> {
-        self.coreclr_context.borrow_mut()
+    pub fn handle_header(
+        &mut self,
+        timestamp_raw: u64,
+        timer_resolution: u32,
+        perf_freq: u64,
+        clock_type: u32,
+    ) {
+        if clock_type != 1 {
+            log::warn!("QPC not used as clock");
+            self.event_timestamps_are_qpc = false;
+        } else {
+            self.event_timestamps_are_qpc = true;
+        }
+
+        self.timestamp_converter = TimestampConverter {
+            reference_raw: timestamp_raw,
+            raw_to_ns_factor: 1000 * 1000 * 1000 / perf_freq,
+        };
+    }
+
+    pub fn handle_collection_start(&mut self, interval_raw: u32) {
+        let interval_nanos = interval_raw as u64 * 100;
+        let interval = SamplingInterval::from_nanos(interval_nanos);
+        log::info!("Sample rate {}ms", interval.as_secs_f64() * 1000.);
+        self.profile.borrow_mut().set_interval(interval);
+        self.context_switch_handler
+            .replace(ContextSwitchHandler::new(interval_raw as u64));
+    }
+
+    pub fn handle_thread_dcstart(
+        &mut self,
+        timestamp_raw: u64,
+        tid: u32,
+        pid: u32,
+        name: Option<String>,
+    ) {
+        if !self.is_interesting_process(pid, None, None) {
+            return;
+        }
+
+        let timestamp = self.timestamp_converter.convert_time(timestamp_raw);
+
+        // if there's an existing thread, remove it, assume we dropped an end thread event
+        self.remove_thread(tid, Some(timestamp));
+        self.add_thread(pid, tid, timestamp);
+
+        if let Some(thread_name) = name {
+            if !thread_name.is_empty() {
+                self.set_thread_name(tid, &thread_name);
+            }
+        }
+    }
+
+    pub fn handle_thread_start(
+        &mut self,
+        timestamp_raw: u64,
+        tid: u32,
+        pid: u32,
+        name: Option<String>,
+    ) {
+        if !self.is_interesting_process(pid, None, None) {
+            return;
+        }
+
+        let timestamp = self.timestamp_converter.convert_time(timestamp_raw);
+
+        // if there's an existing thread, remove it, assume we dropped an end thread event
+        self.remove_thread(tid, Some(timestamp));
+        self.add_thread(pid, tid, timestamp);
+
+        if let Some(thread_name) = name {
+            if !thread_name.is_empty() {
+                self.set_thread_name(tid, &thread_name);
+            }
+        }
+    }
+
+    pub fn handle_thread_set_name(&mut self, _timestamp_raw: u64, tid: u32, name: String) {
+        if !name.is_empty() {
+            self.set_thread_name(tid, &name);
+        }
+    }
+
+    pub fn handle_thread_end(&mut self, timestamp_raw: u64, tid: u32) {
+        let timestamp = self.timestamp_converter.convert_time(timestamp_raw);
+        self.remove_thread(tid, Some(timestamp));
+    }
+
+    pub fn handle_thread_dcend(&mut self, timestamp_raw: u64, tid: u32) {
+        let timestamp = self.timestamp_converter.convert_time(timestamp_raw);
+        self.remove_thread(tid, Some(timestamp));
+    }
+
+    pub fn handle_process_dcstart(
+        &mut self,
+        timestamp_raw: u64,
+        pid: u32,
+        parent_pid: u32,
+        image_file_name: String,
+    ) {
+        if !self.is_interesting_process(pid, Some(parent_pid), Some(&image_file_name)) {
+            return;
+        }
+
+        let timestamp = self.timestamp_converter.convert_time(timestamp_raw);
+        self.add_process(
+            pid,
+            parent_pid,
+            &self.map_device_path(&image_file_name),
+            timestamp,
+        );
+    }
+
+    pub fn handle_process_start(
+        &mut self,
+        timestamp_raw: u64,
+        pid: u32,
+        parent_pid: u32,
+        image_file_name: String,
+    ) {
+        if !self.is_interesting_process(pid, Some(parent_pid), Some(&image_file_name)) {
+            return;
+        }
+
+        let timestamp = self.timestamp_converter.convert_time(timestamp_raw);
+        self.add_process(
+            pid,
+            parent_pid,
+            &self.map_device_path(&image_file_name),
+            timestamp,
+        );
+    }
+
+    pub fn handle_process_end(&mut self, _timestamp_raw: u64, _pid: u32) {
+        // TODO
+    }
+
+    pub fn handle_process_dcend(&mut self, _timestamp_raw: u64, _pid: u32) {
+        // TODO
+    }
+
+    pub fn handle_stack_arm64(
+        &mut self,
+        timestamp_raw: u64,
+        pid: u32,
+        tid: u32,
+        stack_len: usize,
+        stack_address_iter: impl Iterator<Item = u64>,
+    ) {
+        if !self.threads.contains_key(&tid) {
+            return;
+        }
+
+        // On ARM64, this seems to be simpler -- stacks come in with full kernel and user frames.
+        // At least, I've never seen a kernel stack come in separately.
+        // TODO -- is this because I can't use PROFILE events in the VM?
+
+        // Iterate over the stack addresses, starting with the instruction pointer
+        let stack: Vec<StackFrame> = stack_address_iter
+            .enumerate()
+            .map(|(i, addr)| {
+                if i == 0 {
+                    StackFrame::InstructionPointer(addr, self.stack_mode_for_address(addr))
+                } else {
+                    StackFrame::ReturnAddress(addr, self.stack_mode_for_address(addr))
+                }
+            })
+            .collect();
+
+        let cpu_delta_raw = self
+            .context_switch_handler
+            .borrow_mut()
+            .consume_cpu_delta(&mut self.get_thread_mut(tid).unwrap().context_switch_data);
+        let cpu_delta =
+            CpuDelta::from_nanos(cpu_delta_raw * self.timestamp_converter.raw_to_ns_factor);
+        let timestamp = self.timestamp_converter.convert_time(timestamp_raw);
+        self.add_sample(pid, tid, timestamp, timestamp_raw, cpu_delta, 1, stack);
+    }
+
+    pub fn handle_stack_x86(
+        &mut self,
+        timestamp_raw: u64,
+        pid: u32,
+        tid: u32,
+        stack_len: usize,
+        stack_address_iter: impl Iterator<Item = u64>,
+    ) {
+        let mut stack: Vec<StackFrame> = Vec::with_capacity(stack_len);
+        let mut address_iter = stack_address_iter;
+        let Some(first_frame_address) = address_iter.next() else {
+            return;
+        };
+        let first_frame_stack_mode = self.stack_mode_for_address(first_frame_address);
+        stack.push(StackFrame::InstructionPointer(
+            first_frame_address,
+            first_frame_stack_mode,
+        ));
+        for frame_address in address_iter {
+            let stack_mode = self.stack_mode_for_address(frame_address);
+            stack.push(StackFrame::ReturnAddress(frame_address, stack_mode));
+        }
+
+        if first_frame_stack_mode == StackMode::Kernel {
+            let mut thread = self.get_thread_mut(tid).unwrap();
+            if let Some(pending_stack) = thread
+                .pending_stacks
+                .iter_mut()
+                .rev()
+                .find(|s| s.timestamp == timestamp_raw)
+            {
+                if let Some(kernel_stack) = pending_stack.kernel_stack.as_mut() {
+                    log::warn!(
+                        "Multiple kernel stacks for timestamp {timestamp_raw} on thread {tid}"
+                    );
+                    kernel_stack.extend(&stack);
+                } else {
+                    pending_stack.kernel_stack = Some(stack);
+                }
+            }
+            return;
+        }
+
+        // We now know that we have a user stack. User stacks always come last. Consume
+        // the pending stack with matching timestamp.
+
+        // the number of pending stacks at or before our timestamp
+        let num_pending_stacks = self
+            .get_thread(tid)
+            .unwrap()
+            .pending_stacks
+            .iter()
+            .take_while(|s| s.timestamp <= timestamp_raw)
+            .count();
+
+        let pending_stacks: VecDeque<_> = self
+            .get_thread_mut(tid)
+            .unwrap()
+            .pending_stacks
+            .drain(..num_pending_stacks)
+            .collect();
+
+        // Use this user stack for all pending stacks from this thread.
+        for pending_stack in pending_stacks {
+            let PendingStack {
+                timestamp: timestamp_raw,
+                kernel_stack,
+                off_cpu_sample_group,
+                on_cpu_sample_cpu_delta,
+            } = pending_stack;
+            let timestamp = self.timestamp_converter.convert_time(timestamp_raw);
+
+            if let Some(off_cpu_sample_group) = off_cpu_sample_group {
+                let OffCpuSampleGroup {
+                    begin_timestamp: begin_timestamp_raw,
+                    end_timestamp: end_timestamp_raw,
+                    sample_count,
+                } = off_cpu_sample_group;
+
+                let cpu_delta_raw = {
+                    let mut thread = self.get_thread_mut(tid).unwrap();
+                    self.context_switch_handler
+                        .borrow_mut()
+                        .consume_cpu_delta(&mut thread.context_switch_data)
+                };
+                let cpu_delta =
+                    CpuDelta::from_nanos(cpu_delta_raw * self.timestamp_converter.raw_to_ns_factor);
+
+                // Add a sample at the beginning of the paused range.
+                // This "first sample" will carry any leftover accumulated running time ("cpu delta").
+                let begin_timestamp = self.timestamp_converter.convert_time(begin_timestamp_raw);
+                self.add_sample(
+                    pid,
+                    tid,
+                    begin_timestamp,
+                    begin_timestamp_raw,
+                    cpu_delta,
+                    1,
+                    stack.clone(),
+                );
+
+                if sample_count > 1 {
+                    // Emit a "rest sample" with a CPU delta of zero covering the rest of the paused range.
+                    let weight = i32::try_from(sample_count - 1).unwrap_or(0);
+                    let end_timestamp = self.timestamp_converter.convert_time(end_timestamp_raw);
+                    self.add_sample(
+                        pid,
+                        tid,
+                        end_timestamp,
+                        end_timestamp_raw,
+                        CpuDelta::ZERO,
+                        weight,
+                        stack.clone(),
+                    );
+                }
+            }
+
+            if let Some(cpu_delta) = on_cpu_sample_cpu_delta {
+                if let Some(mut combined_stack) = kernel_stack {
+                    combined_stack.extend_from_slice(&stack[..]);
+                    self.add_sample(
+                        pid,
+                        tid,
+                        timestamp,
+                        timestamp_raw,
+                        cpu_delta,
+                        1,
+                        combined_stack,
+                    );
+                } else {
+                    self.add_sample(
+                        pid,
+                        tid,
+                        timestamp,
+                        timestamp_raw,
+                        cpu_delta,
+                        1,
+                        stack.clone(),
+                    );
+                }
+                self.stack_sample_count += 1;
+            }
+        }
+    }
+
+    pub fn handle_sample(&mut self, timestamp_raw: u64, tid: u32) {
+        self.sample_count += 1;
+
+        let Some(mut thread) = self.get_thread_mut(tid) else {
+            return;
+        };
+
+        let off_cpu_sample_group = self
+            .context_switch_handler
+            .borrow_mut()
+            .handle_on_cpu_sample(timestamp_raw, &mut thread.context_switch_data);
+        let delta = self
+            .context_switch_handler
+            .borrow_mut()
+            .consume_cpu_delta(&mut thread.context_switch_data);
+        let cpu_delta = CpuDelta::from_nanos(delta * self.timestamp_converter.raw_to_ns_factor);
+        thread.pending_stacks.push_back(PendingStack {
+            timestamp: timestamp_raw,
+            kernel_stack: None,
+            off_cpu_sample_group,
+            on_cpu_sample_cpu_delta: Some(cpu_delta),
+        });
+    }
+
+    pub fn handle_virtual_alloc_free(
+        &mut self,
+        timestamp_raw: u64,
+        is_free: bool,
+        pid: u32,
+        tid: u32,
+        region_size: u64,
+        stringified_properties: String,
+    ) {
+        if !self.is_interesting_process(pid, None, None) {
+            return;
+        }
+
+        let timestamp = self.timestamp_converter.convert_time(timestamp_raw);
+        let delta_size = if is_free {
+            -(region_size as f64)
+        } else {
+            region_size as f64
+        };
+        let op_name = if is_free {
+            "VirtualFree"
+        } else {
+            "VirtualAlloc"
+        };
+
+        let Some(memory_usage_counter) = self.get_or_create_memory_usage_counter(tid) else {
+            return;
+        };
+        let Some(thread_handle) = self.get_thread(tid).map(|t| t.handle) else {
+            return;
+        };
+        self.profile.borrow_mut().add_counter_sample(
+            memory_usage_counter,
+            timestamp,
+            delta_size,
+            1,
+        );
+        self.profile.borrow_mut().add_marker(
+            thread_handle,
+            CategoryHandle::OTHER,
+            op_name,
+            SimpleMarker(stringified_properties),
+            MarkerTiming::Instant(timestamp),
+        );
+    }
+
+    pub fn handle_image_id(
+        &mut self,
+        pid: u32,
+        image_base: u64,
+        image_timestamp: u32,
+        image_size: u32,
+        image_path: String,
+    ) {
+        if !self.is_interesting_process(pid, None, None) && pid != 0 {
+            return;
+        }
+        //eprintln!("ImageID pid: {} 0x{:x} {} {} {}", pid, image_base, image_path, image_size, image_timestamp);
+        // "libs" is used as a cache to store the image path and size until we get the DbgID_RSDS event
+        if self
+            .libs_with_pending_debugid
+            .contains_key(&(pid, image_base))
+        {
+            // I see odd entries like this with no corresponding DbgID_RSDS:
+            //   ImageID pid: 3156 0xf70000 com.docker.cli.exe 49819648 0
+            // they all come from something docker-related. So don't panic on the duplicate.
+            //panic!("libs_with_pending_debugid already contains key 0x{:x} for pid {}", image_base, pid);
+        }
+        self.libs_with_pending_debugid
+            .insert((pid, image_base), (image_path, image_size, image_timestamp));
+    }
+
+    pub fn handle_image_debug_id(
+        &mut self,
+        pid: u32,
+        image_base: u64,
+        debug_id: DebugId,
+        pdb_path: String,
+    ) {
+        if !self.is_interesting_process(pid, None, None) && pid != 0 {
+            return;
+        }
+
+        //let pdb_path = Path::new(&pdb_path);
+        let Some((ref path, image_size, timestamp)) =
+            self.libs_with_pending_debugid.remove(&(pid, image_base))
+        else {
+            log::warn!(
+                "DbID_RSDS for image at 0x{:x} for pid {}, but has no entry in libs",
+                image_base,
+                pid
+            );
+            return;
+        };
+        //eprintln!("DbgID_RSDS pid: {} 0x{:x} {} {} {} {}", pid, image_base, path, debug_id, pdb_path, age);
+        let code_id = Some(format!("{timestamp:08X}{image_size:x}"));
+        let name = Path::new(path)
+            .file_name()
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_owned();
+        let debug_name = Path::new(&pdb_path)
+            .file_name()
+            .map(|f| f.to_str().unwrap().to_owned())
+            .unwrap_or(name.clone());
+        let info = LibraryInfo {
+            name,
+            debug_name,
+            path: path.clone(),
+            code_id,
+            symbol_table: None,
+            debug_path: pdb_path,
+            debug_id,
+            arch: Some(self.arch.to_owned()),
+        };
+        if pid == 0 || image_base >= self.kernel_min {
+            if let Some(oldinfo) = self.kernel_pending_libraries.get(&image_base) {
+                assert_eq!(*oldinfo, info);
+            } else {
+                self.kernel_pending_libraries.insert(image_base, info);
+            }
+        } else if let Some(mut process) = self.get_process_mut(pid) {
+            process.pending_libraries.insert(image_base, info);
+        } else {
+            log::warn!("No process for pid {pid}");
+        }
+    }
+
+    pub fn handle_image_load(
+        &mut self,
+        timestamp_raw: u64,
+        pid: u32,
+        image_base: u64,
+        image_size: u64,
+        path: String,
+    ) {
+        // KernelTraceControl/ImageID/ and KernelTraceControl/ImageID/DbgID_RSDS are synthesized from MSNT_SystemTrace/Image/Load
+        // but don't contain the full path of the binary. We go through a bit of a dance to store the information from those events
+        // in pending_libraries and deal with it here. We assume that the KernelTraceControl events come before the Image/Load event.
+
+        // the ProcessId field doesn't necessarily match s.process_id();
+        if !self.is_interesting_process(pid, None, None) && pid != 0 {
+            return;
+        }
+
+        let path = self.map_device_path(&path);
+
+        let info = if pid == 0 {
+            self.kernel_pending_libraries.remove(&image_base)
+        } else if let Some(mut process) = self.get_process_mut(pid) {
+            process.pending_libraries.remove(&image_base)
+        } else {
+            log::warn!("Received image load for unknown pid {pid}");
+            return;
+        };
+
+        // If the file doesn't exist on disk we won't have KernelTraceControl/ImageID events
+        // This happens for the ghost drivers mentioned here: https://devblogs.microsoft.com/oldnewthing/20160913-00/?p=94305
+        let Some(mut info) = info else { return };
+
+        info.path = path;
+
+        // attempt to categorize the library based on the path
+        let path_lower = info.path.to_lowercase();
+        let debug_path_lower = info.debug_path.to_lowercase();
+
+        let known_category = if debug_path_lower.contains(".ni.pdb") {
+            KnownCategory::CoreClrR2r
+        } else if path_lower.contains("windows\\system32") || path_lower.contains("windows\\winsxs")
+        {
+            KnownCategory::System
+        } else {
+            KnownCategory::Unknown
+        };
+
+        let lib_handle = self.profile.borrow_mut().add_lib(info);
+        if pid == 0 || image_base >= self.kernel_min {
+            self.profile.borrow_mut().add_kernel_lib_mapping(
+                lib_handle,
+                image_base,
+                image_base + image_size,
+                0,
+            );
+            return;
+        }
+
+        let info = if known_category != KnownCategory::Unknown {
+            let category = self.get_category(known_category);
+            LibMappingInfo::new_lib_with_category(lib_handle, category.into())
+        } else {
+            LibMappingInfo::new_lib(lib_handle)
+        };
+
+        self.get_process_mut(pid)
+            .unwrap()
+            .regular_lib_mapping_ops
+            .push(
+                timestamp_raw,
+                LibMappingOp::Add(LibMappingAdd {
+                    start_avma: image_base,
+                    end_avma: image_base + image_size,
+                    relative_address_at_start: 0,
+                    info,
+                }),
+            );
+    }
+
+    pub fn handle_vsync(&mut self, timestamp_raw: u64) {
+        #[derive(Debug, Clone)]
+        pub struct VSyncMarker;
+
+        impl ProfilerMarker for VSyncMarker {
+            const MARKER_TYPE_NAME: &'static str = "Vsync";
+
+            fn json_marker_data(&self) -> Value {
+                json!({
+                    "type": Self::MARKER_TYPE_NAME,
+                    "name": ""
+                })
+            }
+
+            fn schema() -> MarkerSchema {
+                MarkerSchema {
+                    type_name: Self::MARKER_TYPE_NAME,
+                    locations: vec![
+                        MarkerLocation::MarkerChart,
+                        MarkerLocation::MarkerTable,
+                        MarkerLocation::TimelineOverview,
+                    ],
+                    chart_label: Some("{marker.data.name}"),
+                    tooltip_label: None,
+                    table_label: Some("{marker.name} - {marker.data.name}"),
+                    fields: vec![MarkerSchemaField::Dynamic(MarkerDynamicField {
+                        key: "name",
+                        label: "Details",
+                        format: MarkerFieldFormat::String,
+                        searchable: false,
+                    })],
+                }
+            }
+        }
+
+        let gpu_thread = self.gpu_thread_handle.get_or_insert_with(|| {
+            let start_timestamp = Timestamp::from_nanos_since_reference(0);
+            let gpu = self
+                .profile
+                .borrow_mut()
+                .add_process("GPU", 1, start_timestamp);
+            self.profile
+                .borrow_mut()
+                .add_thread(gpu, 1, start_timestamp, false)
+        });
+        let timestamp = self.timestamp_converter.convert_time(timestamp_raw);
+        self.profile.borrow_mut().add_marker(
+            *gpu_thread,
+            CategoryHandle::OTHER,
+            "Vsync",
+            VSyncMarker {},
+            MarkerTiming::Instant(timestamp),
+        );
+    }
+
+    pub fn handle_cswitch(&mut self, timestamp_raw: u64, old_tid: u32, new_tid: u32) {
+        // println!("CSwitch {} -> {} @ {} on {}", old_tid, old_tid, e.EventHeader.TimeStamp, unsafe { e.BufferContext.Anonymous.ProcessorIndex });
+
+        if let Some(mut old_thread) = self.get_thread_mut(old_tid) {
+            self.context_switch_handler
+                .borrow_mut()
+                .handle_switch_out(timestamp_raw, &mut old_thread.context_switch_data);
+        }
+        if let Some(mut new_thread) = self.get_thread_mut(old_tid) {
+            let off_cpu_sample_group = self
+                .context_switch_handler
+                .borrow_mut()
+                .handle_switch_in(timestamp_raw, &mut new_thread.context_switch_data);
+            if let Some(off_cpu_sample_group) = off_cpu_sample_group {
+                new_thread.pending_stacks.push_back(PendingStack {
+                    timestamp: timestamp_raw,
+                    kernel_stack: None,
+                    off_cpu_sample_group: Some(off_cpu_sample_group),
+                    on_cpu_sample_cpu_delta: None,
+                });
+            }
+        }
+    }
+
+    pub fn handle_js_method_load(
+        &mut self,
+        timestamp_raw: u64,
+        pid: u32,
+        method_name: String,
+        method_start_address: u64,
+        method_size: u64,
+    ) {
+        if !self.is_interesting_process(pid, None, None) && pid != 0 {
+            return;
+        }
+
+        self.ensure_process_jit_info(pid);
+        let Some(process) = self.get_process_mut(pid) else {
+            return;
+        };
+        let mut process_jit_info = self.get_process_jit_info(pid);
+
+        let timestamp = self.timestamp_converter.convert_time(timestamp_raw);
+        let relative_address = process_jit_info.next_relative_address;
+        process_jit_info.next_relative_address += method_size as u32;
+
+        if let Some(main_thread) = process.main_thread_handle {
+            self.profile.borrow_mut().add_marker(
+                main_thread,
+                CategoryHandle::OTHER,
+                "JitFunctionAdd",
+                JitFunctionAddMarker(method_name.to_owned()),
+                MarkerTiming::Instant(timestamp),
+            );
+        }
+
+        let (category, js_frame) = self
+            .js_category_manager
+            .borrow_mut()
+            .classify_jit_symbol(&method_name, &mut self.profile.borrow_mut());
+        let info =
+            LibMappingInfo::new_jit_function(process_jit_info.lib_handle, category, js_frame);
+        process_jit_info.jit_mapping_ops.push(
+            timestamp_raw,
+            LibMappingOp::Add(LibMappingAdd {
+                start_avma: method_start_address,
+                end_avma: method_start_address + method_size,
+                relative_address_at_start: relative_address,
+                info,
+            }),
+        );
+        process_jit_info.symbols.push(Symbol {
+            address: relative_address,
+            size: Some(method_size as u32),
+            name: method_name,
+        });
+    }
+
+    pub fn handle_freeform_marker_start(
+        &mut self,
+        timestamp_raw: u64,
+        tid: u32,
+        name: &str,
+        stringified_properties: String,
+    ) {
+        let Some(mut thread) = self.get_thread_mut(tid) else {
+            return;
+        };
+        let timestamp = self.timestamp_converter.convert_time(timestamp_raw);
+        thread.pending_markers.insert(
+            name.to_owned(),
+            PendingMarker {
+                text: stringified_properties,
+                start: timestamp,
+            },
+        );
+    }
+
+    pub fn handle_freeform_marker_end(
+        &mut self,
+        timestamp_raw: u64,
+        tid: u32,
+        name: &str,
+        stringified_properties: String,
+        known_category: KnownCategory,
+    ) {
+        let Some(mut thread) = self.get_thread_mut(tid) else {
+            return;
+        };
+
+        let timestamp = self.timestamp_converter.convert_time(timestamp_raw);
+
+        // Combine the start and end markers into a single marker.
+        // Alternatively, we could output the start marker with IntervalStart, however this has one big drawback:
+        // The text stored in the start marker would not be available in the UI!
+        // The Firefox Profiler combines IntervalStart and IntervalEnd marker into a single marker
+        // whose data is taken only from the *end* marker.
+        // So here we manually merge them, taking the data from the *start* marker.
+        let (timing, text) = if let Some(pending) = thread.pending_markers.remove(name) {
+            (
+                MarkerTiming::Interval(pending.start, timestamp),
+                pending.text,
+            )
+        } else {
+            (MarkerTiming::IntervalEnd(timestamp), stringified_properties)
+        };
+
+        let category = self.get_category(known_category);
+        self.profile.borrow_mut().add_marker(
+            thread.handle,
+            category,
+            name.split_once('/').unwrap().1,
+            SimpleMarker(text),
+            timing,
+        );
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn handle_firefox_marker(
+        &mut self,
+        tid: u32,
+        marker_name: &str,
+        start_time_qpc: u64,
+        end_time_qpc: u64,
+        phase: Option<u8>,
+        maybe_user_timing_name: Option<String>,
+        maybe_explicit_marker_name: Option<String>,
+        text: String,
+    ) {
+        let Some(thread) = self.get_thread(tid) else {
+            return;
+        };
+
+        assert!(self.event_timestamps_are_qpc, "Inconsistent timestamp formats! ETW traces with Firefox events should be captured with QPC timestamps (-ClockType PerfCounter) so that ETW sample timestamps are compatible with the QPC timestamps in Firefox ETW trace events, so that the markers appear in the right place.");
+        let (phase, instant_time_qpc): (u8, u64) = match phase {
+            Some(phase) => (phase, start_time_qpc),
+            None => {
+                // Before the landing of https://bugzilla.mozilla.org/show_bug.cgi?id=1882640 ,
+                // Firefox ETW trace events didn't have phase information, so we need to
+                // guess a phase based on the timestamps.
+                if start_time_qpc != 0 && end_time_qpc != 0 {
+                    (PHASE_INTERVAL, 0)
+                } else if start_time_qpc != 0 {
+                    (PHASE_INSTANT, start_time_qpc)
+                } else {
+                    (PHASE_INSTANT, end_time_qpc)
+                }
+            }
+        };
+        let timing = match phase {
+            PHASE_INSTANT => {
+                MarkerTiming::Instant(self.timestamp_converter.convert_time(instant_time_qpc))
+            }
+            PHASE_INTERVAL => MarkerTiming::Interval(
+                self.timestamp_converter.convert_time(start_time_qpc),
+                self.timestamp_converter.convert_time(end_time_qpc),
+            ),
+            PHASE_INTERVAL_START => {
+                MarkerTiming::IntervalStart(self.timestamp_converter.convert_time(start_time_qpc))
+            }
+            PHASE_INTERVAL_END => {
+                MarkerTiming::IntervalEnd(self.timestamp_converter.convert_time(end_time_qpc))
+            }
+            _ => panic!("Unexpected marker phase {phase}"),
+        };
+
+        if marker_name == "UserTiming" {
+            let name = maybe_user_timing_name.unwrap();
+            self.profile.borrow_mut().add_marker(
+                thread.handle,
+                CategoryHandle::OTHER,
+                "UserTiming",
+                UserTimingMarker(name),
+                timing,
+            );
+        } else if marker_name == "SimpleMarker" || marker_name == "Text" || marker_name == "tracing"
+        {
+            let marker_name = maybe_explicit_marker_name.unwrap();
+            self.profile.borrow_mut().add_marker(
+                thread.handle,
+                CategoryHandle::OTHER,
+                &marker_name,
+                SimpleMarker(text.clone()),
+                timing,
+            );
+        } else {
+            self.profile.borrow_mut().add_marker(
+                thread.handle,
+                CategoryHandle::OTHER,
+                marker_name,
+                SimpleMarker(text.clone()),
+                timing,
+            );
+        }
+    }
+
+    pub fn handle_chrome_marker(
+        &mut self,
+        tid: u32,
+        marker_name: &str,
+        timestamp_raw: u64,
+        phase: &str,
+        keyword_bitfield: u64,
+        text: String,
+    ) {
+        let Some(thread) = self.get_thread(tid) else {
+            return;
+        };
+
+        let timestamp = self.timestamp_converter.convert_us(timestamp_raw);
+
+        let timing = match phase {
+            "Begin" => MarkerTiming::IntervalStart(timestamp),
+            "End" => MarkerTiming::IntervalEnd(timestamp),
+            _ => MarkerTiming::Instant(timestamp),
+        };
+        let keyword = KeywordNames::from_bits(keyword_bitfield).unwrap();
+        if keyword == KeywordNames::blink_user_timing {
+            self.profile.borrow_mut().add_marker(
+                thread.handle,
+                CategoryHandle::OTHER,
+                "UserTiming",
+                UserTimingMarker(marker_name.to_owned()),
+                timing,
+            );
+        } else {
+            self.profile.borrow_mut().add_marker(
+                thread.handle,
+                CategoryHandle::OTHER,
+                marker_name,
+                SimpleMarker(text.clone()),
+                timing,
+            );
+        }
+    }
+    pub fn handle_unknown_event(
+        &mut self,
+        timestamp_raw: u64,
+        tid: u32,
+        task_and_op: &str,
+        stringified_properties: String,
+    ) {
+        let Some(thread) = self.get_thread(tid) else {
+            return;
+        };
+
+        let timestamp = self.timestamp_converter.convert_us(timestamp_raw);
+        let timing = MarkerTiming::Instant(timestamp);
+        // this used to create a new category based on provider_name, just lump them together for now
+        let category = self.get_category(KnownCategory::Unknown);
+        self.profile.borrow_mut().add_marker(
+            thread.handle,
+            category,
+            task_and_op,
+            SimpleMarker(stringified_properties),
+            timing,
+        );
+        //println!("unhandled {}", s.name())
+    }
+
+    pub fn finish(mut self) -> Profile {
+        // Push queued samples into the profile.
+        // We queue them so that we can get symbolicated JIT function names. To get symbolicated JIT function names,
+        // we have to call profile.add_sample after we call profile.set_lib_symbol_table, and we don't have the
+        // complete JIT symbol table before we've seen all JIT symbols.
+        // (This is a rather weak justification. The better justification is that this is consistent with what
+        // samply does on Linux and macOS, where the queued samples also want to respect JIT function names from
+        // a /tmp/perf-1234.map file, and this file may not exist until the profiled process finishes.)
+        let mut stack_frame_scratch_buf = Vec::new();
+        for (process_id, process) in self.processes.iter() {
+            let process = process.borrow_mut();
+            let jitdump_lib_mapping_op_queues = match self.process_jit_infos.remove(process_id) {
+                Some(jit_info) => {
+                    let jit_info = jit_info.into_inner();
+                    self.profile.borrow_mut().set_lib_symbol_table(
+                        jit_info.lib_handle,
+                        Arc::new(SymbolTable::new(jit_info.symbols)),
+                    );
+                    vec![jit_info.jit_mapping_ops]
+                }
+                None => Vec::new(),
+            };
+
+            let process_sample_data = ProcessSampleData::new(
+                process.unresolved_samples.clone(),
+                process.regular_lib_mapping_ops.clone(),
+                jitdump_lib_mapping_op_queues,
+                None,
+                Vec::new(),
+            );
+            //main_thread_handle.unwrap_or_else(|| panic!("process no main thread {:?}", process_id)));
+            let user_category = self.get_category(KnownCategory::User).into();
+            let kernel_category = self.get_category(KnownCategory::Kernel).into();
+            process_sample_data.flush_samples_to_profile(
+                &mut self.profile.borrow_mut(),
+                user_category,
+                kernel_category,
+                &mut stack_frame_scratch_buf,
+                &self.unresolved_stacks.borrow(),
+            )
+        }
+
+        /*if merge_threads {
+            profile.add_thread(global_thread);
+        } else {
+            for (_, thread) in threads.drain() { profile.add_thread(thread.builder); }
+        }*/
+
+        log::info!(
+            "{} events, {} samples, {} stack-samples",
+            self.event_count,
+            self.sample_count,
+            self.stack_sample_count
+        );
+
+        self.profile.into_inner()
     }
 }
 

--- a/samply/src/windows/profiler.rs
+++ b/samply/src/windows/profiler.rs
@@ -148,6 +148,7 @@ pub fn start_recording(
 
     let mut context = ProfileContext::new(profile, &arch, included_processes);
     etw_gecko::profile_pid_from_etl_file(&mut context, &merged_etl);
+    let profile = context.finish();
 
     // delete etl_file
     std::fs::remove_file(&merged_etl).unwrap_or_else(|_| {
@@ -161,8 +162,7 @@ pub fn start_recording(
     let file = File::create(&output_file).unwrap();
     let writer = BufWriter::new(file);
     {
-        let profile = context.profile.borrow();
-        to_writer(writer, &*profile).expect("Couldn't write JSON");
+        to_writer(writer, &profile).expect("Couldn't write JSON");
     }
 
     // then fire up the server for the profiler front end, if not save-only


### PR DESCRIPTION
This PR makes it so that all ProfileContext state mutation happens through ProfileContext methods. This lets us remove many RefCells.

Not super well-tested but I figured I'd rather land it early so that we can find and fix the regressions together.