### PR TITLE
Add a --browsers flag to samply record

### DIFF
--- a/samply/src/main.rs
+++ b/samply/src/main.rs
@@ -196,6 +196,10 @@ struct RecordArgs {
     /// Enable Graphics-related event capture.
     #[arg(long)]
     gfx: bool,
+
+    /// Enable browser-related event capture (JavaScript stacks and trace events)
+    #[arg(long)]
+    browsers: bool,
 }
 
 #[derive(ValueEnum, Copy, Clone, Debug, PartialEq, Eq)]
@@ -472,6 +476,7 @@ impl RecordArgs {
             interval,
             vm_hack,
             gfx: self.gfx,
+            browsers: self.browsers,
         }
     }
 

--- a/samply/src/shared/recording_props.rs
+++ b/samply/src/shared/recording_props.rs
@@ -32,6 +32,7 @@ pub struct RecordingProps {
     pub interval: Duration,
     pub vm_hack: bool,
     pub gfx: bool,
+    pub browsers: bool,
 }
 
 /// Which process(es) to record.

--- a/samply/src/windows/chrome.rs
+++ b/samply/src/windows/chrome.rs
@@ -1,5 +1,10 @@
 use bitflags::bitflags;
 
+use super::elevated_helper::ElevatedRecordingProps;
+
+// https://source.chromium.org/chromium/chromium/src/+/main:third_party/win_build_output/mc/base/trace_event/etw_manifest/chrome_events_win.h;l=622-623;drc=a9274264bd203626a6530bebae3e7d4eae12c733
+pub const CHROME_PROVIDER_GUID: &str = "d2d578d9-2936-45b6-a09f-30e32715f42d";
+
 bitflags! {
     // https://source.chromium.org/chromium/chromium/src/+/main:base/trace_event/trace_event_etw_export_win.cc;l=103;drc=8c29f4a8930c3ccccdf1b66c28fe484cee7c7362
     #[derive(PartialEq, Eq)]
@@ -53,4 +58,25 @@ bitflags! {
         const __OTHER_EVENTS = 0x400000000000;
         const __DISABLED_OTHER_EVENTS = 0x800000000000;
     }
+}
+
+pub fn chrome_xperf_args(props: &ElevatedRecordingProps) -> Vec<String> {
+    let mut providers = vec![];
+
+    if !props.browsers {
+        return providers;
+    }
+
+    // JIT symbols
+    providers.push("Microsoft-JScript:0x3".to_string());
+
+    // UserTiming trace events
+    let enabled_keywords = KeywordNames::blink_user_timing;
+    providers.push(format!(
+        "{}:{:#x}",
+        CHROME_PROVIDER_GUID,
+        enabled_keywords.bits()
+    ));
+
+    providers
 }

--- a/samply/src/windows/elevated_helper.rs
+++ b/samply/src/windows/elevated_helper.rs
@@ -28,6 +28,7 @@ pub struct ElevatedRecordingProps {
     pub vm_hack: bool,
     pub is_attach: bool,
     pub gfx: bool,
+    pub browsers: bool,
 }
 
 impl ElevatedRecordingProps {
@@ -43,6 +44,7 @@ impl ElevatedRecordingProps {
             vm_hack: recording_props.vm_hack,
             is_attach: recording_mode.is_attach_mode(),
             gfx: recording_props.gfx,
+            browsers: recording_props.browsers,
         }
     }
 }

