### PR TITLE
Change the marker API in fxprof-processed-profile and add support for deduplicated string fields in markers

### DIFF
--- a/fxprof-processed-profile/src/lib.rs
+++ b/fxprof-processed-profile/src/lib.rs
@@ -66,7 +66,11 @@ pub use frame::{Frame, FrameFlags, FrameInfo};
 pub use global_lib_table::{LibraryHandle, UsedLibraryAddressesIterator};
 pub use lib_mappings::LibMappings;
 pub use library_info::{LibraryInfo, Symbol, SymbolTable};
-pub use markers::*;
+pub use markers::{
+    Marker, MarkerFieldFormat, MarkerFieldFormatKind, MarkerFieldSchema, MarkerHandle,
+    MarkerLocation, MarkerSchema, MarkerStaticField, MarkerTiming, MarkerTypeHandle,
+    StaticSchemaMarker,
+};
 pub use process::ThreadHandle;
 pub use profile::{Profile, SamplingInterval, StringHandle};
 pub use reference_timestamp::ReferenceTimestamp;

--- a/fxprof-processed-profile/src/marker_table.rs
+++ b/fxprof-processed-profile/src/marker_table.rs
@@ -1,9 +1,13 @@
-use serde::ser::{Serialize, SerializeMap, Serializer};
-use serde_json::Value;
+use serde::ser::{Serialize, SerializeMap, SerializeSeq, Serializer};
 
+use crate::markers::{InternalMarkerSchema, MarkerFieldFormatKind};
 use crate::serialization_helpers::SerializableOptionalTimestampColumn;
-use crate::thread_string_table::ThreadInternalStringIndex;
-use crate::{CategoryHandle, MarkerHandle, MarkerTiming, Timestamp};
+use crate::string_table::{GlobalStringIndex, GlobalStringTable, StringIndex};
+use crate::thread_string_table::{ThreadInternalStringIndex, ThreadStringTable};
+use crate::{
+    CategoryHandle, Marker, MarkerFieldFormat, MarkerHandle, MarkerTiming, MarkerTypeHandle,
+    Timestamp,
+};
 
 #[derive(Debug, Clone, Default)]
 pub struct MarkerTable {
@@ -12,7 +16,33 @@ pub struct MarkerTable {
     marker_starts: Vec<Option<Timestamp>>,
     marker_ends: Vec<Option<Timestamp>>,
     marker_phases: Vec<Phase>,
-    marker_datas: Vec<Value>,
+    marker_type_handles: Vec<MarkerTypeHandle>,
+    marker_stacks: Vec<Option<usize>>,
+    /// The field values for any marker fields of [kind](`MarkerFieldFormat::kind`) [`MarkerFieldFormatKind::Number`].
+    ///
+    /// This Vec can contain zero or more values per marker, depending on the marker's
+    /// type's schema's `number_field_count`. For the marker with index i,
+    /// its field values will be at index sum_{k in 0..i}(marker_schema[k].number_field_count).
+    marker_field_number_values: Vec<f64>,
+    /// The field values for any marker fields of [kind](`MarkerFieldFormat::kind`) [`MarkerFieldFormatKind::String`].
+    ///
+    /// This Vec can contain zero or more values per marker, depending on the marker's
+    /// type's schema's `string_field_count`. For the marker with index i,
+    /// its field values will be at index sum_{k in 0..i}(marker_schema[k].string_field_count).
+    ///
+    /// The [`StringIndex`] can be either a [`ThreadInternalStringIndex`] or a [`GlobalStringIndex`],
+    /// depending on the string field's format - if the field format is [`MarkerFieldFormat::String`],
+    /// the string index will be thread-internal, for all the other string format variants the
+    /// index will be global.
+    ///
+    /// We make this distinction because, in the actual JSON, we currently only use string indexes for
+    /// the [`MarkerFieldFormat::String`] format (serialized as "unique-string"). The other
+    /// string format variants currently still use actual strings in the JSON, not string indexes.
+    /// So for these we don't want to add the strings to the thread's string table.
+    ///
+    /// https://github.com/firefox-devtools/profiler/issues/5022 tracks supporting string indexes
+    /// for the other string format variants.
+    marker_field_string_values: Vec<StringIndex>,
 }
 
 impl MarkerTable {
@@ -20,12 +50,17 @@ impl MarkerTable {
         Default::default()
     }
 
-    pub fn add_marker(
+    #[allow(clippy::too_many_arguments)]
+    pub fn add_marker<T: Marker>(
         &mut self,
-        category: CategoryHandle,
-        name: ThreadInternalStringIndex,
+        name_string_index: ThreadInternalStringIndex,
+        marker_type_handle: MarkerTypeHandle,
+        schema: &InternalMarkerSchema,
+        marker: T,
         timing: MarkerTiming,
-        data: Value,
+        category: CategoryHandle,
+        thread_string_table: &mut ThreadStringTable,
+        global_string_table: &mut GlobalStringTable,
     ) -> MarkerHandle {
         let (s, e, phase) = match timing {
             MarkerTiming::Instant(s) => (Some(s), None, Phase::Instant),
@@ -34,37 +69,168 @@ impl MarkerTable {
             MarkerTiming::IntervalEnd(e) => (None, Some(e), Phase::IntervalEnd),
         };
         self.marker_categories.push(category);
-        self.marker_name_string_indexes.push(name);
+        self.marker_name_string_indexes.push(name_string_index);
         self.marker_starts.push(s);
         self.marker_ends.push(e);
         self.marker_phases.push(phase);
-        self.marker_datas.push(data);
+        self.marker_type_handles.push(marker_type_handle);
+        self.marker_stacks.push(None);
+        for (field_index, field) in schema.fields().iter().enumerate() {
+            match field.format.kind() {
+                MarkerFieldFormatKind::String => {
+                    let global_string_index = marker.string_field_value(field_index as u32).0;
+                    let string_index = if field.format == MarkerFieldFormat::String {
+                        // This one ends up as `format: "unique-string"` with an index into the thread string table
+                        let thread_string_index = thread_string_table
+                            .index_for_global_string(global_string_index, global_string_table);
+                        thread_string_index.0
+                    } else {
+                        // These end up in the JSON as JSON strings, not as string indexes.
+                        global_string_index.0
+                    };
+                    self.marker_field_string_values.push(string_index);
+                }
+                MarkerFieldFormatKind::Number => {
+                    let number_value = marker.number_field_value(field_index as u32);
+                    self.marker_field_number_values.push(number_value)
+                }
+            }
+        }
 
         MarkerHandle(self.marker_categories.len() - 1)
     }
 
-    pub fn get_marker_data_mut(&mut self, marker: MarkerHandle) -> &mut Value {
-        &mut self.marker_datas[marker.0]
+    pub fn set_marker_stack(&mut self, marker: MarkerHandle, stack_index: Option<usize>) {
+        self.marker_stacks[marker.0] = stack_index;
+    }
+
+    pub fn as_serializable<'a>(
+        &'a self,
+        schemas: &'a [InternalMarkerSchema],
+        global_string_table: &'a GlobalStringTable,
+    ) -> impl Serialize + 'a {
+        SerializableMarkerTable {
+            marker_table: self,
+            global_string_table,
+            schemas,
+        }
     }
 }
 
-impl Serialize for MarkerTable {
+struct SerializableMarkerTable<'a> {
+    marker_table: &'a MarkerTable,
+    global_string_table: &'a GlobalStringTable,
+    schemas: &'a [InternalMarkerSchema],
+}
+
+impl<'a> Serialize for SerializableMarkerTable<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let len = self.marker_name_string_indexes.len();
+        let Self { marker_table, .. } = self;
+        let len = marker_table.marker_name_string_indexes.len();
         let mut map = serializer.serialize_map(None)?;
         map.serialize_entry("length", &len)?;
-        map.serialize_entry("category", &self.marker_categories)?;
-        map.serialize_entry("data", &self.marker_datas)?;
+        map.serialize_entry("category", &marker_table.marker_categories)?;
+        map.serialize_entry("data", &SerializableMarkerTableDataColumn(self))?;
         map.serialize_entry(
             "endTime",
-            &SerializableOptionalTimestampColumn(&self.marker_ends),
+            &SerializableOptionalTimestampColumn(&marker_table.marker_ends),
         )?;
-        map.serialize_entry("name", &self.marker_name_string_indexes)?;
-        map.serialize_entry("phase", &self.marker_phases)?;
+        map.serialize_entry("name", &marker_table.marker_name_string_indexes)?;
+        map.serialize_entry("phase", &marker_table.marker_phases)?;
         map.serialize_entry(
             "startTime",
-            &SerializableOptionalTimestampColumn(&self.marker_starts),
+            &SerializableOptionalTimestampColumn(&marker_table.marker_starts),
         )?;
+        map.end()
+    }
+}
+
+struct SerializableMarkerTableDataColumn<'a>(&'a SerializableMarkerTable<'a>);
+
+impl<'a> Serialize for SerializableMarkerTableDataColumn<'a> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let marker_table = self.0.marker_table;
+        let schemas = self.0.schemas;
+        let global_string_table = self.0.global_string_table;
+        let len = marker_table.marker_name_string_indexes.len();
+        let mut seq = serializer.serialize_seq(Some(len))?;
+        let mut remaining_string_fields = &marker_table.marker_field_string_values[..];
+        let mut remaining_number_fields = &marker_table.marker_field_number_values[..];
+        for i in 0..len {
+            let marker_type_handle = marker_table.marker_type_handles[i];
+            let stack_index = marker_table.marker_stacks[i];
+            let schema = &schemas[marker_type_handle.0];
+            let string_fields;
+            let number_fields;
+            (string_fields, remaining_string_fields) =
+                remaining_string_fields.split_at(schema.string_field_count());
+            (number_fields, remaining_number_fields) =
+                remaining_number_fields.split_at(schema.number_field_count());
+            seq.serialize_element(&SerializableMarkerDataElement {
+                global_string_table,
+                stack_index,
+                schema,
+                string_fields,
+                number_fields,
+            })?;
+        }
+        seq.end()
+    }
+}
+
+struct SerializableMarkerDataElement<'a> {
+    global_string_table: &'a GlobalStringTable,
+    stack_index: Option<usize>,
+    schema: &'a InternalMarkerSchema,
+    string_fields: &'a [StringIndex],
+    number_fields: &'a [f64],
+}
+
+impl<'a> Serialize for SerializableMarkerDataElement<'a> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let Self {
+            global_string_table,
+            stack_index,
+            schema,
+            mut string_fields,
+            mut number_fields,
+        } = self;
+        let mut map = serializer.serialize_map(None)?;
+        map.serialize_entry("type", &schema.type_name())?;
+        if let Some(stack_index) = stack_index {
+            map.serialize_entry("cause", &SerializableMarkerCause(*stack_index))?;
+        }
+        for field in schema.fields() {
+            match field.format.kind() {
+                MarkerFieldFormatKind::String => {
+                    let value;
+                    (value, string_fields) = string_fields.split_first().unwrap();
+                    if field.format == MarkerFieldFormat::String {
+                        map.serialize_entry(&field.key, value)?;
+                    } else {
+                        let str_val = global_string_table
+                            .get_string(GlobalStringIndex(*value))
+                            .unwrap();
+                        map.serialize_entry(&field.key, str_val)?;
+                    }
+                }
+                MarkerFieldFormatKind::Number => {
+                    let value;
+                    (value, number_fields) = number_fields.split_first().unwrap();
+                    map.serialize_entry(&field.key, &value)?;
+                }
+            }
+        }
+
+        map.end()
+    }
+}
+
+struct SerializableMarkerCause(usize);
+impl Serialize for SerializableMarkerCause {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut map = serializer.serialize_map(Some(1))?;
+        map.serialize_entry("stack", &self.0)?;
         map.end()
     }
 }

