### PR TITLE
Don't look up symbols for all-zero debug IDs.

### DIFF
--- a/samply-api/src/lib.rs
+++ b/samply-api/src/lib.rs
@@ -159,8 +159,13 @@ mod source;
 mod symbolicate;
 
 pub(crate) fn to_debug_id(breakpad_id: &str) -> Result<DebugId, samply_symbols::Error> {
-    DebugId::from_breakpad(breakpad_id)
-        .map_err(|_| samply_symbols::Error::InvalidBreakpadId(breakpad_id.to_string()))
+    // Only accept breakpad IDs with the right syntax, and which aren't all-zeros.
+    match DebugId::from_breakpad(breakpad_id) {
+        Ok(debug_id) if !debug_id.is_nil() => Ok(debug_id),
+        _ => Err(samply_symbols::Error::InvalidBreakpadId(
+            breakpad_id.to_string(),
+        )),
+    }
 }
 
 #[derive(Clone, Copy)]


### PR DESCRIPTION
All-zero debug IDs are sometimes created when no debug ID is available. Looking up symbols based on such a nil debug ID is never going to yield useful symbols, and could even cause existing useful symbols to be discarded.

In practice, if you were importing a simpleperf profile on a macOS machine which had a clone of the LLVM repo on its hard drive, the imported profile would lose all its Java function names after symbolication.

This happened due to the following comedy of errors:

 - The LLVM directory contains a dSYM with an all-zeros mach-O UUID under llvm/test/tools/llvm-dwarfdump/X86/Inputs/empty.dSYM.
 - This dSYM is indexed by Spotlight and can be looked up by the UUID.
 - In perf.data profiles captured by simpleperf, files such as base.vdex don't have a build ID.
 - When samply converts such a perf.data file to a profile, it creates an all-zeros DebugId for any library without a build ID.
 - The Java function names are in the profile JSON, before async symbolication happens.
 - When the local symbol server processes the symbolication request, it looks up a debug file for the all-zeros debug ID and finds empty.dSYM using Spotlight.
 - It then returns a response which basically means "I know all the symbols in this file, but the addresses you requested are outside of any of the functions, they don't have symbols."
 - The front-end then proceeds to replace the Java function names with strings of the shape "<unknown at 0x1234>".

With this patch, a symbolication request with an all-zeros debug ID will just fail with an "invalid breakpad ID" error, and the existing symbols for the library will be preserved.