### PR TITLE
Add an --include-args=<N> CLI argument.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1959,6 +1959,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
+ "shlex",
  "sysctl",
  "tempfile",
  "thiserror",
@@ -2095,6 +2096,12 @@ dependencies = [
  "ryu",
  "serde",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "slab"

--- a/samply/Cargo.toml
+++ b/samply/Cargo.toml
@@ -51,6 +51,7 @@ env_logger = "0.11.3"
 cfg-if = "1.0.0"
 fs4 = "0.8.3"
 humantime = "2.1.0"
+shlex = "1.3.0"
 
 [target.'cfg(any(target_os = "android", target_os = "macos", target_os = "linux"))'.dependencies]
 

--- a/samply/src/main.rs
+++ b/samply/src/main.rs
@@ -356,6 +356,13 @@ pub struct ProfileCreationArgs {
     #[arg(long)]
     per_cpu_threads: bool,
 
+    /// Include up to <INCLUDE_ARGS> command line arguments in the process name.
+    /// This can help differentiate processes if the same executable is used
+    /// for different types of programs. And in --reuse-threads mode it
+    /// allows more control over which processes are matched up.
+    #[arg(long, default_value = "0", num_args=0..=1, require_equals = true, default_missing_value = "100")]
+    include_args: usize,
+
     /// Emit .syms.json sidecar file containing gathered symbol info for all frames referenced by
     /// this profile. With this file along with the profile, samply can load the profile
     /// and provide symbols to the front end without needing debug files to be
@@ -526,6 +533,7 @@ impl ImportArgs {
             fold_recursive_prefix: self.profile_creation_args.fold_recursive_prefix,
             unlink_aux_files: self.profile_creation_args.unlink_aux_files,
             create_per_cpu_threads: self.profile_creation_args.per_cpu_threads,
+            arg_count_to_include_in_process_name: self.profile_creation_args.include_args,
             override_arch: self.override_arch.clone(),
             unstable_presymbolicate: self.profile_creation_args.unstable_presymbolicate,
             coreclr: to_coreclr_profile_props(&self.coreclr),
@@ -643,6 +651,7 @@ impl RecordArgs {
             fold_recursive_prefix: self.profile_creation_args.fold_recursive_prefix,
             unlink_aux_files: self.profile_creation_args.unlink_aux_files,
             create_per_cpu_threads: self.profile_creation_args.per_cpu_threads,
+            arg_count_to_include_in_process_name: self.profile_creation_args.include_args,
             override_arch: None,
             unstable_presymbolicate: self.profile_creation_args.unstable_presymbolicate,
             coreclr: to_coreclr_profile_props(&self.coreclr),

--- a/samply/src/shared/mod.rs
+++ b/samply/src/shared/mod.rs
@@ -8,6 +8,7 @@ pub mod jitdump_manager;
 pub mod lib_mappings;
 pub mod marker_file;
 pub mod perf_map;
+pub mod process_name;
 pub mod process_sample_data;
 pub mod recording_props;
 pub mod recycling;

--- a/samply/src/shared/process_name.rs
+++ b/samply/src/shared/process_name.rs
@@ -1,0 +1,16 @@
+#[allow(dead_code)]
+pub fn make_process_name(
+    executable: &str,
+    args: Vec<String>,
+    arg_count_to_include: usize,
+) -> String {
+    let mut args = args.iter().map(std::ops::Deref::deref);
+    let _executable = args.next();
+    let mut included_args = args.take(arg_count_to_include).peekable();
+    if included_args.peek().is_some() {
+        let joined_args = shlex::try_join(included_args).unwrap_or_default();
+        format!("{executable} {joined_args}")
+    } else {
+        executable.to_owned()
+    }
+}

--- a/samply/src/shared/recording_props.rs
+++ b/samply/src/shared/recording_props.rs
@@ -63,7 +63,7 @@ impl RecordingMode {
 }
 
 /// Properties which are meaningful both for recording a profile and
-/// for converting a perf.data file to a profile.
+/// for converting a perf.data / ETL file to a profile.
 #[derive(Debug, Clone)]
 pub struct ProfileCreationProps {
     pub profile_name: String,
@@ -78,6 +78,8 @@ pub struct ProfileCreationProps {
     pub unlink_aux_files: bool,
     /// Create a separate thread for each CPU.
     pub create_per_cpu_threads: bool,
+    /// Include up to N command line arguments in the process name
+    pub arg_count_to_include_in_process_name: usize,
     /// Override system architecture.
     #[allow(dead_code)]
     pub override_arch: Option<String>,

--- a/samply/src/windows/etw_gecko.rs
+++ b/samply/src/windows/etw_gecko.rs
@@ -93,7 +93,14 @@ pub fn profile_pid_from_etl_file(context: &mut ProfileContext, etl_file: &Path) 
                 let pid: u32 = parser.parse("ProcessId");
                 let parent_pid: u32 = parser.parse("ParentId");
                 let image_file_name: String = parser.parse("ImageFileName");
-                context.handle_process_dcstart(timestamp_raw, pid, parent_pid, image_file_name);
+                let cmdline: String = parser.parse("CommandLine");
+                context.handle_process_dcstart(
+                    timestamp_raw,
+                    pid,
+                    parent_pid,
+                    image_file_name,
+                    cmdline,
+                );
             }
             "MSNT_SystemTrace/Process/Start" => {
                 // note: the event's e.EventHeader.process_id here is the parent (i.e. the process that spawned
@@ -102,7 +109,14 @@ pub fn profile_pid_from_etl_file(context: &mut ProfileContext, etl_file: &Path) 
                 let pid: u32 = parser.parse("ProcessId");
                 let parent_pid: u32 = parser.parse("ParentId");
                 let image_file_name: String = parser.parse("ImageFileName");
-                context.handle_process_start(timestamp_raw, pid, parent_pid, image_file_name);
+                let cmdline: String = parser.parse("CommandLine");
+                context.handle_process_start(
+                    timestamp_raw,
+                    pid,
+                    parent_pid,
+                    image_file_name,
+                    cmdline,
+                );
             }
             "MSNT_SystemTrace/Process/End" => {
                 let pid: u32 = parser.parse("ProcessId");


### PR DESCRIPTION
Often it is necessary to look at the arguments that a process was launched with if you want to figure out what that process was supposed to do. This commit adds those arguments to the process name in the proflie. You can specify a number to limit the number of arguments.

Note that the profiler UI currently doesn't deal with long process names very well; in the thread list at the top, the name is truncated and the tooltip doesn't show it, but in the call tree, the scope bar shows the entire name, and if it's very long, it overflows and causes extra horizontal scrollbars and doesn't shrink if any calltree transforms are added.