### PR TITLE
Add command line arguments to specify symbol paths and symbol servers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -512,6 +512,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs-next"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf36e65a80337bea855cd4ef9b8401ffce06a7baedf2e85ec467b1ac3f6e82b6"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
 name = "dirs-sys"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -521,6 +531,17 @@ dependencies = [
  "option-ext",
  "redox_users",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
 ]
 
 [[package]]
@@ -1507,6 +1528,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
+name = "platform-dirs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e188d043c1a692985f78b5464853a263f1a27e5bd6322bad3a4078ee3c998a38"
+dependencies = [
+ "dirs-next",
+]
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1877,7 +1907,6 @@ dependencies = [
  "crossbeam-channel",
  "ctrlc",
  "debugid",
- "dirs",
  "env_logger",
  "etw-reader",
  "flate2",
@@ -1908,6 +1937,7 @@ dependencies = [
  "opener",
  "parking_lot",
  "percent-encoding",
+ "platform-dirs",
  "rand",
  "rangemap",
  "runas",
@@ -2651,6 +2681,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2658,6 +2704,12 @@ checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
 dependencies = [
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"

--- a/samply-symbols/src/shared.rs
+++ b/samply-symbols/src/shared.rs
@@ -188,16 +188,19 @@ impl FromStr for CodeId {
         if s.len() <= 17 {
             // 8 bytes timestamp + 1 to 8 bytes of image size
             Ok(CodeId::PeCodeId(PeCodeId::from_str(s)?))
-        } else if s.len() == 32 {
+        } else if s.len() == 32 && is_uppercase_hex(s) {
             // mach-O UUID
             Ok(CodeId::MachoUuid(Uuid::from_str(s).map_err(|_| ())?))
-        } else if s.len() >= 34 {
+        } else {
             // ELF build ID. These are usually 40 hex characters (= 20 bytes).
             Ok(CodeId::ElfBuildId(ElfBuildId::from_str(s)?))
-        } else {
-            Err(())
         }
     }
+}
+
+fn is_uppercase_hex(s: &str) -> bool {
+    s.chars()
+        .all(|c| c.is_ascii_hexdigit() && (c.is_ascii_digit() || c.is_ascii_uppercase()))
 }
 
 impl std::fmt::Display for CodeId {

--- a/samply/Cargo.toml
+++ b/samply/Cargo.toml
@@ -41,7 +41,7 @@ nix-base32 = "0.1.1"
 serde_derive = "1.0.137"
 serde = "1.0.202"
 wholesym = { version = "0.5.0", path = "../wholesym", features = ["api"]}
-dirs = "5.0.0"
+platform-dirs = "0.3"
 once_cell = "1.17"
 fxhash = "0.2.1"
 mio = { version = "0.8.11", features = ["os-ext", "os-poll"] }

--- a/samply/src/linux/profiler.rs
+++ b/samply/src/linux/profiler.rs
@@ -29,6 +29,7 @@ use crate::shared::ctrl_c::CtrlC;
 use crate::shared::recording_props::{
     ProcessLaunchProps, ProfileCreationProps, RecordingMode, RecordingProps,
 };
+use crate::shared::symbol_props::SymbolProps;
 
 #[cfg(target_arch = "x86_64")]
 pub type ConvertRegsNative = crate::linux_shared::ConvertRegsX86_64;
@@ -40,6 +41,7 @@ pub fn start_recording(
     recording_mode: RecordingMode,
     recording_props: RecordingProps,
     profile_creation_props: ProfileCreationProps,
+    symbol_props: SymbolProps,
     server_props: Option<ServerProps>,
 ) -> Result<ExitStatus, ()> {
     let process_launch_props = match recording_mode {
@@ -50,7 +52,13 @@ pub fn start_recording(
             std::process::exit(1)
         }
         RecordingMode::Pid(pid) => {
-            start_profiling_pid(pid, recording_props, profile_creation_props, server_props);
+            start_profiling_pid(
+                pid,
+                recording_props,
+                profile_creation_props,
+                symbol_props,
+                server_props,
+            );
             return Ok(ExitStatus::from_raw(0));
         }
         RecordingMode::Launch(process_launch_props) => process_launch_props,
@@ -236,7 +244,7 @@ pub fn start_recording(
         )
         .expect("Couldn't parse libinfo map from profile file");
 
-        start_server_main(profile_filename, server_props, libinfo_map);
+        start_server_main(profile_filename, server_props, symbol_props, libinfo_map);
     }
 
     let exit_status = match wait_status {
@@ -250,6 +258,7 @@ fn start_profiling_pid(
     pid: u32,
     recording_props: RecordingProps,
     profile_creation_props: ProfileCreationProps,
+    symbol_props: SymbolProps,
     server_props: Option<ServerProps>,
 ) {
     // When the first Ctrl+C is received, stop recording.
@@ -328,7 +337,7 @@ fn start_profiling_pid(
         )
         .expect("Couldn't parse libinfo map from profile file");
 
-        start_server_main(&output_file, server_props, libinfo_map);
+        start_server_main(&output_file, server_props, symbol_props, libinfo_map);
     }
 }
 

--- a/samply/src/mac/profiler.rs
+++ b/samply/src/mac/profiler.rs
@@ -19,11 +19,13 @@ use crate::server::{start_server_main, ServerProps};
 use crate::shared::recording_props::{
     ProcessLaunchProps, ProfileCreationProps, RecordingMode, RecordingProps,
 };
+use crate::shared::symbol_props::SymbolProps;
 
 pub fn start_recording(
     recording_mode: RecordingMode,
     recording_props: RecordingProps,
     profile_creation_props: ProfileCreationProps,
+    symbol_props: SymbolProps,
     server_props: Option<ServerProps>,
 ) -> Result<ExitStatus, MachError> {
     let mut unlink_aux_files = profile_creation_props.unlink_aux_files;
@@ -225,7 +227,7 @@ pub fn start_recording(
         )
         .expect("Couldn't parse libinfo map from profile file");
 
-        start_server_main(&output_file, server_props, libinfo_map);
+        start_server_main(&output_file, server_props, symbol_props, libinfo_map);
     }
 
     Ok(exit_status)

--- a/samply/src/name.rs
+++ b/samply/src/name.rs
@@ -1,0 +1,6 @@
+/// The name to use in paths such as config file paths.
+pub const SAMPLY_NAME: &str = "samply";
+
+/// What to call samply in user-visible strings like error messages.
+#[allow(unused)]
+pub const SAMPLY_NAME_PRINT_STRING: &str = "samply";

--- a/samply/src/shared/mod.rs
+++ b/samply/src/shared/mod.rs
@@ -14,6 +14,7 @@ pub mod recycling;
 pub mod stack_converter;
 pub mod stack_depth_limiting_frame_iter;
 pub mod symbol_precog;
+pub mod symbol_props;
 pub mod timestamp_converter;
 pub mod types;
 pub mod unresolved_samples;

--- a/samply/src/shared/symbol_props.rs
+++ b/samply/src/shared/symbol_props.rs
@@ -1,0 +1,17 @@
+use std::path::PathBuf;
+
+#[derive(Debug, Clone)]
+pub struct SymbolProps {
+    /// Extra directories containing symbol files
+    pub symbol_dir: Vec<PathBuf>,
+    /// Additional URLs of symbol servers serving PDB / DLL / EXE files
+    pub windows_symbol_server: Vec<String>,
+    /// Overrides the default cache directory for Windows symbol files which were downloaded from a symbol server
+    pub windows_symbol_cache: Option<PathBuf>,
+    /// Additional URLs of symbol servers serving Breakpad .sym files
+    pub breakpad_symbol_server: Vec<String>,
+    /// Overrides the default cache directory for Breakpad symbol files
+    pub breakpad_symbol_cache: Option<PathBuf>,
+    /// Extra directory containing symbol files, with the directory structure used by simpleperf's scripts
+    pub simpleperf_binary_cache: Option<PathBuf>,
+}

--- a/samply/src/windows/profiler.rs
+++ b/samply/src/windows/profiler.rs
@@ -19,6 +19,7 @@ use crate::server::{start_server_main, ServerProps};
 use crate::shared::ctrl_c::CtrlC;
 use crate::shared::included_processes::IncludedProcesses;
 use crate::shared::recording_props::{ProfileCreationProps, RecordingMode, RecordingProps};
+use crate::shared::symbol_props::SymbolProps;
 use crate::windows::elevated_helper::{self, ElevatedHelperSession};
 
 // Hello intrepid explorer! You may be in this code because you'd like to extend something,
@@ -51,6 +52,7 @@ pub fn start_recording(
     recording_mode: RecordingMode,
     recording_props: RecordingProps,
     profile_creation_props: ProfileCreationProps,
+    symbol_props: SymbolProps,
     server_props: Option<ServerProps>,
 ) -> Result<ExitStatus, i32> {
     let timebase = std::time::SystemTime::now();
@@ -183,7 +185,7 @@ pub fn start_recording(
         )
         .expect("Couldn't parse libinfo map from profile file");
 
-        start_server_main(&output_file, server_props, libinfo_map);
+        start_server_main(&output_file, server_props, symbol_props, libinfo_map);
     }
 
     Ok(ExitStatus::from_raw(0))

--- a/wholesym/src/config.rs
+++ b/wholesym/src/config.rs
@@ -20,6 +20,8 @@ pub struct SymbolManagerConfig {
     pub(crate) use_spotlight: bool,
     pub(crate) debuginfod_cache_dir_if_not_installed: Option<PathBuf>,
     pub(crate) debuginfod_servers: Vec<(String, PathBuf)>,
+    pub(crate) extra_symbol_directories: Vec<PathBuf>,
+    pub(crate) simpleperf_binary_cache_directories: Vec<PathBuf>,
 }
 
 impl SymbolManagerConfig {
@@ -172,6 +174,21 @@ impl SymbolManagerConfig {
     /// of dSYM files based on a mach-O UUID. Ignored on non-macOS.
     pub fn use_spotlight(mut self, use_spotlight: bool) -> Self {
         self.use_spotlight = use_spotlight;
+        self
+    }
+
+    /// Add an additional directory that may contain symbol files.
+    /// We will check "<dir>/<binaryname>" and "<dir>/<debug_name>".
+    pub fn extra_symbols_directory(mut self, dir: impl Into<PathBuf>) -> Self {
+        self.extra_symbol_directories.push(dir.into());
+        self
+    }
+
+    /// Add a simpleperf "binary_cache" directory which will be checked for symbols.
+    ///
+    /// The simpleperf scripts pull files from the Android device into this directory.
+    pub fn simpleperf_binary_cache_dir(mut self, dir: impl Into<PathBuf>) -> Self {
+        self.simpleperf_binary_cache_directories.push(dir.into());
         self
     }
 }


### PR DESCRIPTION
This adds the following:

```
      --symbol-dir <SYMBOL_DIR>
          Extra directories containing symbol files
      --windows-symbol-server <WINDOWS_SYMBOL_SERVER>
          Additional URLs of symbol servers serving PDB / DLL / EXE files
      --windows-symbol-cache <WINDOWS_SYMBOL_CACHE>
          Overrides the default cache directory for Windows symbol files which were downloaded from a symbol server
      --breakpad-symbol-server <BREAKPAD_SYMBOL_SERVER>
          Additional URLs of symbol servers serving Breakpad .sym files
      --breakpad-symbol-cache <BREAKPAD_SYMBOL_CACHE>
          Overrides the default cache directory for Breakpad symbol files
      --simpleperf-binary-cache <SIMPLEPERF_BINARY_CACHE>
          Extra directory containing symbol files, with the directory structure used by simpleperf's scripts
```

This makes it so that, if you use simpleperf to profile a Firefox build from the Play Store, you can use `samply import perf.data --breakpad-symbol-server https://symbols.mozilla.org/` and you will get full Firefox symbols.