### PR TITLE
Add --time-range option for import for Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1914,6 +1914,7 @@ dependencies = [
  "fxhash",
  "fxprof-processed-profile",
  "http-body-util",
+ "humantime",
  "hyper",
  "hyper-util",
  "lazy_static",

--- a/fxprof-processed-profile/src/timestamp.rs
+++ b/fxprof-processed-profile/src/timestamp.rs
@@ -5,7 +5,7 @@ use serde::ser::{Serialize, Serializer};
 /// Timestamps in the profile are stored in reference to the profile's [`ReferenceTimestamp`](crate::ReferenceTimestamp).
 #[derive(Debug, Clone, Copy, PartialOrd, Ord, PartialEq, Eq, Hash)]
 pub struct Timestamp {
-    pub nanos: u64,
+    nanos: u64,
 }
 
 impl Timestamp {

--- a/fxprof-processed-profile/src/timestamp.rs
+++ b/fxprof-processed-profile/src/timestamp.rs
@@ -5,7 +5,7 @@ use serde::ser::{Serialize, Serializer};
 /// Timestamps in the profile are stored in reference to the profile's [`ReferenceTimestamp`](crate::ReferenceTimestamp).
 #[derive(Debug, Clone, Copy, PartialOrd, Ord, PartialEq, Eq, Hash)]
 pub struct Timestamp {
-    nanos: u64,
+    pub nanos: u64,
 }
 
 impl Timestamp {

--- a/samply/Cargo.toml
+++ b/samply/Cargo.toml
@@ -50,6 +50,7 @@ log = "0.4.21"
 env_logger = "0.11.3"
 cfg-if = "1.0.0"
 fs4 = "0.8.3"
+humantime = "2.1.0"
 
 [target.'cfg(any(target_os = "android", target_os = "macos", target_os = "linux"))'.dependencies]
 

--- a/samply/src/main.rs
+++ b/samply/src/main.rs
@@ -519,13 +519,6 @@ impl ImportArgs {
             let name = self.file.file_name().unwrap_or(self.file.as_os_str());
             name.to_string_lossy().into()
         };
-        cfg_if::cfg_if! {
-            if #[cfg(target_os = "windows")] {
-                let time_range = self.time_range;
-            } else {
-                let time_range = None;
-            }
-        }
         ProfileCreationProps {
             profile_name,
             main_thread_only: self.profile_creation_args.main_thread_only,
@@ -540,7 +533,10 @@ impl ImportArgs {
             unknown_event_markers: self.profile_creation_args.unknown_event_markers,
             #[cfg(not(target_os = "windows"))]
             unknown_event_markers: false,
-            time_range,
+            #[cfg(target_os = "windows")]
+            time_range: self.time_range,
+            #[cfg(not(target_os = "windows"))]
+            time_range: None,
         }
     }
 
@@ -580,22 +576,20 @@ impl RecordArgs {
             std::process::exit(1);
         }
         let interval = Duration::from_secs_f64(1.0 / self.rate);
-        cfg_if::cfg_if! {
-            if #[cfg(target_os = "windows")] {
-                let (vm_hack, keep_etl) = (self.vm_hack, self.keep_etl);
-            } else {
-                let (vm_hack, keep_etl) = (false, false);
-            }
-        }
-
         RecordingProps {
             output_file: self.output.clone(),
             time_limit,
             interval,
-            vm_hack,
             gfx: self.gfx,
             browsers: self.browsers,
-            keep_etl,
+            #[cfg(target_os = "windows")]
+            vm_hack: self.vm_hack,
+            #[cfg(not(target_os = "windows"))]
+            vm_hack: None,
+            #[cfg(target_os = "windows")]
+            keep_etl: self.keep_etl,
+            #[cfg(not(target_os = "windows"))]
+            keep_etl: None,
         }
     }
 

--- a/samply/src/main.rs
+++ b/samply/src/main.rs
@@ -148,10 +148,12 @@ struct ImportArgs {
     coreclr: Vec<CoreClrArgs>,
 
     /// Time range of recording to include in profile. Format is "start-stop" or "start+duration" with each part optional, e.g. "5s", "5s-", "-10s", "1s-10s" or "1s+9s".
+    #[cfg(target_os = "windows")]
     #[arg(long, value_parser=parse_time_range)]
     time_range: Option<(std::time::Duration, std::time::Duration)>,
 }
 