--- a/samply/src/windows/firefox.rs
+++ b/samply/src/windows/firefox.rs
@@ -1,0 +1,43 @@
+use bitflags::bitflags;
+
+use super::elevated_helper::ElevatedRecordingProps;
+
+// From https://searchfox.org/mozilla-central/rev/0e7394a77cdbe1df5e04a1d4171d6da67b57fa17/mozglue/baseprofiler/public/BaseProfilerMarkersPrerequisites.h#355-360
+pub const PHASE_INSTANT: u8 = 0;
+pub const PHASE_INTERVAL: u8 = 1;
+pub const PHASE_INTERVAL_START: u8 = 2;
+pub const PHASE_INTERVAL_END: u8 = 3;
+
+/// The Firefox provider GUID, which is a hash of the string "Mozilla.FirefoxTraceLogger".
+/// https://searchfox.org/mozilla-central/rev/010ccb86d48fa23b2874d1a7cbe6957ec78538c3/tools/profiler/core/ETWTools.cpp#14-32
+pub const FIREFOX_PROVIDER_GUID: &str = "c923f508-96e4-5515-e32c-7539d1b10504";
+
+bitflags! {
+    // https://searchfox.org/mozilla-central/rev/010ccb86d48fa23b2874d1a7cbe6957ec78538c3/mozglue/baseprofiler/public/BaseProfilerMarkersPrerequisites.h#779-790
+    #[derive(PartialEq, Eq)]
+    pub struct EtwMarkerGroup: u64 {
+        const Generic = 1;
+        const UserMarkers = 1 << 1;
+        const Memory = 1 << 2;
+        const Scheduling = 1 << 3;
+        const Text = 1 << 4;
+        const Tracing = 1 << 5;
+    }
+}
+
+pub fn firefox_xperf_args(props: &ElevatedRecordingProps) -> Vec<String> {
+    let mut providers = vec![];
+
+    if !props.browsers {
+        return providers;
+    }
+
+    // JIT symbols
+    providers.push("Microsoft-JScript:0x3".to_string());
+
+    // UserTiming + GC markers
+    let bits = (EtwMarkerGroup::UserMarkers | EtwMarkerGroup::Memory).bits();
+    providers.push(format!("{}:{:#x}", FIREFOX_PROVIDER_GUID, bits));
+
+    providers
+}

--- a/samply/src/windows/firefox_etw_flags.rs
+++ b/samply/src/windows/firefox_etw_flags.rs
@@ -1,5 +1,0 @@
-// From https://searchfox.org/mozilla-central/rev/0e7394a77cdbe1df5e04a1d4171d6da67b57fa17/mozglue/baseprofiler/public/BaseProfilerMarkersPrerequisites.h#355-360
-pub const PHASE_INSTANT: u8 = 0;
-pub const PHASE_INTERVAL: u8 = 1;
-pub const PHASE_INTERVAL_START: u8 = 2;
-pub const PHASE_INTERVAL_END: u8 = 3;

--- a/samply/src/windows/mod.rs
+++ b/samply/src/windows/mod.rs
@@ -1,9 +1,9 @@
-mod chrome_etw_flags;
+mod chrome;
 mod console;
 mod coreclr;
 mod elevated_helper;
 mod etw_gecko;
-mod firefox_etw_flags;
+mod firefox;
 mod gfx;
 pub mod import;
 mod profile_context;

--- a/samply/src/windows/profile_context.rs
+++ b/samply/src/windows/profile_context.rs
@@ -12,7 +12,7 @@ use fxprof_processed_profile::{
 use serde_json::{json, Value};
 use uuid::Uuid;
 
-use super::chrome_etw_flags::KeywordNames;
+use super::chrome::KeywordNames;
 use super::winutils;
 use crate::shared::context_switch::{
     ContextSwitchHandler, OffCpuSampleGroup, ThreadContextSwitchData,
@@ -28,7 +28,7 @@ use crate::shared::recycling::{ProcessRecycler, ProcessRecyclingData, ThreadRecy
 use crate::shared::timestamp_converter::TimestampConverter;
 use crate::shared::types::{StackFrame, StackMode};
 use crate::shared::unresolved_samples::{UnresolvedSamples, UnresolvedStacks};
-use crate::windows::firefox_etw_flags::{
+use crate::windows::firefox::{
     PHASE_INSTANT, PHASE_INTERVAL, PHASE_INTERVAL_END, PHASE_INTERVAL_START,
 };
 

--- a/samply/src/windows/xperf.rs
+++ b/samply/src/windows/xperf.rs
@@ -59,6 +59,10 @@ impl Xperf {
 
         user_providers.append(&mut super::coreclr::coreclr_xperf_args(props));
         user_providers.append(&mut super::gfx::gfx_xperf_args(props));
+        user_providers.append(&mut super::firefox::firefox_xperf_args(props));
+        user_providers.append(&mut super::chrome::chrome_xperf_args(props));
+        user_providers.sort_unstable();
+        user_providers.dedup();
 
         let xperf_path = self.get_xperf_path()?;
         // start xperf.exe, logging to the same location as the output file, just with a .etl


### PR DESCRIPTION
This flag enables the `Microsoft-JScript` provider to get JS JIT stacks in Firefox / Chrome / Edge, and the Firefox and Chrome providers to get PerformanceUserTiming trace events.

Not sure if `--browsers` is the best name but it'll do for now. There's also no way for samply users to pick the exact flags that get passed to these providers - for now, the workaround is to use xperf manually and then do `samply import trace.etl`.