### PR TITLE
Make CoreCLR markers optional due to large size

### DIFF
--- a/samply/src/linux/profiler.rs
+++ b/samply/src/linux/profiler.rs
@@ -65,7 +65,7 @@ pub fn start_recording(
         iteration_count,
     } = process_launch_props;
 
-    if recording_props.coreclr {
+    if profile_creation_props.coreclr.any_enabled() {
         // We need to set DOTNET_PerfMapEnabled=2 in the environment if it's not already set.
         // TODO: implement unlink_aux_files for linux
         if !env_vars.iter().any(|p| p.0 == "DOTNET_PerfMapEnabled") {

--- a/samply/src/mac/profiler.rs
+++ b/samply/src/mac/profiler.rs
@@ -56,7 +56,7 @@ pub fn start_recording(
                 iteration_count,
             } = process_launch_props;
 
-            if recording_props.coreclr {
+            if profile_creation_props.coreclr.any_enabled() {
                 // We need to set DOTNET_PerfMapEnabled=2 in the environment if it's not already set.
                 // If we set it, we'll also set unlink_aux_files=true to avoid leaving files
                 // behind in the temp directory. But if it's set manually, assume the user

--- a/samply/src/main.rs
+++ b/samply/src/main.rs
@@ -19,7 +19,7 @@ use std::io::{BufReader, BufWriter};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-use clap::{Args, Parser, Subcommand};
+use clap::{Args, Parser, Subcommand, ValueEnum};
 #[cfg(any(target_os = "android", target_os = "linux"))]
 use linux::profiler;
 #[cfg(target_os = "macos")]
@@ -31,7 +31,7 @@ use profile_json_preparse::parse_libinfo_map_from_profile_file;
 use server::{start_server_main, PortSelection, ServerProps};
 use shared::included_processes::IncludedProcesses;
 use shared::recording_props::{
-    ProcessLaunchProps, ProfileCreationProps, RecordingMode, RecordingProps,
+    CoreClrProfileProps, ProcessLaunchProps, ProfileCreationProps, RecordingMode, RecordingProps,
 };
 #[cfg(target_os = "windows")]
 use windows::profiler;
@@ -132,6 +132,10 @@ struct ImportArgs {
     /// Explicitly specify architecture of profile to import.
     #[arg(long)]
     override_arch: Option<String>,
+
+    /// Enable CoreCLR event conversion.
+    #[clap(long, require_equals = true, value_name = "FLAG", value_enum, value_delimiter = ',', num_args = 0.., default_values_t = vec![CoreClrArgs::Enabled])]
+    coreclr: Vec<CoreClrArgs>,
 }
 
 #[allow(unused)]
@@ -186,13 +190,8 @@ struct RecordArgs {
     all: bool,
 
     /// Enable CoreCLR event capture.
-    #[arg(long)]
-    coreclr: bool,
-
-    /// Enable CoreCLR fine-grained allocation event capture (Windows only).
-    #[cfg(target_os = "windows")]
-    #[arg(long)]
-    coreclr_allocs: bool,
+    #[clap(long, require_equals = true, value_name = "FLAG", value_enum, value_delimiter = ',', num_args = 0.., default_missing_value = "enabled")]
+    coreclr: Vec<CoreClrArgs>,
 
     /// VM hack for arm64 Windows VMs to not try to record PROFILE events (Windows only).
     #[cfg(target_os = "windows")]
@@ -202,6 +201,28 @@ struct RecordArgs {
     /// Enable Graphics-related event capture.
     #[arg(long)]
     gfx: bool,
+}
+
+#[derive(ValueEnum, Copy, Clone, Debug, PartialEq, Eq)]
+enum CoreClrArgs {
+    Enabled,
+    #[cfg(target_os = "windows")]
+    GcMarkers,
+    #[cfg(target_os = "windows")]
+    GcSuspendedThreads,
+    #[cfg(target_os = "windows")]
+    GcDetailedAllocs,
+    #[cfg(target_os = "windows")]
+    EventStacks,
+}
+
+impl std::fmt::Display for CoreClrArgs {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.to_possible_value()
+            .expect("no values are skipped")
+            .get_name()
+            .fmt(f)
+    }
 }
 
 #[derive(Debug, Args)]
@@ -391,6 +412,7 @@ impl ImportArgs {
             create_per_cpu_threads: self.profile_creation_args.per_cpu_threads,
             override_arch: self.override_arch.clone(),
             unstable_presymbolicate: self.profile_creation_args.unstable_presymbolicate,
+            coreclr: to_coreclr_profile_props(&self.coreclr),
         }
     }
 
@@ -428,18 +450,17 @@ impl RecordArgs {
         let interval = Duration::from_secs_f64(1.0 / self.rate);
         cfg_if::cfg_if! {
             if #[cfg(target_os = "windows")] {
-                let (vm_hack, coreclr_allocs) = (self.vm_hack, self.coreclr_allocs);
+                let vm_hack = self.vm_hack;
             } else {
-                let (vm_hack, coreclr_allocs) = (false, false);
+                let vm_hack = false;
             }
         }
+
         RecordingProps {
             output_file: self.output.clone(),
             time_limit,
             interval,
             main_thread_only: self.main_thread_only,
-            coreclr: self.coreclr,
-            coreclr_allocs,
             vm_hack,
             gfx: self.gfx,
         }
@@ -496,6 +517,7 @@ impl RecordArgs {
             create_per_cpu_threads: self.profile_creation_args.per_cpu_threads,
             override_arch: None,
             unstable_presymbolicate: self.profile_creation_args.unstable_presymbolicate,
+            coreclr: to_coreclr_profile_props(&self.coreclr),
         }
     }
 }
@@ -518,6 +540,23 @@ impl ServerArgs {
             verbose: self.verbose,
             open_in_browser,
         }
+    }
+}
+
+fn to_coreclr_profile_props(coreclr_args: &[CoreClrArgs]) -> CoreClrProfileProps {
+    // on Windows, the ..Default::default() has no effect, and clippy doesn't like it
+    #[allow(clippy::needless_update)]
+    CoreClrProfileProps {
+        enabled: coreclr_args.contains(&CoreClrArgs::Enabled),
+        #[cfg(target_os = "windows")]
+        gc_markers: coreclr_args.contains(&CoreClrArgs::GcMarkers),
+        #[cfg(target_os = "windows")]
+        gc_suspensions: coreclr_args.contains(&CoreClrArgs::GcSuspendedThreads),
+        #[cfg(target_os = "windows")]
+        gc_detailed_allocs: coreclr_args.contains(&CoreClrArgs::GcDetailedAllocs),
+        #[cfg(target_os = "windows")]
+        event_stacks: coreclr_args.contains(&CoreClrArgs::EventStacks),
+        ..Default::default()
     }
 }
 

