### PR TITLE
Set a useful profile name for imported simpleperf profiles again.

### DIFF
--- a/samply/src/linux/profiler.rs
+++ b/samply/src/linux/profiler.rs
@@ -389,7 +389,7 @@ fn make_converter(
     Converter::<framehop::UnwinderNative<MmapRangeOrVec, framehop::MayAllocateDuringUnwind>>::new(
         &profile_creation_props,
         ReferenceTimestamp::from_system_time(SystemTime::now()),
-        None,
+        profile_creation_props.profile_name(),
         HashMap::new(),
         machine_info.as_ref().map(|info| info.release.as_str()),
         first_sample_time,

--- a/samply/src/shared/recording_props.rs
+++ b/samply/src/shared/recording_props.rs
@@ -66,7 +66,8 @@ impl RecordingMode {
 /// for converting a perf.data / ETL file to a profile.
 #[derive(Debug, Clone)]
 pub struct ProfileCreationProps {
-    pub profile_name: String,
+    pub profile_name: Option<String>,
+    pub fallback_profile_name: String,
     /// Only include the main thread of each process.
     #[allow(dead_code)]
     pub main_thread_only: bool,
@@ -94,6 +95,14 @@ pub struct ProfileCreationProps {
     /// Time range to include, relative to start of recording.
     #[allow(dead_code)]
     pub time_range: Option<(std::time::Duration, std::time::Duration)>,
+}
+
+impl ProfileCreationProps {
+    pub fn profile_name(&self) -> &str {
+        self.profile_name
+            .as_deref()
+            .unwrap_or(&self.fallback_profile_name)
+    }
 }
 
 /// Properties which are meaningful for launching and recording a fresh process.

--- a/samply/src/windows/import.rs
+++ b/samply/src/windows/import.rs
@@ -19,7 +19,7 @@ pub fn convert_etl_file_to_profile(
 
     let interval_8khz = SamplingInterval::from_nanos(122100); // 8192Hz // only with the higher recording rate?
     let profile = Profile::new(
-        &profile_creation_props.profile_name,
+        profile_creation_props.profile_name(),
         timebase,
         interval_8khz, // recording_props.interval.into(),
     );

--- a/samply/src/windows/profiler.rs
+++ b/samply/src/windows/profiler.rs
@@ -51,7 +51,7 @@ pub fn start_recording(
     let timebase = ReferenceTimestamp::from_system_time(timebase);
 
     let profile = Profile::new(
-        &profile_creation_props.profile_name,
+        profile_creation_props.profile_name(),
         timebase,
         SamplingInterval::from_nanos(1000000), // will be replaced with correct interval from file later
     );


### PR DESCRIPTION
PR #274 broke the profile name computation for imported simpleperf profiles - we were no longer putting the device name and the Android version into the profile name, because the code to do so didn't run, because handle_exec wasn't called, because on Android processes mostly don't exec, ever. Every app process gets forked from the Android zygote.