--- a/fxprof-processed-profile/src/markers.rs
+++ b/fxprof-processed-profile/src/markers.rs
@@ -2,13 +2,24 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use serde::ser::{SerializeMap, SerializeSeq};
+use serde::Serialize;
 use serde_derive::Serialize;
-use serde_json::Value;
 
+use crate::{CategoryHandle, Profile};
+
+use super::profile::StringHandle;
 use super::timestamp::Timestamp;
 
+/// The handle for a marker. Returned from [`Profile::add_marker`].
+///
+/// This allows adding a stack to marker after the marker has been added.
 #[derive(Debug, Clone, Copy, PartialOrd, Ord, PartialEq, Eq, Hash)]
 pub struct MarkerHandle(pub(crate) usize);
+
+/// The handle for a marker type. Returned from [`Profile::register_marker_type`].
+#[derive(Debug, Clone, Copy, PartialOrd, Ord, PartialEq, Eq, Hash)]
+pub struct MarkerTypeHandle(pub(crate) usize);
 
 /// Specifies timestamps for a marker.
 #[derive(Debug, Clone)]
@@ -33,84 +44,392 @@ pub enum MarkerTiming {
     IntervalEnd(Timestamp),
 }
 
-/// The trait that all markers implement.
+/// The marker trait. You'll likely want to implement [`StaticSchemaMarker`] instead.
 ///