--- a/samply/src/shared/recording_props.rs
+++ b/samply/src/shared/recording_props.rs
@@ -2,6 +2,27 @@ use std::ffi::OsString;
 use std::path::PathBuf;
 use std::time::Duration;
 
+use serde_derive::{Deserialize, Serialize};
+
+#[derive(Debug, Default, Clone, Copy, Serialize, Deserialize)]
+pub struct CoreClrProfileProps {
+    pub enabled: bool,
+    pub gc_markers: bool,
+    pub gc_suspensions: bool,
+    pub gc_detailed_allocs: bool,
+    pub event_stacks: bool,
+}
+
+impl CoreClrProfileProps {
+    pub fn any_enabled(&self) -> bool {
+        self.enabled
+            || self.gc_markers
+            || self.gc_suspensions
+            || self.gc_detailed_allocs
+            || self.event_stacks
+    }
+}
+
 /// Properties which are meaningful both for recording a fresh process
 /// as well as for recording an existing process.
 #[derive(Debug, Clone)]
@@ -10,8 +31,6 @@ pub struct RecordingProps {
     pub time_limit: Option<Duration>,
     pub interval: Duration,
     pub main_thread_only: bool,
-    pub coreclr: bool,
-    pub coreclr_allocs: bool,
     pub vm_hack: bool,
     pub gfx: bool,
 }
@@ -56,6 +75,8 @@ pub struct ProfileCreationProps {
     pub override_arch: Option<String>,
     /// Dump presymbolication info.
     pub unstable_presymbolicate: bool,
+    /// CoreCLR specific properties.
+    pub coreclr: CoreClrProfileProps,
 }
 
 /// Properties which are meaningful for launching and recording a fresh process.

--- a/samply/src/windows/etw_gecko.rs
+++ b/samply/src/windows/etw_gecko.rs
@@ -25,7 +25,7 @@ pub fn profile_pid_from_etl_file(context: &mut ProfileContext, etl_file: &Path) 
 
     let demand_zero_faults = false; //pargs.contains("--demand-zero-faults");
 
-    let mut core_clr_context = coreclr::CoreClrContext::new();
+    let mut core_clr_context = coreclr::CoreClrContext::new(context.creation_props());
 
     let result = open_trace(etl_file, |e| {
         let Ok(s) = schema_locator.event_schema(e) else {

--- a/samply/src/windows/profile_context.rs
+++ b/samply/src/windows/profile_context.rs
@@ -222,6 +222,8 @@ impl AddressClassifier {
 pub struct ProfileContext {
     profile: Profile,
 
+    profile_creation_props: ProfileCreationProps,
+
     // state -- keep track of the processes etc we've seen as we're processing,
     // and their associated handles in the json profile
     processes: HashMap<u32, ProcessState>,
@@ -295,6 +297,7 @@ impl ProfileContext {
 
         Self {
             profile,
+            profile_creation_props,
             processes: HashMap::new(),
             dead_processes_with_reused_pids: Vec::new(),
             threads: HashMap::new(),
@@ -322,6 +325,10 @@ impl ProfileContext {
             },
             event_timestamps_are_qpc: false,
         }
+    }
+
+    pub fn creation_props(&self) -> ProfileCreationProps {
+        self.profile_creation_props.clone()
     }
 
     pub fn is_arm64(&self) -> bool {

--- a/samply/src/windows/profiler.rs
+++ b/samply/src/windows/profiler.rs
@@ -66,7 +66,7 @@ pub fn start_recording(
     let mut elevated_helper = ElevatedHelperSession::new(recording_props.output_file.clone())
         .unwrap_or_else(|e| panic!("Couldn't start elevated helper process: {e:?}"));
     elevated_helper
-        .start_xperf(&recording_props, &recording_mode)
+        .start_xperf(&recording_props, &profile_creation_props, &recording_mode)
         .unwrap();
 
     let included_processes = match recording_mode {
@@ -140,7 +140,7 @@ pub fn start_recording(
 
     eprintln!("Processing ETL trace...");
 
-    let output_file = recording_props.output_file;
+    let output_file = recording_props.output_file.clone();
 
     let arch = profile_creation_props
         .override_arch


### PR DESCRIPTION
Given how markers are written in the profile.json, CoreCLR GC markers generate a _lot_ of data, especially when there are a lot of CoreCLR processes flying around. This PR adds some more fine-grained controls of what to capture and generate.

The reason this is in `ProfileCreationProps` and not in `RecordingProps` is because it influences conversion from an existing .etl file as well -- we may have an .etl file with full GC info, but we don't want to include it in the `profile.json`. But if we're recording, we can tell `xperf` to just not include these events at all.
