### PR TITLE
When using --reuse-threads, recycle JIT functions by (name, size) on Windows

### DIFF
--- a/samply/src/linux_shared/process.rs
+++ b/samply/src/linux_shared/process.rs
@@ -306,13 +306,9 @@ where
         );
 
         if let (Some(name), Some(recycler)) = (symbol_name, self.jit_function_recycler.as_mut()) {
-            (lib_handle, relative_address_at_start) = recycler.recycle(
-                start_address,
-                end_address,
-                relative_address_at_start,
-                name,
-                lib_handle,
-            );
+            let code_size = (end_address - start_address) as u32;
+            (lib_handle, relative_address_at_start) =
+                recycler.recycle(name, code_size, lib_handle, relative_address_at_start);
         }
 
         let (category, js_frame) =

--- a/samply/src/shared/jit_function_recycler.rs
+++ b/samply/src/shared/jit_function_recycler.rs
@@ -16,13 +16,11 @@ pub struct JitFunctionRecycler {
 impl JitFunctionRecycler {
     pub fn recycle(
         &mut self,
-        start_address: u64,
-        end_address: u64,
-        relative_address: u32,
         name: &str,
+        code_size: u32,
         lib_handle: LibraryHandle,
+        relative_address: u32,
     ) -> (LibraryHandle, u32) {
-        let code_size = (end_address - start_address) as u32;
         let name_and_code_size = (name.to_owned(), code_size);
         match self
             .jit_functions_for_reuse_by_name_and_size

--- a/samply/src/windows/etw_gecko.rs
+++ b/samply/src/windows/etw_gecko.rs
@@ -237,7 +237,7 @@ pub fn profile_pid_from_etl_file(context: &mut ProfileContext, etl_file: &Path) 
                     pid,
                     method_name,
                     method_start_address.as_u64(),
-                    method_size,
+                    method_size as u32,
                 );
             }
             /*"V8.js/SourceLoad/" |


### PR DESCRIPTION
This is already happening on the other platforms.