### PR TITLE
Dont double adjust return addresses in imported simpleperf profiles

### DIFF
--- a/fxprof-processed-profile/src/frame.rs
+++ b/fxprof-processed-profile/src/frame.rs
@@ -19,12 +19,32 @@ pub enum Frame {
     /// the library mappings on the process which were specified using
     /// [`Profile::add_lib_mapping`](crate::Profile::add_lib_mapping).
     ReturnAddress(u64),
+    /// A code address taken from a return address, but adjusted so that it
+    /// points into the previous instruction. Usually this is "return address
+    /// minus one byte", but some unwinders subtract 2 or 4 bytes if they know
+    /// more about the architecture-dependent instruction size.
+    ///
+    /// When you call a function with a call instruction, the return address
+    /// is set up in such a way that, once the called function returns, the CPU
+    /// continues executing after the call instruction. That means that the return
+    /// address points to the instruction *after* the call instruction. But for
+    /// stack unwinding, you're interested in **the call instruction itself**.
+    /// The call instruction and the instruction after often have very different
+    /// symbol information (different line numbers, or even different inline stacks).
+    ///
+    /// This code address will be resolved to a library-relative address using
+    /// the library mappings on the process which were specified using
+    /// [`Profile::add_lib_mapping`](crate::Profile::add_lib_mapping).
+    AdjustedReturnAddress(u64),
     /// A relative address taken from the instruction pointer which
     /// has already been resolved to a `LibraryHandle`.
     RelativeAddressFromInstructionPointer(LibraryHandle, u32),
     /// A relative address taken from a return address which
     /// has already been resolved to a `LibraryHandle`.
     RelativeAddressFromReturnAddress(LibraryHandle, u32),
+    /// A relative address taken from an adjusted return address which
+    /// has already been resolved to a `LibraryHandle`.
+    RelativeAddressFromAdjustedReturnAddress(LibraryHandle, u32),
     /// A string, containing an index returned by
     /// [`Profile::intern_string`](crate::Profile::intern_string).
     Label(StringHandle),

--- a/fxprof-processed-profile/src/profile.rs
+++ b/fxprof-processed-profile/src/profile.rs
@@ -581,14 +581,24 @@ impl Profile {
                     &mut self.kernel_libs,
                     ra.saturating_sub(1),
                 ),
+                Frame::AdjustedReturnAddress(ara) => {
+                    process.convert_address(&mut self.global_libs, &mut self.kernel_libs, ara)
+                }
                 Frame::RelativeAddressFromInstructionPointer(lib_handle, relative_address) => {
                     let global_lib_index = self.global_libs.index_for_used_lib(lib_handle);
                     InternalFrameLocation::AddressInLib(relative_address, global_lib_index)
                 }
                 Frame::RelativeAddressFromReturnAddress(lib_handle, relative_address) => {
                     let global_lib_index = self.global_libs.index_for_used_lib(lib_handle);
-                    let nudged_relative_address = relative_address.saturating_sub(1);
-                    InternalFrameLocation::AddressInLib(nudged_relative_address, global_lib_index)
+                    let adjusted_relative_address = relative_address.saturating_sub(1);
+                    InternalFrameLocation::AddressInLib(adjusted_relative_address, global_lib_index)
+                }
+                Frame::RelativeAddressFromAdjustedReturnAddress(
+                    lib_handle,
+                    adjusted_relative_address,
+                ) => {
+                    let global_lib_index = self.global_libs.index_for_used_lib(lib_handle);
+                    InternalFrameLocation::AddressInLib(adjusted_relative_address, global_lib_index)
                 }
                 Frame::Label(string_index) => {
                     let thread_string_index =

--- a/samply/src/import/perf.rs
+++ b/samply/src/import/perf.rs
@@ -89,6 +89,8 @@ where
         .map_or(0, |r| r.first_sample_time);
     let endian = perf_file.endian();
     let simpleperf_meta_info = perf_file.simpleperf_meta_info().ok().flatten();
+    let is_simpleperf = simpleperf_meta_info.is_some();
+    let call_chain_return_addresses_are_preadjusted = is_simpleperf;
     let mut product_postfix = String::new();
     if let Some(host) = perf_file.hostname().ok().flatten() {
         write!(product_postfix, " on {host}").unwrap();
@@ -144,6 +146,7 @@ where
         extra_dir,
         interpretation.clone(),
         simpleperf_symbol_tables,
+        call_chain_return_addresses_are_preadjusted,
     );
 
     let mut last_timestamp = 0;

--- a/samply/src/linux/profiler.rs
+++ b/samply/src/linux/profiler.rs
@@ -387,6 +387,7 @@ fn make_converter(
         None,
         interpretation,
         None,
+        false,
     )
 }
 

--- a/samply/src/linux_shared/converter.rs
+++ b/samply/src/linux_shared/converter.rs
@@ -630,10 +630,12 @@ where
                     continue;
                 }
 
