### PR TITLE
Stop using string indexes in marker fields for now.

### DIFF
--- a/fxprof-processed-profile/src/marker_table.rs
+++ b/fxprof-processed-profile/src/marker_table.rs
@@ -4,10 +4,7 @@ use crate::markers::{InternalMarkerSchema, MarkerFieldFormatKind};
 use crate::serialization_helpers::SerializableOptionalTimestampColumn;
 use crate::string_table::{GlobalStringIndex, GlobalStringTable, StringIndex};
 use crate::thread_string_table::{ThreadInternalStringIndex, ThreadStringTable};
-use crate::{
-    CategoryHandle, Marker, MarkerFieldFormat, MarkerHandle, MarkerTiming, MarkerTypeHandle,
-    Timestamp,
-};
+use crate::{CategoryHandle, Marker, MarkerHandle, MarkerTiming, MarkerTypeHandle, Timestamp};
 
 #[derive(Debug, Clone, Default)]
 pub struct MarkerTable {
@@ -30,15 +27,10 @@ pub struct MarkerTable {
     /// type's schema's `string_field_count`. For the marker with index i,
     /// its field values will be at index sum_{k in 0..i}(marker_schema[k].string_field_count).
     ///
-    /// The [`StringIndex`] can be either a [`ThreadInternalStringIndex`] or a [`GlobalStringIndex`],
-    /// depending on the string field's format - if the field format is [`MarkerFieldFormat::String`],
-    /// the string index will be thread-internal, for all the other string format variants the
-    /// index will be global.
-    ///
-    /// We make this distinction because, in the actual JSON, we currently only use string indexes for
-    /// the [`MarkerFieldFormat::String`] format (serialized as "unique-string"). The other
-    /// string format variants currently still use actual strings in the JSON, not string indexes.
-    /// So for these we don't want to add the strings to the thread's string table.
+    /// The [`StringIndex`] is always a [`GlobalStringIndex`]. In the future, once we start treating
+    /// `MarkerFieldFormat::String` as `format: "unique-string"`, it'll be a thread-internal index
+    /// for those fields. Using "unique-string" is currently blocked by
+    /// https://github.com/firefox-devtools/profiler/issues/5034 .
     ///
     /// https://github.com/firefox-devtools/profiler/issues/5022 tracks supporting string indexes
     /// for the other string format variants.
@@ -59,8 +51,8 @@ impl MarkerTable {
         marker: T,
         timing: MarkerTiming,
         category: CategoryHandle,
-        thread_string_table: &mut ThreadStringTable,
-        global_string_table: &mut GlobalStringTable,
+        _thread_string_table: &mut ThreadStringTable,
+        _global_string_table: &mut GlobalStringTable,
     ) -> MarkerHandle {
         let (s, e, phase) = match timing {
             MarkerTiming::Instant(s) => (Some(s), None, Phase::Instant),
@@ -79,16 +71,7 @@ impl MarkerTable {
             match field.format.kind() {
                 MarkerFieldFormatKind::String => {
                     let global_string_index = marker.string_field_value(field_index as u32).0;
-                    let string_index = if field.format == MarkerFieldFormat::String {
-                        // This one ends up as `format: "unique-string"` with an index into the thread string table
-                        let thread_string_index = thread_string_table
-                            .index_for_global_string(global_string_index, global_string_table);
-                        thread_string_index.0
-                    } else {
-                        // These end up in the JSON as JSON strings, not as string indexes.
-                        global_string_index.0
-                    };
-                    self.marker_field_string_values.push(string_index);
+                    self.marker_field_string_values.push(global_string_index.0);
                 }
                 MarkerFieldFormatKind::Number => {
                     let number_value = marker.number_field_value(field_index as u32);
@@ -205,14 +188,10 @@ impl<'a> Serialize for SerializableMarkerDataElement<'a> {
                 MarkerFieldFormatKind::String => {
                     let value;
                     (value, string_fields) = string_fields.split_first().unwrap();
-                    if field.format == MarkerFieldFormat::String {
-                        map.serialize_entry(&field.key, value)?;
-                    } else {
-                        let str_val = global_string_table
-                            .get_string(GlobalStringIndex(*value))
-                            .unwrap();
-                        map.serialize_entry(&field.key, str_val)?;
-                    }
+                    let str_val = global_string_table
+                        .get_string(GlobalStringIndex(*value))
+                        .unwrap();
+                    map.serialize_entry(&field.key, str_val)?;
                 }
                 MarkerFieldFormatKind::Number => {
                     let value;

--- a/fxprof-processed-profile/src/markers.rs
+++ b/fxprof-processed-profile/src/markers.rs
@@ -501,7 +501,6 @@ pub enum MarkerFieldFormat {
     /// Important: Do not put URL or file path information here, as it will not
     /// be sanitized during profile upload. Please be careful with including
     /// other types of PII here as well.
-    #[serde(rename = "unique-string")]
     String,
 
     // ----------------------------------------------------

--- a/fxprof-processed-profile/tests/integration_tests/main.rs
+++ b/fxprof-processed-profile/tests/integration_tests/main.rs
@@ -398,7 +398,7 @@ fn profile_without_js() {
                     {
                       "key": "name",
                       "label": "Details",
-                      "format": "unique-string",
+                      "format": "string",
                       "searchable": true
                     }
                   ]
@@ -414,7 +414,7 @@ fn profile_without_js() {
                     {
                       "key": "eventName",
                       "label": "Event name",
-                      "format": "unique-string",
+                      "format": "string",
                       "searchable": true
                     },
                     {
@@ -786,11 +786,11 @@ fn profile_without_js() {
                   "data": [
                     {
                       "type": "Text",
-                      "name": 19
+                      "name": "Hello world!"
                     },
                     {
                       "type": "custom",
-                      "eventName": 21,
+                      "eventName": "My event",
                       "allocationSize": 512000.0,
                       "url": "https://mozilla.org/",
                       "latency": 123.0
@@ -802,7 +802,7 @@ fn profile_without_js() {
                   ],
                   "name": [
                     18,
-                    20
+                    19
                   ],
                   "phase": [
                     0,
@@ -987,9 +987,7 @@ fn profile_without_js() {
                   "0x2778f4",
                   "libc_symbol_3",
                   "Experimental",
-                  "Hello world!",
-                  "CustomName",
-                  "My event"
+                  "CustomName"
                 ],
                 "tid": "12345",
                 "unregisterTime": null


### PR DESCRIPTION
These strings are currently not searchable in the UI: https://github.com/firefox-devtools/profiler/issues/5034

Once that bug is fixed, this patch can be reverted.