### PR TITLE
Don't add markers for unknown ETW events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 target
 profile.json
+profile.syms.json
 .DS_Store
 .direnv/
 

--- a/samply/src/main.rs
+++ b/samply/src/main.rs
@@ -273,6 +273,11 @@ pub struct ProfileCreationArgs {
     /// in the profile.json, instead of a sidecar file.)
     #[arg(long)]
     unstable_presymbolicate: bool,
+
+    /// Emit markers for any unknown ETW events that are encountered.
+    #[cfg(target_os = "windows")]
+    #[arg(long)]
+    unknown_event_markers: bool,
 }
 
 #[derive(Debug, Args)]
@@ -413,6 +418,7 @@ impl ImportArgs {
             override_arch: self.override_arch.clone(),
             unstable_presymbolicate: self.profile_creation_args.unstable_presymbolicate,
             coreclr: to_coreclr_profile_props(&self.coreclr),
+            unknown_event_markers: self.profile_creation_args.unknown_event_markers,
         }
     }
 
@@ -518,6 +524,7 @@ impl RecordArgs {
             override_arch: None,
             unstable_presymbolicate: self.profile_creation_args.unstable_presymbolicate,
             coreclr: to_coreclr_profile_props(&self.coreclr),
+            unknown_event_markers: self.profile_creation_args.unknown_event_markers,
         }
     }
 }

--- a/samply/src/main.rs
+++ b/samply/src/main.rs
@@ -418,7 +418,10 @@ impl ImportArgs {
             override_arch: self.override_arch.clone(),
             unstable_presymbolicate: self.profile_creation_args.unstable_presymbolicate,
             coreclr: to_coreclr_profile_props(&self.coreclr),
+            #[cfg(target_os = "windows")]
             unknown_event_markers: self.profile_creation_args.unknown_event_markers,
+            #[cfg(not(target_os = "windows"))]
+            unknown_event_markers: false,
         }
     }
 
@@ -524,7 +527,10 @@ impl RecordArgs {
             override_arch: None,
             unstable_presymbolicate: self.profile_creation_args.unstable_presymbolicate,
             coreclr: to_coreclr_profile_props(&self.coreclr),
+            #[cfg(target_os = "windows")]
             unknown_event_markers: self.profile_creation_args.unknown_event_markers,
+            #[cfg(not(target_os = "windows"))]
+            unknown_event_markers: false,
         }
     }
 }

--- a/samply/src/shared/recording_props.rs
+++ b/samply/src/shared/recording_props.rs
@@ -77,6 +77,8 @@ pub struct ProfileCreationProps {
     pub unstable_presymbolicate: bool,
     /// CoreCLR specific properties.
     pub coreclr: CoreClrProfileProps,
+    /// Create markers for unknown events.
+    pub unknown_event_markers: bool,
 }
 
 /// Properties which are meaningful for launching and recording a fresh process.

--- a/samply/src/windows/coreclr.rs
+++ b/samply/src/windows/coreclr.rs
@@ -28,6 +28,7 @@ pub struct CoreClrContext {
     props: CoreClrProfileProps,
     last_marker_on_thread: HashMap<u32, MarkerHandle>,
     gc_markers_on_thread: HashMap<u32, HashMap<&'static str, SavedMarkerInfo>>,
+    unknown_event_markers: bool,
 }
 
 impl CoreClrContext {
@@ -36,6 +37,7 @@ impl CoreClrContext {
             props: profile_creation_props.coreclr,
             last_marker_on_thread: HashMap::new(),
             gc_markers_on_thread: HashMap::new(),
+            unknown_event_markers: profile_creation_props.unknown_event_markers,
         }
     }
 
@@ -382,8 +384,6 @@ pub fn handle_coreclr_event(
     s: &TypedEvent,
     parser: &mut Parser,
 ) {
-    let show_unknown_events = false;
-
     let (gc_markers, gc_suspensions, gc_allocs, event_stacks) = (
         coreclr_context.props.gc_markers,
         coreclr_context.props.gc_suspensions,
@@ -717,7 +717,7 @@ pub fn handle_coreclr_event(
         _ => {}
     }
 
-    if !handled && show_unknown_events {
+    if !handled && coreclr_context.unknown_event_markers {
         let text = event_properties_to_string(s, parser, None);
         let marker_handle = context.add_thread_instant_marker(
             timestamp_raw,

--- a/samply/src/windows/etw_gecko.rs
+++ b/samply/src/windows/etw_gecko.rs
@@ -112,6 +112,9 @@ pub fn profile_pid_from_etl_file(context: &mut ProfileContext, etl_file: &Path) 
                 let pid: u32 = parser.parse("ProcessId");
                 context.handle_process_dcend(timestamp_raw, pid);
             }
+            "MSNT_SystemTrace/Process/Terminate" => {
+                // nothing, but we don't want a marker for it
+            }
             "MSNT_SystemTrace/StackWalk/Stack" => {
                 let tid: u32 = parser.parse("StackThread");
                 let pid: u32 = parser.parse("StackProcess");
@@ -205,6 +208,9 @@ pub fn profile_pid_from_etl_file(context: &mut ProfileContext, etl_file: &Path) 
                 let image_size: u64 = parser.try_parse("ImageSize").unwrap();
                 let path: String = parser.try_parse("FileName").unwrap();
                 context.handle_image_load(timestamp_raw, pid, image_base, image_size, path);
+            }
+            "MSNT_SystemTrace/Image/UnLoad" => {
+                // nothing, but we don't want a marker for it
             }
             "Microsoft-Windows-DxgKrnl/VSyncDPC/Info " => {
                 context.handle_vsync(timestamp_raw);

--- a/samply/src/windows/profile_context.rs
+++ b/samply/src/windows/profile_context.rs
@@ -1664,6 +1664,10 @@ impl ProfileContext {
         task_and_op: &str,
         stringified_properties: String,
     ) {
+        if !self.profile_creation_props.unknown_event_markers {
+            return;
+        }
+
         let Some(thread) = self.threads.get_mut(&tid) else {
             return;
         };


### PR DESCRIPTION
These are useful for debugging and might be a nice command line option in the future, but for now they just add random `Image/UnLoad` and `Process/Terminated` events which aren't useful
