### PR TITLE
Remove unused frameTable optimizations column.

### DIFF
--- a/fxprof-processed-profile/src/frame_table.rs
+++ b/fxprof-processed-profile/src/frame_table.rs
@@ -134,7 +134,6 @@ impl<'a> Serialize for SerializableFrameTable<'a> {
         map.serialize_entry("implementation", &SerializableSingleValueColumn((), len))?;
         map.serialize_entry("line", &SerializableSingleValueColumn((), len))?;
         map.serialize_entry("column", &SerializableSingleValueColumn((), len))?;
-        map.serialize_entry("optimizations", &SerializableSingleValueColumn((), len))?;
         map.end()
     }
 }

--- a/fxprof-processed-profile/tests/integration_tests/main.rs
+++ b/fxprof-processed-profile/tests/integration_tests/main.rs
@@ -618,24 +618,6 @@ fn profile_without_js() {
                     null,
                     null,
                     null
-                  ],
-                  "optimizations": [
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null
                   ]
                 },
                 "funcTable": {
@@ -1150,10 +1132,6 @@ fn profile_with_js() {
                   "column": [
                     null,
                     null
-                  ],
-                  "optimizations": [
-                    null,
-                    null
                   ]
                 },
                 "funcTable": {
@@ -1380,8 +1358,7 @@ fn profile_counters_with_sorted_processes() {
                   "innerWindowID": [],
                   "implementation": [],
                   "line": [],
-                  "column": [],
-                  "optimizations": []
+                  "column": []
                 },
                 "funcTable": {
                   "length": 0,
@@ -1464,8 +1441,7 @@ fn profile_counters_with_sorted_processes() {
                   "innerWindowID": [],
                   "implementation": [],
                   "line": [],
-                  "column": [],
-                  "optimizations": []
+                  "column": []
                 },
                 "funcTable": {
                   "length": 0,


### PR DESCRIPTION
This column was removed in the format's version 45. We currently output version 46.

https://github.com/firefox-devtools/profiler/blob/0e34f633f0c5e4018eaae2aadab766d18c5b0bed/src/profile-logic/processed-profile-versioning.js#L2206-L2209