+/// Markers have a type, a name, a category, and an arbitrary number of fields.
+/// The fields of a marker type are defined by the marker type's schema, see [`MarkerSchema`].
+/// The timestamps are not part of the marker; they are supplied separately to
+/// [`Profile::add_marker`] when a marker is added to the profile.
+///
+/// You can implement this trait manually if the schema of your marker type is only
+/// known at runtime. If the schema is known at compile time, you'll want to implement
+/// [`StaticSchemaMarker`] instead - there is a blanket impl which implements [`Marker`]
+/// for any type that implements [`StaticSchemaMarker`].
+pub trait Marker {
+    /// The [`MarkerTypeHandle`] of this marker type. Created with [`Profile::register_marker_type`] or
+    /// with [`Profile::static_schema_marker_type`].
+    fn marker_type(&self, profile: &mut Profile) -> MarkerTypeHandle;
+
+    /// The name of this marker, as an interned string handle.
+    ///
+    /// The name is shown as the row label in the marker chart. It can also be
+    /// used as `{marker.name}` in the various `label` template strings in the schema.
+    fn name(&self, profile: &mut Profile) -> StringHandle;
+
+    /// The category of this marker. The marker chart groups marker rows by category.
+    fn category(&self, profile: &mut Profile) -> CategoryHandle;
+
+    /// Called for any fields defined in the schema whose [`format`](MarkerFieldSchema::format) is
+    /// of [kind](MarkerFieldFormat::kind) [`MarkerFieldFormatKind::String`].
+    ///
+    /// `field_index` is an index into the schema's [`fields`](MarkerSchema::fields).
+    ///
+    /// You can panic for any unexpected field indexes, for example
+    /// using `unreachable!()`. You can even panic unconditionally if this
+    /// marker type doesn't have any string fields.
+    ///
+    /// If you do see unexpected calls to this method, make sure you're not registering
+    /// multiple different schemas with the same [`MarkerSchema::type_name`].
+    fn string_field_value(&self, field_index: u32) -> StringHandle;
+
+    /// Called for any fields defined in the schema whose [`format`](MarkerFieldSchema::format) is
+    /// of [kind](MarkerFieldFormat::kind) [`MarkerFieldFormatKind::Number`].
+    ///
+    /// `field_index` is an index into the schema's [`fields`](MarkerSchema::fields).
+    ///
+    /// You can panic for any unexpected field indexes, for example
+    /// using `unreachable!()`. You can even panic unconditionally if this
+    /// marker type doesn't have any number fields.
+    ///
+    /// If you do see unexpected calls to this method, make sure you're not registering
+    /// multiple different schemas with the same [`MarkerSchema::type_name`].
+    fn number_field_value(&self, field_index: u32) -> f64;
+}
+
+/// The trait for markers whose schema is known at compile time. Any type which implements
+/// [`StaticSchemaMarker`] automatically implements the [`Marker`] trait via a blanket impl.
+///
+/// Markers have a type, a name, a category, and an arbitrary number of fields.
+/// The fields of a marker type are defined by the marker type's schema, see [`MarkerSchema`].
+/// The timestamps are not part of the marker; they are supplied separately to
+/// [`Profile::add_marker`] when a marker is added to the profile.
+///
+/// In [`StaticSchemaMarker`], the schema is returned from a static `schema` method.
 ///
 /// ```
-/// use fxprof_processed_profile::{ProfilerMarker, MarkerLocation, MarkerFieldFormat, MarkerSchema, MarkerDynamicField, MarkerSchemaField};
-/// use serde_json::json;
+/// use fxprof_processed_profile::{
+///     Profile, Marker, MarkerLocation, MarkerFieldFormat, MarkerSchema, MarkerFieldSchema,
+///     StaticSchemaMarker, CategoryHandle, StringHandle,
+/// };
 ///
-/// /// An example marker type with some text content.
+/// /// An example marker type with a name and some text content.
 /// #[derive(Debug, Clone)]
-/// pub struct TextMarker(pub String);
+/// pub struct TextMarker {
+///   pub name: StringHandle,
+///   pub text: StringHandle,
+/// }
 ///
-/// impl ProfilerMarker for TextMarker {
-///     const MARKER_TYPE_NAME: &'static str = "Text";
-///
-///     fn json_marker_data(&self) -> serde_json::Value {
-///         json!({
-///             "type": Self::MARKER_TYPE_NAME,
-///             "name": self.0
-///         })
-///     }
+/// impl StaticSchemaMarker for TextMarker {
+///     const UNIQUE_MARKER_TYPE_NAME: &'static str = "Text";
 ///
 ///     fn schema() -> MarkerSchema {
 ///         MarkerSchema {
-///             type_name: Self::MARKER_TYPE_NAME,
+///             type_name: Self::UNIQUE_MARKER_TYPE_NAME.into(),
 ///             locations: vec![MarkerLocation::MarkerChart, MarkerLocation::MarkerTable],
-///             chart_label: Some("{marker.data.name}"),
+///             chart_label: Some("{marker.data.text}".into()),
 ///             tooltip_label: None,
-///             table_label: Some("{marker.name} - {marker.data.name}"),
-///             fields: vec![MarkerSchemaField::Dynamic(MarkerDynamicField {
-///                 key: "name",
-///                 label: "Details",
+///             table_label: Some("{marker.name} - {marker.data.text}".into()),
+///             fields: vec![MarkerFieldSchema {
+///                 key: "text".into(),
+///                 label: "Contents".into(),
 ///                 format: MarkerFieldFormat::String,
 ///                 searchable: true,
-///             })],
+///             }],
+///             static_fields: vec![],
 ///         }
+///     }
+///
+///     fn name(&self, _profile: &mut Profile) -> StringHandle {
+///         self.name
+///     }
+///
+///     fn category(&self, _profile: &mut Profile) -> CategoryHandle {
+///         CategoryHandle::OTHER
+///     }
+///
+///     fn string_field_value(&self, _field_index: u32) -> StringHandle {
+///         self.text
+///     }
+///
+///     fn number_field_value(&self, _field_index: u32) -> f64 {
+///         unreachable!()
 ///     }
 /// }
 /// ```