+#[allow(unused)]
 fn parse_time_range(
     arg: &str,
 ) -> Result<(std::time::Duration, std::time::Duration), humantime::DurationError> {
@@ -517,6 +519,13 @@ impl ImportArgs {
             let name = self.file.file_name().unwrap_or(self.file.as_os_str());
             name.to_string_lossy().into()
         };
+        cfg_if::cfg_if! {
+            if #[cfg(target_os = "windows")] {
+                let time_range = self.time_range;
+            } else {
+                let time_range = None;
+            }
+        }
         ProfileCreationProps {
             profile_name,
             main_thread_only: self.profile_creation_args.main_thread_only,
@@ -531,7 +540,7 @@ impl ImportArgs {
             unknown_event_markers: self.profile_creation_args.unknown_event_markers,
             #[cfg(not(target_os = "windows"))]
             unknown_event_markers: false,
-            time_range: self.time_range,
+            time_range,
         }
     }
 

--- a/samply/src/main.rs
+++ b/samply/src/main.rs
@@ -585,11 +585,11 @@ impl RecordArgs {
             #[cfg(target_os = "windows")]
             vm_hack: self.vm_hack,
             #[cfg(not(target_os = "windows"))]
-            vm_hack: None,
+            vm_hack: false,
             #[cfg(target_os = "windows")]
             keep_etl: self.keep_etl,
             #[cfg(not(target_os = "windows"))]
-            keep_etl: None,
+            keep_etl: false,
         }
     }
 

--- a/samply/src/shared/recording_props.rs
+++ b/samply/src/shared/recording_props.rs
@@ -36,6 +36,7 @@ pub struct RecordingProps {
     pub gfx: bool,
     #[allow(dead_code)]
     pub browsers: bool,
+    #[allow(dead_code)]
     pub keep_etl: bool,
 }
 
@@ -89,6 +90,7 @@ pub struct ProfileCreationProps {
     #[allow(dead_code)]
     pub unknown_event_markers: bool,
     /// Time range to include, relative to start of recording.
+    #[allow(dead_code)]
     pub time_range: Option<(std::time::Duration, std::time::Duration)>,
 }
 

--- a/samply/src/shared/recording_props.rs
+++ b/samply/src/shared/recording_props.rs
@@ -33,6 +33,7 @@ pub struct RecordingProps {
     pub vm_hack: bool,
     pub gfx: bool,
     pub browsers: bool,
+    pub keep_etl: bool,
 }
 
 /// Which process(es) to record.
@@ -81,6 +82,8 @@ pub struct ProfileCreationProps {
     pub coreclr: CoreClrProfileProps,
     /// Create markers for unknown events.
     pub unknown_event_markers: bool,
+    pub tstart: Option<u32>,
+    pub tstop: Option<u32>,
 }
 
 /// Properties which are meaningful for launching and recording a fresh process.

--- a/samply/src/shared/recording_props.rs
+++ b/samply/src/shared/recording_props.rs
@@ -82,8 +82,8 @@ pub struct ProfileCreationProps {
     pub coreclr: CoreClrProfileProps,
     /// Create markers for unknown events.
     pub unknown_event_markers: bool,
-    pub tstart: Option<u32>,
-    pub tstop: Option<u32>,
+    /// Time range to include, relative to start of recording.
+    pub time_range: Option<(std::time::Duration, std::time::Duration)>,
 }
 
 /// Properties which are meaningful for launching and recording a fresh process.

