### PR TITLE
Remove extra CounterHandle definition.

### DIFF
--- a/fxprof-processed-profile/src/thread.rs
+++ b/fxprof-processed-profile/src/thread.rs
@@ -22,9 +22,6 @@ use crate::{CategoryHandle, Marker, MarkerHandle, MarkerTiming, MarkerTypeHandle
 #[derive(Debug, Clone, Copy, PartialOrd, Ord, PartialEq, Eq, Hash)]
 pub struct ProcessHandle(pub(crate) usize);
 
-#[derive(Debug, Clone, Copy, PartialOrd, Ord, PartialEq, Eq, Hash)]
-pub struct CounterHandle(pub(crate) usize);
-
 #[derive(Debug)]
 pub struct Thread {
     process: ProcessHandle,


### PR DESCRIPTION
This one was unused; the real one is in counters.rs.

This fixes a clippy warning.