-pub trait ProfilerMarker {
-    /// The name of the marker type.
-    const MARKER_TYPE_NAME: &'static str;
+pub trait StaticSchemaMarker {
+    /// A unique string name for this marker type. Has to match the
+    /// [`MarkerSchema::type_name`] of this type's schema.
+    const UNIQUE_MARKER_TYPE_NAME: &'static str;
 
-    /// A static method that returns a `MarkerSchema`, which contains all the
-    /// information needed to stream the display schema associated with a
-    /// marker type.
+    /// The [`MarkerSchema`] for this marker type.
     fn schema() -> MarkerSchema;
 
-    /// A method that streams the marker payload data as a serde_json object.
-    fn json_marker_data(&self) -> Value;
+    /// The name of this marker, as an interned string handle.
+    ///
+    /// The name is shown as the row label in the marker chart. It can also be
+    /// used as `{marker.name}` in the various `label` template strings in the schema.
+    fn name(&self, profile: &mut Profile) -> StringHandle;
+
+    /// The category of this marker. The marker chart groups marker rows by category.
+    fn category(&self, profile: &mut Profile) -> CategoryHandle;
+
+    /// Called for any fields defined in the schema whose [`format`](MarkerFieldSchema::format) is
+    /// of [kind](MarkerFieldFormat::kind) [`MarkerFieldFormatKind::String`].
+    ///
+    /// `field_index` is an index into the schema's [`fields`](MarkerSchema::fields).
+    ///
+    /// You can panic for any unexpected field indexes, for example
+    /// using `unreachable!()`. You can even panic unconditionally if this
+    /// marker type doesn't have any string fields.
+    ///
+    /// If you do see unexpected calls to this method, make sure you're not registering
+    /// multiple different schemas with the same [`MarkerSchema::type_name`].
+    fn string_field_value(&self, field_index: u32) -> StringHandle;
+
+    /// Called for any fields defined in the schema whose [`format`](MarkerFieldSchema::format) is
+    /// of [kind](MarkerFieldFormat::kind) [`MarkerFieldFormatKind::Number`].
+    ///
+    /// `field_index` is an index into the schema's [`fields`](MarkerSchema::fields).
+    ///
+    /// You can panic for any unexpected field indexes, for example
+    /// using `unreachable!()`. You can even panic unconditionally if this
+    /// marker type doesn't have any number fields.
+    ///
+    /// If you do see unexpected calls to this method, make sure you're not registering
+    /// multiple different schemas with the same [`MarkerSchema::type_name`].
+    fn number_field_value(&self, field_index: u32) -> f64;
 }
 
-/// Describes a marker type.
-#[derive(Debug, Clone, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct MarkerSchema {
-    /// The name of this marker type.
-    #[serde(rename = "name")]
-    pub type_name: &'static str,
+impl<T: StaticSchemaMarker> Marker for T {
+    fn marker_type(&self, profile: &mut Profile) -> MarkerTypeHandle {
+        profile.static_schema_marker_type::<Self>()
+    }
 
-    /// List of marker display locations. Empty for SpecialFrontendLocation.
-    #[serde(rename = "display")]
+    fn name(&self, profile: &mut Profile) -> StringHandle {
+        <T as StaticSchemaMarker>::name(self, profile)
+    }
+
+    fn category(&self, profile: &mut Profile) -> CategoryHandle {
+        <T as StaticSchemaMarker>::category(self, profile)
+    }
+
+    fn string_field_value(&self, field_index: u32) -> StringHandle {
+        <T as StaticSchemaMarker>::string_field_value(self, field_index)
+    }
+
+    fn number_field_value(&self, field_index: u32) -> f64 {
+        <T as StaticSchemaMarker>::number_field_value(self, field_index)
+    }
+}
+
+/// Describes a marker type, including the names and types of the marker's fields.
+///
+/// Example:
+///
+/// ```
+/// use fxprof_processed_profile::{
+///     Profile, Marker, MarkerLocation, MarkerFieldFormat, MarkerSchema, MarkerFieldSchema,
+///     MarkerStaticField, StaticSchemaMarker, CategoryHandle, StringHandle,
+/// };
+///
+/// # fn fun() {
+/// let schema = MarkerSchema {
+///     type_name: "custom".into(),
+///     locations: vec![MarkerLocation::MarkerChart, MarkerLocation::MarkerTable],
+///     chart_label: Some("{marker.data.eventName}".into()),
+///     tooltip_label: Some("Custom {marker.name} marker".into()),
+///     table_label: Some("{marker.name} - {marker.data.eventName} with allocation size {marker.data.allocationSize} (latency: {marker.data.latency})".into()),
+///     fields: vec![
+///         MarkerFieldSchema {
+///             key: "eventName".into(),
+///             label: "Event name".into(),
+///             format: MarkerFieldFormat::String,
+///             searchable: true,
+///         },
+///         MarkerFieldSchema {
+///             key: "allocationSize".into(),
+///             label: "Allocation size".into(),
+///             format: MarkerFieldFormat::Bytes,
+///             searchable: true,
+///         },
+///         MarkerFieldSchema {
+///             key: "url".into(),
+///             label: "URL".into(),
+///             format: MarkerFieldFormat::Url,
+///             searchable: true,
+///         },
+///         MarkerFieldSchema {
+///             key: "latency".into(),
+///             label: "Latency".into(),
+///             format: MarkerFieldFormat::Duration,
+///             searchable: true,
+///         },
+///     ],
+///     static_fields: vec![MarkerStaticField {
+///         label: "Description".into(),
+///         value: "This is a test marker with a custom schema.".into(),
+///     }],
+/// };
+/// # }
+/// ```
+#[derive(Debug, Clone)]
+pub struct MarkerSchema {
+    /// The unique name of this marker type. There must not be any other schema
+    /// with the same name.
+    pub type_name: String,
+
+    /// List of marker display locations.
     pub locations: Vec<MarkerLocation>,
 
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub chart_label: Option<&'static str>,
+    /// A template string defining the label shown within each marker's box in the marker chart.
+    ///
+    /// Usable template literals are `{marker.name}` and `{marker.data.fieldname}`.
+    ///
+    /// If set to `None`, the boxes in the marker chart will be empty.
+    pub chart_label: Option<String>,
 
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub tooltip_label: Option<&'static str>,
+    /// A template string defining the label shown in the first row of the marker's tooltip.
+    ///
+    /// Usable template literals are `{marker.name}` and `{marker.data.fieldname}`.
+    ///
+    /// Defaults to `{marker.name}` if set to `None`. (TODO: verify this is true)
+    pub tooltip_label: Option<String>,
 
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub table_label: Option<&'static str>,
+    /// A template string defining the label shown within each marker's box in the marker chart.
+    ///
+    /// Usable template literals are `{marker.name}` and `{marker.data.fieldname}`.
+    ///
+    /// Defaults to `{marker.name}` if set to `None`. (TODO: verify this is true)
+    pub table_label: Option<String>,
 
-    /// The marker fields. These can be specified on each marker.
-    #[serde(rename = "data")]
-    pub fields: Vec<MarkerSchemaField>,
+    /// The marker fields. The values are supplied by each marker, in the marker's
+    /// implementations of the `string_field_value` and `number_field_value` trait methods.
+    pub fields: Vec<MarkerFieldSchema>,
+
+    /// The static fields of this marker type, with fixed values that apply to all markers of this type.
+    /// These are usually used for things like a human readable marker type description.
+    pub static_fields: Vec<MarkerStaticField>,
 }
 
-/// The location of markers with this type.
+#[derive(Debug, Clone)]
+pub struct InternalMarkerSchema {
+    /// The name of this marker type.
+    type_name: String,
+
+    /// List of marker display locations.
+    locations: Vec<MarkerLocation>,
+
+    chart_label: Option<String>,
+    tooltip_label: Option<String>,
+    table_label: Option<String>,
+
+    /// The marker fields. These can be specified on each marker.
+    fields: Vec<MarkerFieldSchema>,
+
+    string_field_count: usize,
+    number_field_count: usize,
+
+    /// The static fields of this marker type, with fixed values that apply to all markers.
+    /// These are usually used for things like a human readable marker type description.
+    static_fields: Vec<MarkerStaticField>,
+}
+
+impl From<MarkerSchema> for InternalMarkerSchema {
+    fn from(schema: MarkerSchema) -> Self {
+        let string_field_count = schema
+            .fields
+            .iter()
+            .filter(|f| f.format.kind() == MarkerFieldFormatKind::String)
+            .count();
+        let number_field_count = schema
+            .fields
+            .iter()
+            .filter(|f| f.format.kind() == MarkerFieldFormatKind::Number)
+            .count();
+        Self {
+            type_name: schema.type_name,
+            locations: schema.locations,
+            chart_label: schema.chart_label,
+            tooltip_label: schema.tooltip_label,
+            table_label: schema.table_label,
+            fields: schema.fields,
+            string_field_count,
+            number_field_count,
+            static_fields: schema.static_fields,
+        }
+    }
+}
+
+impl InternalMarkerSchema {
+    pub fn type_name(&self) -> &str {
+        &self.type_name
+    }
+    pub fn fields(&self) -> &[MarkerFieldSchema] {
+        &self.fields
+    }
+    pub fn string_field_count(&self) -> usize {
+        self.string_field_count
+    }
+    pub fn number_field_count(&self) -> usize {
+        self.number_field_count
+    }
+    fn serialize_self<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut map = serializer.serialize_map(None)?;
+        map.serialize_entry("name", &self.type_name)?;
+        map.serialize_entry("display", &self.locations)?;
+        if let Some(label) = &self.chart_label {
+            map.serialize_entry("chartLabel", label)?;
+        }
+        if let Some(label) = &self.tooltip_label {
+            map.serialize_entry("tooltipLabel", label)?;
+        }
+        if let Some(label) = &self.table_label {
+            map.serialize_entry("tableLabel", label)?;
+        }
+        map.serialize_entry("data", &SerializableSchemaFields(self))?;
+        map.end()
+    }
+
+    fn serialize_fields<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut seq =
+            serializer.serialize_seq(Some(self.fields.len() + self.static_fields.len()))?;
+        for field in &self.fields {
+            seq.serialize_element(field)?;
+        }
+        for field in &self.static_fields {
+            seq.serialize_element(field)?;
+        }
+        seq.end()
+    }
+}
+
+impl Serialize for InternalMarkerSchema {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.serialize_self(serializer)
+    }
+}
+
+struct SerializableSchemaFields<'a>(&'a InternalMarkerSchema);
+
+impl<'a> Serialize for SerializableSchemaFields<'a> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.0.serialize_fields(serializer)
+    }
+}
+
+// /// The location of markers with this type.
 ///
 /// Markers can be shown in different parts of the Firefox Profiler UI.
 ///