--- a/samply/src/windows/etw_gecko.rs
+++ b/samply/src/windows/etw_gecko.rs
@@ -386,7 +386,13 @@ pub fn profile_pid_from_etl_file(context: &mut ProfileContext, etl_file: &Path) 
             dotnet_event if dotnet_event.starts_with("Microsoft-Windows-DotNETRuntime") => {
                 let is_in_range = context.is_in_time_range(timestamp_raw);
                 // Note: No "/" at end of event name, because we want DotNETRuntimeRundown as well
-                coreclr::handle_coreclr_event(context, &mut core_clr_context, &s, &mut parser, is_in_range);
+                coreclr::handle_coreclr_event(
+                    context,
+                    &mut core_clr_context,
+                    &s,
+                    &mut parser,
+                    is_in_range,
+                );
             }
             _ => {
                 if !context.is_in_time_range(timestamp_raw) {

--- a/samply/src/windows/import.rs
+++ b/samply/src/windows/import.rs
@@ -28,6 +28,8 @@ pub fn convert_etl_file_to_profile(
 
     let arch = get_native_arch(); // TODO: Detect arch from file
 
+    eprintln!("Processing ETL trace...");
+
     let mut context =
         ProfileContext::new(profile, arch, included_processes, profile_creation_props);
 

--- a/samply/src/windows/profile_context.rs
+++ b/samply/src/windows/profile_context.rs
@@ -46,6 +46,7 @@ pub struct PendingStack {
 #[derive(Debug)]
 pub struct MemoryUsage {
     pub counter: CounterHandle,
+    #[allow(dead_code)]
     pub value: f64,
 }
 
@@ -101,12 +102,15 @@ pub struct PendingMarker {
 #[derive(Debug)]
 pub struct ThreadState {
     pub name: Option<String>,
+    #[allow(dead_code)]
     pub is_main_thread: bool,
     pub handle: ThreadHandle,
     pub label_frame: FrameInfo,
     pub pending_stacks: VecDeque<PendingStack>,
     pub context_switch_data: ThreadContextSwitchData,
+    #[allow(dead_code)]
     pub thread_id: u32,
+    #[allow(dead_code)]
     pub process_id: u32,
     pub pending_markers: HashMap<String, PendingMarker>,
 }
@@ -145,6 +149,7 @@ pub struct ProcessState {
     pub pending_libraries: HashMap<u64, LibraryInfo>,
     pub memory_usage: Option<MemoryUsage>,
     pub process_id: u32,
+    #[allow(dead_code)]
     pub parent_id: u32,
     pub jit_info: ProcessJitInfo,
     pub thread_recycler: Option<ThreadRecycler>,

--- a/samply/src/windows/profile_context.rs
+++ b/samply/src/windows/profile_context.rs
@@ -1735,58 +1735,6 @@ impl ProfileContext {
         //println!("unhandled {}", s.name())
     }
 
-    // Given an image file and an optional command line, try to pull out an informative process name.
-    // The command line is expected to contain the actual command as the first argument. (e.g. if the
-    // image is "C:\...\dotnet.exe", the command line should contain "dotnet.exe myapp.dll").
-    fn name_for_process(&self, image_file_name: &str, command_line: Option<&str>) -> String {
-        let image_path_str = self.map_device_path(image_file_name);
-        let Some(command_line) = command_line else {
-            return image_path_str;
-        };
-        let Ok(image_path) = PathBuf::from_str(&image_path_str) else {
-            return image_path_str;
-        };
-        let Some(file_name) = image_path.file_name().map(|s| s.to_string_lossy()) else {
-            return image_path_str;
-        };
-
-        // Super hacky command line parsing; split at spaces, remove any surrounding quotes.
-        // Will break if paths have embedded spaces.
-        let parts = command_line
-            .split(' ')
-            .map(|s| s.trim_matches(|c| c == '"' || c == '\''));
-
-        if file_name == "dotnet.exe" {
-            eprintln!("dotnet.exe: {}", command_line);
-            if let Some(dotnet_dll) = parts
-                .skip(1)
-                .filter(|&s| {
-                    let lc = s.to_ascii_lowercase();
-                    lc.ends_with(".dll") || lc.ends_with(".exe")
-                })
-                .nth(0)
-            {
-                if let Ok(dotnet_dll_path) = PathBuf::from_str(&dotnet_dll) {
-                    return format!(
-                        "{} (.NET)",
-                        dotnet_dll_path.file_name().unwrap().to_string_lossy()
-                    );
-                }
-            }
-        } else if file_name == "cmd.exe" {
-            eprintln!("cmd.exe: {}", command_line);
-            if let Some(cmd_name) = parts
-                .filter(|&s| !s.starts_with('/') && !s.starts_with('-'))
-                .nth(0)
-            {
-                return format!("{} (cmd)", cmd_name);
-            }
-        }
-
-        // Fall back to the image file name
-        image_path_str
-    }
-
     pub fn is_in_time_range(&self, ts_raw: u64) -> bool {
         let ts = ts_raw - self.timestamp_converter.reference_raw;
         if self.tstart_ns.is_some() && ts < self.tstart_ns.unwrap() {

--- a/samply/src/windows/profiler.rs
+++ b/samply/src/windows/profiler.rs
@@ -148,13 +148,16 @@ pub fn start_recording(
     etw_gecko::profile_pid_from_etl_file(&mut context, &merged_etl);
     let profile = context.finish();
 
-    // delete etl_file
-    std::fs::remove_file(&merged_etl).unwrap_or_else(|_| {
-        panic!(
-            "Failed to delete ETL file {:?}",
-            merged_etl.to_str().unwrap()
-        )
-    });
+    if !recording_props.keep_etl {
+        std::fs::remove_file(&merged_etl).unwrap_or_else(|_| {
+            panic!(
+                "Failed to delete ETL file {:?}",
+                merged_etl.to_str().unwrap()
+            )
+        });
+    } else {
+        eprintln!("ETL path: {:?}", merged_etl);
+    }
 
     // write the profile to a json file
     let file = File::create(&output_file).unwrap();


### PR DESCRIPTION
Add a `--time-range` option for `import` on Windows to allow specifying a time range to include in the profile.json from the ETL file. Processing still tracks process/thread/image lifecycle, but samples and events are only added if they're within this time range. This is very helpful in exploring a very large trace to avoid running into profile.json file size issues. (Could be implemented on other platforms as well, though typically the profiles there are much smaller.)