-                let stack_frame = match is_first_frame {
-                    true => StackFrame::InstructionPointer(address, mode),
-                    false => StackFrame::ReturnAddress(address, mode),
-                };
+                let stack_frame =
+                    match (is_first_frame, call_chain_return_addresses_are_preadjusted) {
+                        (true, _) => StackFrame::InstructionPointer(address, mode),
+                        (false, false) => StackFrame::ReturnAddress(address, mode),
+                        (false, true) => StackFrame::AdjustedReturnAddress(address, mode),
+                    };
                 stack.push(stack_frame);
 
                 is_first_frame = false;

--- a/samply/src/linux_shared/converter.rs
+++ b/samply/src/linux_shared/converter.rs
@@ -88,6 +88,18 @@ where
     /// Whether repeated frames at the base of the stack should be folded
     /// into one frame.
     fold_recursive_prefix: bool,
+
+    /// Determines how the addresses in sample call chains should be interpreted.
+    /// Any addresses after the first frame address are either "return addresses"
+    /// (i.e. they are the address of the instruction *after* the call instruction),
+    /// or they are "adjusted return address" (i.e. an offset was subtracted from
+    /// the return address so that the address now points *into the call instruction*).
+    /// For call chains coming directly from the Linux kernel, no adjustment has been
+    /// performed, so this will be false.
+    /// For call chains coming from simpleperf perf.data files, simpleperf has
+    /// already done the adjusting, either by adjusting the call chains coming from
+    /// the kernel or by doing its own unwinding with an adjusting unwinder,
+    call_chain_return_addresses_are_preadjusted: bool,
 }
 
 const DEFAULT_OFF_CPU_SAMPLING_INTERVAL_NS: u64 = 1_000_000; // 1ms
@@ -109,6 +121,7 @@ where
         extra_binary_artifact_dir: Option<&Path>,
         interpretation: EventInterpretation,
         simpleperf_symbol_tables: Option<Vec<SimpleperfFileRecord>>,
+        call_chain_return_addresses_are_preadjusted: bool,
     ) -> Self {
         let interval = match interpretation.sampling_is_time_based {
             Some(nanos) => SamplingInterval::from_nanos(nanos),
@@ -226,6 +239,7 @@ where
             jit_category_manager: JitCategoryManager::new(),
             fold_recursive_prefix: profile_creation_props.fold_recursive_prefix,
             cpus,
+            call_chain_return_addresses_are_preadjusted,
         }
     }
 
@@ -271,6 +285,7 @@ where
             &mut self.cache,
             &mut stack,
             self.fold_recursive_prefix,
+            self.call_chain_return_addresses_are_preadjusted,
         );
 
         let thread = process.threads.get_thread_by_tid(tid, &mut self.profile);
@@ -389,6 +404,7 @@ where
             &mut self.cache,
             &mut stack,
             self.fold_recursive_prefix,
+            self.call_chain_return_addresses_are_preadjusted,
         );
 
         let stack_index = self
@@ -504,6 +520,7 @@ where
             &mut self.cache,
             &mut stack,
             self.fold_recursive_prefix,
+            self.call_chain_return_addresses_are_preadjusted,
         );
         let unresolved_stack = self.unresolved_stacks.convert(stack.into_iter().rev());
         let thread_handle = process.threads.main_thread.profile_thread;
@@ -555,6 +572,7 @@ where
             &mut self.cache,
             &mut stack,
             self.fold_recursive_prefix,
+            self.call_chain_return_addresses_are_preadjusted,
         );
 
         let thread_handle = match e.tid {
@@ -612,6 +630,7 @@ where
         cache: &mut U::Cache,
         stack: &mut Vec<StackFrame>,
         fold_recursive_prefix: bool,
+        call_chain_return_addresses_are_preadjusted: bool,
     ) {
         stack.truncate(0);
 

--- a/samply/src/shared/types.rs
+++ b/samply/src/shared/types.rs
@@ -45,5 +45,6 @@ impl From<CpuMode> for StackMode {
 pub enum StackFrame {
     InstructionPointer(u64, StackMode),
     ReturnAddress(u64, StackMode),
+    AdjustedReturnAddress(u64, StackMode),
     TruncatedStackMarker,
 }


### PR DESCRIPTION
The addresses in call chains in perf.data files from simpleperf have already been adjusted to point into the call instruction. This is different from what we're used to from perf.data files generated by Linux perf.

The adjustment happens in two places:

If the unwinding happens in the kernel, the callchains are adjusted in [`SampleRecord::AdjustCallChainGeneratedByKernel()`](https://cs.android.com/android/platform/superproject/+/main:system/extras/simpleperf/record.cpp;l=949-982;drc=428d4a5fdb7745f73f52e930120dba9d2f215c26).

If simpleperf does the unwinding of the user stack itself, the callchains are adjusted in libunwindstack,
i.e in the unwinder that's used by simpleperf:

https://cs.android.com/android/platform/superproject/+/main:system/unwinding/libunwindstack/Unwinder.cpp;l=177;drc=8e2c60d01e0928275d30f320c3f83ac4f29b880c
https://cs.android.com/android/platform/superproject/+/main:system/unwinding/libunwindstack/Regs.cpp;l=175-224;drc=c0fa0c327e58eda604b2fd00b81f1c12817542d3