### PR TITLE
Add --breakpad-symbol-dir for local Breakpad stores.

### DIFF
--- a/samply/src/main.rs
+++ b/samply/src/main.rs
@@ -275,6 +275,10 @@ struct SymbolArgs {
     #[arg(long)]
     breakpad_symbol_server: Vec<String>,
 
+    /// Additional local directories containing Breakpad .sym files
+    #[arg(long)]
+    breakpad_symbol_dir: Vec<String>,
+
     /// Overrides the default cache directory for Breakpad symbol files
     #[arg(long)]
     breakpad_symbol_cache: Option<PathBuf>,
@@ -652,6 +656,7 @@ impl SymbolArgs {
             windows_symbol_server: self.windows_symbol_server.clone(),
             windows_symbol_cache: self.windows_symbol_cache.clone(),
             breakpad_symbol_server: self.breakpad_symbol_server.clone(),
+            breakpad_symbol_dir: self.breakpad_symbol_dir.clone(),
             breakpad_symbol_cache: self.breakpad_symbol_cache.clone(),
             simpleperf_binary_cache: self.simpleperf_binary_cache.clone(),
         }

--- a/samply/src/server.rs
+++ b/samply/src/server.rs
@@ -94,6 +94,9 @@ fn create_symbol_manager_config(symbol_props: SymbolProps, verbose: bool) -> Sym
         for base_url in symbol_props.breakpad_symbol_server {
             config = config.breakpad_symbols_server(base_url, &cache_dir)
         }
+        for dir in symbol_props.breakpad_symbol_dir {
+            config = config.breakpad_symbols_dir(dir);
+        }
         if let Some(cache_base_dir) = cache_base_dir {
             let breakpad_symindex_cache_dir =
                 cache_base_dir.join("symbols").join("breakpad-symindex");

--- a/samply/src/shared/symbol_props.rs
+++ b/samply/src/shared/symbol_props.rs
@@ -10,6 +10,8 @@ pub struct SymbolProps {
     pub windows_symbol_cache: Option<PathBuf>,
     /// Additional URLs of symbol servers serving Breakpad .sym files
     pub breakpad_symbol_server: Vec<String>,
+    /// Additional local directories containing Breakpad .sym files
+    pub breakpad_symbol_dir: Vec<String>,
     /// Overrides the default cache directory for Breakpad symbol files
     pub breakpad_symbol_cache: Option<PathBuf>,
     /// Extra directory containing symbol files, with the directory structure used by simpleperf's scripts


### PR DESCRIPTION
This was achievable through using the dir as the cache directory then specifying an invalid symbol server, but it was ugly. Add a command line argument that matches what we already have in SymbolManagerConfig::breakpad_symbols_dir.