### PR TITLE
Use Rust 1.80 until aarch64 test failures are fixed with 1.81

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -77,7 +77,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install Rust
-        run: rustup update stable && rustup default stable && rustup target add ${{ matrix.target }}
+        # 1.81 causes issues when running the tests
+        #run: rustup update stable && rustup default stable && rustup target add ${{ matrix.target }}
+        run: rustup install 1.80 && rustup default 1.80 && rustup target add ${{ matrix.target }}
       - name: Install cross
         # Latest cross release 0.2.5 fails to link binaries for the `aarch64-linux-android` target. A release is pending.
         # Use a specific commit until the release is out. See https://github.com/cross-rs/cross/issues/1222

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -47,7 +47,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install Rust
-        run: rustup target add ${{ matrix.target }}
+        #run: rustup target add ${{ matrix.target }}
+        run: rustup install 1.80 && rustup default 1.80 && rustup target add ${{ matrix.target }}
       - if: ${{ matrix.is_musl }}
         name: Install musl-tools
         run: sudo apt-get install -y musl-tools
@@ -105,7 +106,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install Rust
-        run: rustup target add ${{ matrix.target }}
+        #run: rustup target add ${{ matrix.target }}
+        run: rustup install 1.80 && rustup default 1.80 && rustup target add ${{ matrix.target }}
       - name: Check
         run: cargo check --workspace --verbose --target=${{ matrix.target }}
       - name: Clippy

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -48,7 +48,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Install Rust
         #run: rustup target add ${{ matrix.target }}
-        run: rustup install 1.80 && rustup default 1.80 && rustup target add ${{ matrix.target }}
+        run: rustup install 1.80 && rustup default 1.80 && rustup target add ${{ matrix.target }} && rustup component add clippy rustfmt
       - if: ${{ matrix.is_musl }}
         name: Install musl-tools
         run: sudo apt-get install -y musl-tools
@@ -80,7 +80,7 @@ jobs:
       - name: Install Rust
         # 1.81 causes issues when running the tests
         #run: rustup update stable && rustup default stable && rustup target add ${{ matrix.target }}
-        run: rustup install 1.80 && rustup default 1.80 && rustup target add ${{ matrix.target }}
+        run: rustup install 1.80 && rustup default 1.80 && rustup target add ${{ matrix.target }} && rustup component add clippy rustfmt
       - name: Install cross
         # Latest cross release 0.2.5 fails to link binaries for the `aarch64-linux-android` target. A release is pending.
         # Use a specific commit until the release is out. See https://github.com/cross-rs/cross/issues/1222
@@ -107,7 +107,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Install Rust
         #run: rustup target add ${{ matrix.target }}
-        run: rustup install 1.80 && rustup default 1.80 && rustup target add ${{ matrix.target }}
+        run: rustup install 1.80 && rustup default 1.80 && rustup target add ${{ matrix.target }} && rustup component add clippy rustfmt
       - name: Check
         run: cargo check --workspace --verbose --target=${{ matrix.target }}
       - name: Clippy


### PR DESCRIPTION
The linux cross compilation tests have failures with 1.81, and it's nothing obvious at quick glance from the (massive) log output. This explicitly uses Rust 1.80 for the cross tests until someone can take a look at the 1.81 failures.