### PR TITLE
 Respect the --symbol-dir arg

### DIFF
--- a/samply-symbols/src/shared.rs
+++ b/samply-symbols/src/shared.rs
@@ -43,6 +43,7 @@ pub trait OptionallySendFuture: Future + Send {}
 #[cfg(feature = "send_futures")]
 impl<T> OptionallySendFuture for T where T: Future + Send {}
 
+#[derive(Debug)]
 pub enum CandidatePathInfo<FL: FileLocation> {
     SingleFile(FL),
     InDyldCache {

--- a/samply/src/server.rs
+++ b/samply/src/server.rs
@@ -117,6 +117,10 @@ fn create_symbol_manager_config(symbol_props: SymbolProps, verbose: bool) -> Sym
         config = config.simpleperf_binary_cache_dir(binary_cache);
     }
 
+    for dir in symbol_props.symbol_dir {
+        config = config.extra_symbols_directory(dir);
+    }
+
     config
 }
 


### PR DESCRIPTION
The patch from https://github.com/mstange/samply/pull/235 added the arg but ignored the value.