### PR TITLE
Fix convert_no_kernel.

### DIFF
--- a/samply/src/shared/types.rs
+++ b/samply/src/shared/types.rs
@@ -48,3 +48,14 @@ pub enum StackFrame {
     AdjustedReturnAddress(u64, StackMode),
     TruncatedStackMarker,
 }
+
+impl StackFrame {
+    pub fn stack_mode(&self) -> Option<StackMode> {
+        match self {
+            StackFrame::InstructionPointer(_, stack_mode) => Some(*stack_mode),
+            StackFrame::ReturnAddress(_, stack_mode) => Some(*stack_mode),
+            StackFrame::AdjustedReturnAddress(_, stack_mode) => Some(*stack_mode),
+            StackFrame::TruncatedStackMarker => None,
+        }
+    }
+}

--- a/samply/src/shared/unresolved_samples.rs
+++ b/samply/src/shared/unresolved_samples.rs
@@ -192,12 +192,7 @@ impl UnresolvedStacks {
         frames: impl Iterator<Item = StackFrame>,
     ) -> UnresolvedStackHandle {
         let mut prefix = UnresolvedStackHandle::EMPTY;
-        for frame in frames {
-            match frame {
-                StackFrame::InstructionPointer(_, StackMode::Kernel) => continue,
-                StackFrame::ReturnAddress(_, StackMode::Kernel) => continue,
-                _ => {}
-            }
+        for frame in frames.filter(|f| f.stack_mode() != Some(StackMode::Kernel)) {
             let x = (prefix, frame);
             let node = *self.stack_lookup.entry(x).or_insert_with(|| {
                 let new_index = self.stacks.len() as u32;


### PR DESCRIPTION
I had forgotten to update it for the new StackFrame::AdjustedReturnAddress enum variant.