### PR TITLE
Don't create double slashes in symbol file URLs.

### DIFF
--- a/wholesym/src/debuginfod.rs
+++ b/wholesym/src/debuginfod.rs
@@ -115,6 +115,7 @@ impl ManualDebuginfodSymbolCache {
         server_base_url: &str,
         cache_dir: &Path,
     ) -> Result<PathBuf, Box<dyn std::error::Error>> {
+        let server_base_url = server_base_url.trim_end_matches('/');
         let url = format!("{server_base_url}/buildid/{buildid}/{file_type}");
         if self.verbose {
             eprintln!("Downloading {url}...");

--- a/wholesym/src/helper.rs
+++ b/wholesym/src/helper.rs
@@ -471,6 +471,7 @@ impl Helper {
         server_base_url: &str,
         cache_dir: &Path,
     ) -> FileAndPathHelperResult<WholesymFileContents> {
+        let server_base_url = server_base_url.trim_end_matches('/');
         let url = format!("{server_base_url}/{rel_path}");
         if self.config.verbose {
             eprintln!("Downloading {url}...");


### PR DESCRIPTION
I was running with `--breakpad-symbol-server https://symbols.mozilla.org/try/`, and then samply requested `https://symbols.mozilla.org/try//libxul.so/4851DB73C888BF1D404E0484D2077A4C0/libxul.so.sym`, which is a 404 due to the double slash.