@@ -135,36 +454,23 @@ pub enum MarkerLocation {
     StackChart,
 }
 
-/// The description of a marker field in the marker type's schema.
-#[derive(Debug, Clone, Serialize)]
-#[serde(untagged)]
-pub enum MarkerSchemaField {
-    /// Static fields have the same value on all markers. This is used for
-    /// a "Description" field in the tooltip, for example.
-    Static(MarkerStaticField),
-
-    /// Dynamic fields have a per-marker value. The ProfilerMarker implementation
-    /// on the marker type needs to serialize a field on the data JSON object with
-    /// the matching key.
-    Dynamic(MarkerDynamicField),
-}
-
 /// The field description of a marker field which has the same key and value on all markers with this schema.
 #[derive(Debug, Clone, Serialize)]
 pub struct MarkerStaticField {
-    pub label: &'static str,
-    pub value: &'static str,
+    pub label: String,
+    pub value: String,
 }
 
-/// The field description of a marker field which can have a different value for each marker.
+/// The field description of a marker field. The value for this field is supplied by the marker's implementation
+/// of [`number_field_value`](Marker::number_field_value) / [`string_field_value`](Marker::string_field_value).
 #[derive(Debug, Clone, Serialize)]
-pub struct MarkerDynamicField {
-    /// The field key.
-    pub key: &'static str,
+pub struct MarkerFieldSchema {
+    /// The field key. Must not be `type` or `cause`.
+    pub key: String,
 
     /// The user-visible label of this field.
     #[serde(skip_serializing_if = "str::is_empty")]
-    pub label: &'static str,
+    pub label: String,
 
     /// The format of this field.
     pub format: MarkerFieldFormat,
@@ -174,7 +480,7 @@ pub struct MarkerDynamicField {
 }
 
 /// The field format of a marker field.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 pub enum MarkerFieldFormat {
     // ----------------------------------------------------
@@ -195,12 +501,8 @@ pub enum MarkerFieldFormat {
     /// Important: Do not put URL or file path information here, as it will not
     /// be sanitized during profile upload. Please be careful with including
     /// other types of PII here as well.
+    #[serde(rename = "unique-string")]
     String,
-
-    /// An index into a (currently) thread-local string table, aka UniqueStringArray
-    /// This is effectively an integer, so wherever we need to display this value, we
-    /// must first perform a lookup into the appropriate string table.
-    UniqueString,
 
     // ----------------------------------------------------
     // Numeric types
@@ -256,4 +558,35 @@ pub enum MarkerFieldFormat {
     ///
     /// "Label: 52.23, 0.0054, 123,456.78"
     Decimal,
+}
+
+/// The kind of a marker field. Every marker field is either a string or a number.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MarkerFieldFormatKind {
+    String,
+    Number,
+}
+
+impl MarkerFieldFormat {
+    /// Whether this field is a number field or a string field.
+    ///
+    /// This determines whether we call `number_field_value` or
+    /// `string_field_value` to get the field values.
+    pub fn kind(&self) -> MarkerFieldFormatKind {
+        match self {
+            Self::Url | Self::FilePath | Self::SanitizedString | Self::String => {
+                MarkerFieldFormatKind::String
+            }
+            Self::Duration
+            | Self::Time
+            | Self::Seconds
+            | Self::Milliseconds
+            | Self::Microseconds
+            | Self::Nanoseconds
+            | Self::Bytes
+            | Self::Percentage
+            | Self::Integer
+            | Self::Decimal => MarkerFieldFormatKind::Number,
+        }
+    }
 }

--- a/fxprof-processed-profile/src/markers.rs
+++ b/fxprof-processed-profile/src/markers.rs
@@ -186,6 +186,7 @@ pub enum MarkerFieldFormat {
     FilePath,
 
     /// A plain String, never sanitized for PII.
+    ///
     /// Important: Do not put URL or file path information here, as it will not
     /// be sanitized during profile upload. Please be careful with including
     /// other types of PII here as well.
@@ -194,34 +195,55 @@ pub enum MarkerFieldFormat {
     // ----------------------------------------------------
     // Numeric types
     /// For time data that represents a duration of time.
+    /// The value is given in float milliseconds and will be displayed
+    /// in a unit that is picked based on the magnitude of the number.
     /// e.g. "Label: 5s, 5ms, 5μs"
     Duration,
 
-    /// Data that happened at a specific time, relative to the start of the
-    /// profile. e.g. "Label: 15.5s, 20.5ms, 30.5μs"
+    /// A timestamp, relative to the start of the profile. The value is given in
+    /// float milliseconds.
+    ///
+    ///  e.g. "Label: 15.5s, 20.5ms, 30.5μs"
     Time,
 
-    /// The following are alternatives to display a time only in a specific unit
-    /// of time.
-    Seconds, // "Label: 5s"
-    Milliseconds, // "Label: 5ms"
-    Microseconds, // "Label: 5μs"
-    Nanoseconds,  // "Label: 5ns"
+    /// Display a millisecond value as seconds, regardless of the magnitude of the number.
+    ///
+    /// e.g. "Label: 5s" for a value of 5000.0
+    Seconds,
 
+    /// Display a millisecond value as milliseconds, regardless of the magnitude of the number.
+    ///
+    /// e.g. "Label: 5ms" for a value of 5.0
+    Milliseconds,
+
+    /// Display a millisecond value as microseconds, regardless of the magnitude of the number.
+    ///
+    /// e.g. "Label: 5μs" for a value of 0.0005
+    Microseconds,
+
+    /// Display a millisecond value as seconds, regardless of the magnitude of the number.
+    ///
+    /// e.g. "Label: 5ns" for a value of 0.0000005
+    Nanoseconds,
+
+    /// Display a bytes value in a unit that's appropriate for the number's magnitude.
+    ///
     /// e.g. "Label: 5.55mb, 5 bytes, 312.5kb"
     Bytes,
 
     /// This should be a value between 0 and 1.
-    /// "Label: 50%"
+    /// e.g. "Label: 50%" for a value of 0.5
     Percentage,
 
-    // The integer should be used for generic representations of numbers.
-    // Do not use it for time information.
-    // "Label: 52, 5,323, 1,234,567"
+    /// A generic integer number.
+    /// Do not use it for time information.
+    ///
+    /// "Label: 52, 5,323, 1,234,567"
     Integer,
 
-    // The decimal should be used for generic representations of numbers.
-    // Do not use it for time information.
-    // "Label: 52.23, 0.0054, 123,456.78"
+    /// A generic floating point number.
+    /// Do not use it for time information.
+    ///
+    /// "Label: 52.23, 0.0054, 123,456.78"
     Decimal,
 }

--- a/fxprof-processed-profile/src/markers.rs
+++ b/fxprof-processed-profile/src/markers.rs
@@ -185,12 +185,22 @@ pub enum MarkerFieldFormat {
     /// A file path, supports PII sanitization.
     FilePath,
 
+    /// A regular string, supports PII sanitization.
+    /// Concretely this means that these strings are stripped when uploading
+    /// profiles if you uncheck "Include resource URLs and paths".
+    SanitizedString,
+
     /// A plain String, never sanitized for PII.
     ///
     /// Important: Do not put URL or file path information here, as it will not
     /// be sanitized during profile upload. Please be careful with including
     /// other types of PII here as well.
     String,
+
+    /// An index into a (currently) thread-local string table, aka UniqueStringArray
+    /// This is effectively an integer, so wherever we need to display this value, we
+    /// must first perform a lookup into the appropriate string table.
+    UniqueString,
 
     // ----------------------------------------------------
     // Numeric types

--- a/fxprof-processed-profile/src/profile.rs
+++ b/fxprof-processed-profile/src/profile.rs
@@ -715,7 +715,7 @@ impl<'a> Serialize for SerializableProfileMeta<'a> {
             }),
         )?;
         map.serialize_entry("interval", &(self.0.interval.as_secs_f64() * 1000.0))?;
-        map.serialize_entry("preprocessedProfileVersion", &48)?;
+        map.serialize_entry("preprocessedProfileVersion", &49)?;
         map.serialize_entry("processType", &0)?;
         map.serialize_entry("product", &self.0.product)?;
         map.serialize_entry(

--- a/fxprof-processed-profile/src/string_table.rs
+++ b/fxprof-processed-profile/src/string_table.rs
@@ -38,7 +38,7 @@ impl Serialize for StringTable {
 }
 
 #[derive(Debug, Clone, Copy, PartialOrd, Ord, PartialEq, Eq, Hash)]
-pub struct GlobalStringIndex(StringIndex);
+pub struct GlobalStringIndex(pub(crate) StringIndex);
 
 #[derive(Debug, Clone, Default)]
 pub struct GlobalStringTable {

--- a/fxprof-processed-profile/tests/integration_tests/main.rs
+++ b/fxprof-processed-profile/tests/integration_tests/main.rs
@@ -5,8 +5,8 @@ use assert_json_diff::assert_json_eq;
 use debugid::DebugId;
 use fxprof_processed_profile::{
     CategoryColor, CategoryHandle, CpuDelta, Frame, FrameFlags, FrameInfo, LibraryInfo,
-    MarkerDynamicField, MarkerFieldFormat, MarkerLocation, MarkerSchema, MarkerSchemaField,
-    MarkerStaticField, MarkerTiming, Profile, ProfilerMarker, ReferenceTimestamp, SamplingInterval,
+    MarkerFieldFormat, MarkerFieldSchema, MarkerLocation, MarkerSchema, MarkerStaticField,
+    MarkerTiming, Profile, ReferenceTimestamp, SamplingInterval, StaticSchemaMarker, StringHandle,
     Symbol, SymbolTable, Timestamp,
 };
 use serde_json::json;
@@ -15,94 +15,121 @@ use serde_json::json;
 
 /// An example marker type with some text content.
 #[derive(Debug, Clone)]
-pub struct TextMarker(pub String);
+pub struct TextMarker {
+    pub name: StringHandle,
+    pub text: StringHandle,
+}
 
-impl ProfilerMarker for TextMarker {
-    const MARKER_TYPE_NAME: &'static str = "Text";
-
-    fn json_marker_data(&self) -> serde_json::Value {
-        json!({
-            "type": Self::MARKER_TYPE_NAME,
-            "name": self.0
-        })
-    }
+impl StaticSchemaMarker for TextMarker {
+    const UNIQUE_MARKER_TYPE_NAME: &'static str = "Text";
 
     fn schema() -> MarkerSchema {
         MarkerSchema {
-            type_name: Self::MARKER_TYPE_NAME,
+            type_name: Self::UNIQUE_MARKER_TYPE_NAME.into(),
             locations: vec![MarkerLocation::MarkerChart, MarkerLocation::MarkerTable],
-            chart_label: Some("{marker.data.name}"),
+            chart_label: Some("{marker.data.name}".into()),
             tooltip_label: None,
-            table_label: Some("{marker.name} - {marker.data.name}"),
-            fields: vec![MarkerSchemaField::Dynamic(MarkerDynamicField {
-                key: "name",
-                label: "Details",
+            table_label: Some("{marker.name} - {marker.data.name}".into()),
+            fields: vec![MarkerFieldSchema {
+                key: "name".into(),
+                label: "Details".into(),
                 format: MarkerFieldFormat::String,
                 searchable: true,
-            })],
+            }],
+            static_fields: vec![],
         }
+    }
+
+    fn name(&self, _profile: &mut Profile) -> StringHandle {
+        self.name
+    }
+
+    fn category(&self, _profile: &mut Profile) -> CategoryHandle {
+        CategoryHandle::OTHER
+    }
+
+    fn string_field_value(&self, _field_index: u32) -> StringHandle {
+        self.text
+    }
+
+    fn number_field_value(&self, _field_index: u32) -> f64 {
+        unreachable!()
     }
 }
 
 #[test]
 fn profile_without_js() {
     struct CustomMarker {
-        event_name: String,
+        event_name: StringHandle,
         allocation_size: u32,
-        url: String,
+        url: StringHandle,
         latency: Duration,
     }
-    impl ProfilerMarker for CustomMarker {
-        const MARKER_TYPE_NAME: &'static str = "custom";
+    impl StaticSchemaMarker for CustomMarker {
+        const UNIQUE_MARKER_TYPE_NAME: &'static str = "custom";
 
         fn schema() -> MarkerSchema {
             MarkerSchema {
-                type_name: Self::MARKER_TYPE_NAME,
+                type_name: Self::UNIQUE_MARKER_TYPE_NAME.into(),
                 locations: vec![MarkerLocation::MarkerChart, MarkerLocation::MarkerTable],
                 chart_label: None,
-                tooltip_label: Some("Custom tooltip label"),
+                tooltip_label: Some("Custom tooltip label".into()),
                 table_label: None,
                 fields: vec![
-                    MarkerSchemaField::Dynamic(MarkerDynamicField {
-                        key: "eventName",
-                        label: "Event name",
+                    MarkerFieldSchema {
+                        key: "eventName".into(),
+                        label: "Event name".into(),
                         format: MarkerFieldFormat::String,
                         searchable: true,
-                    }),
-                    MarkerSchemaField::Dynamic(MarkerDynamicField {
-                        key: "allocationSize",
-                        label: "Allocation size",
+                    },
+                    MarkerFieldSchema {
+                        key: "allocationSize".into(),
+                        label: "Allocation size".into(),
                         format: MarkerFieldFormat::Bytes,
                         searchable: true,
-                    }),
-                    MarkerSchemaField::Dynamic(MarkerDynamicField {
-                        key: "url",
-                        label: "URL",
+                    },
+                    MarkerFieldSchema {
+                        key: "url".into(),
+                        label: "URL".into(),
                         format: MarkerFieldFormat::Url,
                         searchable: true,
-                    }),
-                    MarkerSchemaField::Dynamic(MarkerDynamicField {
-                        key: "latency",
-                        label: "Latency",
+                    },
+                    MarkerFieldSchema {
+                        key: "latency".into(),
+                        label: "Latency".into(),
                         format: MarkerFieldFormat::Duration,
                         searchable: true,
-                    }),
-                    MarkerSchemaField::Static(MarkerStaticField {
-                        label: "Description",
-                        value: "This is a test marker with a custom schema.",
-                    }),
+                    },
                 ],
+                static_fields: vec![MarkerStaticField {
+                    label: "Description".into(),
+                    value: "This is a test marker with a custom schema.".into(),
+                }],
             }
         }
 
-        fn json_marker_data(&self) -> serde_json::Value {
-            json!({
-                "type": Self::MARKER_TYPE_NAME,
-                "eventName": self.event_name,
-                "allocationSize": self.allocation_size,
-                "url": self.url,
-                "latency": self.latency.as_secs_f64() * 1000.0,
-            })
+        fn name(&self, profile: &mut Profile) -> StringHandle {
+            profile.intern_string("CustomName")
+        }
+
+        fn category(&self, _profile: &mut Profile) -> CategoryHandle {
+            CategoryHandle::OTHER
+        }
+
+        fn string_field_value(&self, field_index: u32) -> StringHandle {
+            match field_index {
+                0 => self.event_name,
+                2 => self.url,
+                _ => unreachable!(),
+            }
+        }
+
+        fn number_field_value(&self, field_index: u32) -> f64 {
+            match field_index {
+                1 => self.allocation_size.into(),
+                3 => self.latency.as_secs_f64() * 1000.0,
+                _ => unreachable!(),
+            }
         }
     }
 
@@ -268,27 +295,28 @@ fn profile_without_js() {
         1,
     );
 
+    let text_marker = TextMarker {
+        name: profile.intern_string("Experimental"),
+        text: profile.intern_string("Hello world!"),
+    };
     profile.add_marker(
         thread,
-        CategoryHandle::OTHER,
-        "Experimental",
-        TextMarker("Hello world!".to_string()),
         MarkerTiming::Instant(Timestamp::from_millis_since_reference(0.0)),
+        text_marker,
     );
+    let custom_marker = CustomMarker {
+        event_name: profile.intern_string("My event"),
+        allocation_size: 512000,
+        url: profile.intern_string("https://mozilla.org/"),
+        latency: Duration::from_millis(123),
+    };
     profile.add_marker(
         thread,
-        CategoryHandle::OTHER,
-        "CustomName",
-        CustomMarker {
-            event_name: "My event".to_string(),
-            allocation_size: 512000,
-            url: "https://mozilla.org/".to_string(),
-            latency: Duration::from_millis(123),
-        },
         MarkerTiming::Interval(
             Timestamp::from_millis_since_reference(0.0),
             Timestamp::from_millis_since_reference(2.0),
         ),
+        custom_marker,
     );
 
     let memory_counter =
@@ -370,7 +398,7 @@ fn profile_without_js() {
                     {
                       "key": "name",
                       "label": "Details",
-                      "format": "string",
+                      "format": "unique-string",
                       "searchable": true
                     }
                   ]
@@ -386,7 +414,7 @@ fn profile_without_js() {
                     {
                       "key": "eventName",
                       "label": "Event name",
-                      "format": "string",
+                      "format": "unique-string",
                       "searchable": true
                     },
                     {
@@ -757,15 +785,15 @@ fn profile_without_js() {
                   ],
                   "data": [
                     {
-                      "name": "Hello world!",
-                      "type": "Text"
+                      "type": "Text",
+                      "name": 19
                     },
                     {
-                      "allocationSize": 512000,
-                      "eventName": "My event",
-                      "latency": 123.0,
                       "type": "custom",
-                      "url": "https://mozilla.org/"
+                      "eventName": 21,
+                      "allocationSize": 512000.0,
+                      "url": "https://mozilla.org/",
+                      "latency": 123.0
                     }
                   ],
                   "endTime": [
@@ -774,7 +802,7 @@ fn profile_without_js() {
                   ],
                   "name": [
                     18,
-                    19
+                    20
                   ],
                   "phase": [
                     0,
@@ -838,6 +866,7 @@ fn profile_without_js() {
                 },
                 "samples": {
                   "length": 4,
+                  "weightType": "samples",
                   "stack": [
                     null,
                     6,
@@ -856,7 +885,6 @@ fn profile_without_js() {
                     1,
                     1
                   ],
-                  "weightType": "samples",
                   "threadCPUDelta": [
                     0,
                     0,
@@ -959,7 +987,9 @@ fn profile_without_js() {
                   "0x2778f4",
                   "libc_symbol_3",
                   "Experimental",
-                  "CustomName"
+                  "Hello world!",
+                  "CustomName",
+                  "My event"
                 ],
                 "tid": "12345",
                 "unregisterTime": null

--- a/fxprof-processed-profile/tests/integration_tests/main.rs
+++ b/fxprof-processed-profile/tests/integration_tests/main.rs
@@ -342,7 +342,7 @@ fn profile_without_js() {
                 "name": []
               },
               "interval": 1.0,
-              "preprocessedProfileVersion": 48,
+              "preprocessedProfileVersion": 49,
               "processType": 0,
               "product": "test",
               "sampleUnits": {
@@ -1066,7 +1066,7 @@ fn profile_with_js() {
                 "name": []
               },
               "interval": 1.0,
-              "preprocessedProfileVersion": 48,
+              "preprocessedProfileVersion": 49,
               "processType": 0,
               "product": "test with js",
               "sampleUnits": {
@@ -1322,7 +1322,7 @@ fn profile_counters_with_sorted_processes() {
                 "name": []
               },
               "interval": 1.0,
-              "preprocessedProfileVersion": 48,
+              "preprocessedProfileVersion": 49,
               "processType": 0,
               "product": "test",
               "sampleUnits": {

--- a/samply/src/linux_shared/process.rs
+++ b/samply/src/linux_shared/process.rs
@@ -2,8 +2,8 @@ use std::path::{Path, PathBuf};
 
 use framehop::Unwinder;
 use fxprof_processed_profile::{
-    CategoryHandle, CounterHandle, FrameInfo, LibraryHandle, MarkerTiming, ProcessHandle, Profile,
-    ThreadHandle, Timestamp,
+    CounterHandle, FrameInfo, LibraryHandle, MarkerTiming, ProcessHandle, Profile, ThreadHandle,
+    Timestamp,
 };
 
 use super::process_threads::ProcessThreads;
@@ -297,13 +297,11 @@ where
     ) {
         let main_thread = self.threads.main_thread.profile_thread;
         let timing = MarkerTiming::Instant(profile_timestamp);
-        profile.add_marker(
-            main_thread,
-            CategoryHandle::OTHER,
-            "JitFunctionAdd",
-            JitFunctionAddMarker(symbol_name.unwrap_or("<unknown>").to_owned()),
-            timing,
-        );
+        let name = match symbol_name {
+            Some(name) => profile.intern_string(name),
+            None => profile.intern_string("<unknown>"),
+        };
+        profile.add_marker(main_thread, timing, JitFunctionAddMarker(name));
 
         if let (Some(name), Some(recycler)) = (symbol_name, self.jit_function_recycler.as_mut()) {
             let code_size = (end_address - start_address) as u32;

--- a/samply/src/shared/jit_function_add_marker.rs
+++ b/samply/src/shared/jit_function_add_marker.rs
@@ -1,41 +1,47 @@
 use fxprof_processed_profile::{
-    MarkerDynamicField, MarkerFieldFormat, MarkerLocation, MarkerSchema, MarkerSchemaField,
-    MarkerStaticField, ProfilerMarker,
+    CategoryHandle, MarkerFieldFormat, MarkerFieldSchema, MarkerLocation, MarkerSchema,
+    MarkerStaticField, Profile, StaticSchemaMarker, StringHandle,
 };
-use serde_json::json;
 
 #[derive(Debug, Clone)]
-pub struct JitFunctionAddMarker(pub String);
+pub struct JitFunctionAddMarker(pub StringHandle);
 
-impl ProfilerMarker for JitFunctionAddMarker {
-    const MARKER_TYPE_NAME: &'static str = "JitFunctionAdd";
-
-    fn json_marker_data(&self) -> serde_json::Value {
-        json!({
-            "type": Self::MARKER_TYPE_NAME,
-            "functionName": self.0
-        })
-    }
+impl StaticSchemaMarker for JitFunctionAddMarker {
+    const UNIQUE_MARKER_TYPE_NAME: &'static str = "JitFunctionAdd";
 
     fn schema() -> MarkerSchema {
         MarkerSchema {
-            type_name: Self::MARKER_TYPE_NAME,
+            type_name: Self::UNIQUE_MARKER_TYPE_NAME.into(),
             locations: vec![MarkerLocation::MarkerChart, MarkerLocation::MarkerTable],
-            chart_label: Some("{marker.data.functionName}"),
-            tooltip_label: Some("{marker.data.functionName}"),
-            table_label: Some("{marker.data.functionName}"),
-            fields: vec![
-                MarkerSchemaField::Dynamic(MarkerDynamicField {
-                    key: "functionName",
-                    label: "Function",
-                    format: MarkerFieldFormat::String,
-                    searchable: true,
-                }),
-                MarkerSchemaField::Static(MarkerStaticField {
-                    label: "Description",
-                    value: "Emitted when a JIT function is added to the process.",
-                }),
-            ],
+            chart_label: Some("{marker.data.n}".into()),
+            tooltip_label: Some("{marker.data.n}".into()),
+            table_label: Some("{marker.data.n}".into()),
+            fields: vec![MarkerFieldSchema {
+                key: "n".into(),
+                label: "Function".into(),
+                format: MarkerFieldFormat::String,
+                searchable: true,
+            }],
+            static_fields: vec![MarkerStaticField {
+                label: "Description".into(),
+                value: "Emitted when a JIT function is added to the process.".into(),
+            }],
         }
+    }
+
+    fn name(&self, profile: &mut Profile) -> StringHandle {
+        profile.intern_string("JitFunctionAdd")
+    }
+
+    fn category(&self, _profile: &mut Profile) -> CategoryHandle {
+        CategoryHandle::OTHER
+    }
+
+    fn string_field_value(&self, _field_index: u32) -> StringHandle {
+        self.0
+    }
+
+    fn number_field_value(&self, _field_index: u32) -> f64 {
+        unreachable!()
     }
 }

--- a/samply/src/shared/jitdump_manager.rs
+++ b/samply/src/shared/jitdump_manager.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use fxprof_processed_profile::{
-    CategoryHandle, LibraryHandle, MarkerTiming, Profile, Symbol, SymbolTable, ThreadHandle,
+    LibraryHandle, MarkerTiming, Profile, Symbol, SymbolTable, ThreadHandle,
 };
 use linux_perf_data::jitdump::{JitDumpReader, JitDumpRecord, JitDumpRecordType};
 
@@ -187,13 +187,11 @@ impl SingleJitDumpProcessor {
                     });
 
                     let timestamp = timestamp_converter.convert_time(raw_jitdump_record.timestamp);
-                    let timing = MarkerTiming::Instant(timestamp);
+                    let symbol_name_handle = profile.intern_string(symbol_name);
                     profile.add_marker(
                         self.thread_handle,
-                        CategoryHandle::OTHER,
-                        "JitFunctionAdd",
-                        JitFunctionAddMarker(symbol_name.to_owned()),
-                        timing,
+                        MarkerTiming::Instant(timestamp),
+                        JitFunctionAddMarker(symbol_name_handle),
                     );
 
                     let (lib_handle, relative_address_at_start) =


### PR DESCRIPTION
This commit makes the following changes:

1. The main trait has been renamed from ProfilerMarker to Marker, and a
new trait named StaticSchemaMarker has been added.
2. The static and dynamic fields in the marker schema are now specified
separately, in the schema's `fields` and `static_fields` properties.
3. You can now define schemas at runtime. Previously, the schema had to
be known at compile time.
4. The marker name and category are now part of the marker, and are no
longer specified as separate arguments.
5. The values for the dynamic fields are now queried from two new methods,
string_field_value and number_field_value. The previous method named
json_marker_data has been removed.
6. Strings are now serialized as string indexes. This saves space when
multiple markers use the same string field value.

The string deduplication reduced the JSON size from 350MB to 210MB on
one example profile I was testing with (4 iterations of sp3 with lots of
JitFunctionAdd markers and --reuse-threads).