### PR TITLE
Save profiles with gzip compression by default (as profile.json.gz)

### DIFF
--- a/samply/src/linux/profiler.rs
+++ b/samply/src/linux/profiler.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 use std::fs::File;
-use std::io::BufWriter;
 use std::ops::Deref;
 use std::os::unix::process::ExitStatusExt;
 use std::path::Path;
@@ -29,6 +28,7 @@ use crate::shared::ctrl_c::CtrlC;
 use crate::shared::recording_props::{
     ProcessLaunchProps, ProfileCreationProps, RecordingMode, RecordingProps,
 };
+use crate::shared::save_profile::save_profile_to_file;
 use crate::shared::symbol_props::SymbolProps;
 
 #[cfg(target_arch = "x86_64")]
@@ -723,11 +723,7 @@ fn run_profiler(
 
     let profile = converter.finish();
 
-    {
-        let output_file = File::create(output_filename).unwrap();
-        let writer = BufWriter::new(output_file);
-        serde_json::to_writer(writer, &profile).expect("Couldn't write JSON");
-    }
+    save_profile_to_file(&profile, output_filename).expect("Couldn't write JSON");
 
     if unstable_presymbolicate {
         crate::shared::symbol_precog::presymbolicate(

--- a/samply/src/mac/profiler.rs
+++ b/samply/src/mac/profiler.rs
@@ -1,13 +1,11 @@
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::fs::File;
-use std::io::BufWriter;
 use std::process::ExitStatus;
 use std::thread;
 use std::time::Duration;
 
 use crossbeam_channel::unbounded;
-use serde_json::to_writer;
 
 use super::error::SamplingError;
 use super::process_launcher::{
@@ -19,6 +17,7 @@ use crate::server::{start_server_main, ServerProps};
 use crate::shared::recording_props::{
     ProcessLaunchProps, ProfileCreationProps, RecordingMode, RecordingProps,
 };
+use crate::shared::save_profile::save_profile_to_file;
 use crate::shared::symbol_props::SymbolProps;
 
 pub fn start_recording(
@@ -206,12 +205,7 @@ pub fn start_recording(
         }
     };
 
-    {
-        // Write the profile to a file.
-        let file = File::create(&output_file).unwrap();
-        let writer = BufWriter::new(file);
-        to_writer(writer, &profile).expect("Couldn't write JSON");
-    }
+    save_profile_to_file(&profile, &output_file).expect("Couldn't write JSON");
 
     if unstable_presymbolicate {
         crate::shared::symbol_precog::presymbolicate(

--- a/samply/src/shared/mod.rs
+++ b/samply/src/shared/mod.rs
@@ -12,6 +12,7 @@ pub mod process_name;
 pub mod process_sample_data;
 pub mod recording_props;
 pub mod recycling;
+pub mod save_profile;
 pub mod stack_converter;
 pub mod stack_depth_limiting_frame_iter;
 pub mod symbol_precog;

--- a/samply/src/shared/save_profile.rs
+++ b/samply/src/shared/save_profile.rs
@@ -1,0 +1,34 @@
+use std::ffi::OsStr;
+use std::fs::File;
+use std::io::BufWriter;
+use std::path::Path;
+
+use flate2::{Compression, GzBuilder};
+use fxprof_processed_profile::Profile;
+
+// Level two has an acceptable trade-off between how long compression
+// takes and how much data it saves on the profile JSONs I tested with.
+const GZIP_COMPRESSION_LEVEL: u32 = 2;
+
+pub fn save_profile_to_file(profile: &Profile, output_path: &Path) -> std::io::Result<()> {
+    let output_file = match File::create(output_path) {
+        Ok(output_file) => output_file,
+        Err(err) => {
+            eprintln!("Couldn't create output file {:?}: {}", output_path, err);
+            std::process::exit(1);
+        }
+    };
+
+    let writer = BufWriter::new(output_file);
+    let is_gz = output_path.extension() == Some(OsStr::new("gz"));
+    if is_gz {
+        let name_without_gz = output_path.file_stem().unwrap().to_string_lossy();
+        let builder = GzBuilder::new().filename(name_without_gz.as_bytes());
+        let gz = builder.write(writer, Compression::new(GZIP_COMPRESSION_LEVEL));
+        let gz = BufWriter::new(gz);
+        serde_json::to_writer(gz, &profile)?;
+    } else {
+        serde_json::to_writer(writer, &profile)?;
+    }
+    Ok(())
+}

--- a/samply/src/windows/import.rs
+++ b/samply/src/windows/import.rs
@@ -1,18 +1,16 @@
-use std::fs::File;
-use std::io::BufWriter;
 use std::path::Path;
 
 use fxprof_processed_profile::{Profile, ReferenceTimestamp, SamplingInterval};
-use serde_json::to_writer;
 
 use super::etw_gecko;
 use crate::shared::included_processes::IncludedProcesses;
 use crate::shared::recording_props::ProfileCreationProps;
+use crate::shared::save_profile::save_profile_to_file;
 use crate::windows::profile_context::ProfileContext;
 
 pub fn convert_etl_file_to_profile(
     filename: &Path,
-    output_filename: &Path,
+    output_file: &Path,
     profile_creation_props: ProfileCreationProps,
     included_processes: Option<IncludedProcesses>,
 ) {
@@ -36,13 +34,7 @@ pub fn convert_etl_file_to_profile(
     etw_gecko::profile_pid_from_etl_file(&mut context, filename);
 
     let profile = context.finish();
-
-    // write the profile to a json file
-    let file = File::create(output_filename).unwrap();
-    let writer = BufWriter::new(file);
-    {
-        to_writer(writer, &profile).expect("Couldn't write JSON");
-    }
+    save_profile_to_file(&profile, output_file).expect("Couldn't write JSON");
 }
 
 #[cfg(target_arch = "x86")]

--- a/samply/src/windows/profiler.rs
+++ b/samply/src/windows/profiler.rs
@@ -1,10 +1,8 @@
 use std::fs::File;
-use std::io::BufWriter;
 use std::os::windows::process::ExitStatusExt;
 use std::process::ExitStatus;
 
 use fxprof_processed_profile::{Profile, ReferenceTimestamp, SamplingInterval};
-use serde_json::to_writer;
 
 use super::etw_gecko;
 use super::profile_context::ProfileContext;
@@ -12,6 +10,7 @@ use crate::server::{start_server_main, ServerProps};
 use crate::shared::ctrl_c::CtrlC;
 use crate::shared::included_processes::IncludedProcesses;
 use crate::shared::recording_props::{ProfileCreationProps, RecordingMode, RecordingProps};
+use crate::shared::save_profile::save_profile_to_file;
 use crate::shared::symbol_props::SymbolProps;
 use crate::windows::elevated_helper::ElevatedHelperSession;
 
@@ -159,12 +158,7 @@ pub fn start_recording(
         eprintln!("ETL path: {:?}", merged_etl);
     }
 
-    // write the profile to a json file
-    let file = File::create(&output_file).unwrap();
-    let writer = BufWriter::new(file);
-    {
-        to_writer(writer, &profile).expect("Couldn't write JSON");
-    }
+    save_profile_to_file(&profile, &output_file).expect("Couldn't write JSON");
 
     if unstable_presymbolicate {
         crate::shared::symbol_precog::presymbolicate(


### PR DESCRIPTION
Fixes #12.

This reduces the file size but adds some latency.
This is mostly an experiment; we can revert it if it causes problems.