### PR TITLE
Detect python functions by the "py::" prefix.

### DIFF
--- a/samply/src/shared/jit_category_manager.rs
+++ b/samply/src/shared/jit_category_manager.rs
@@ -36,6 +36,7 @@ impl JitCategoryManager {
         ("JS:+", "Maglev", CategoryColor::Green, true),
         ("JS:*", "Turbofan", CategoryColor::Green, true),
         ("JS:?", "JavaScript", CategoryColor::Blue, true),
+        ("py::", "Python", CategoryColor::Blue, true),
         ("Builtin:", "Builtin", CategoryColor::Brown, false),
         ("BytecodeHandler:", "Interpreter", CategoryColor::Red, false),
         ("Interpreter: ", "Interpreter", CategoryColor::Red, true),


### PR DESCRIPTION
Python has support for perf JIT maps. It prefixes the python function names with "py::": https://github.com/python/cpython/blob/4b89c5ebfc7d5d4f008eee0ae6da765dfc28e3a9/Python/perf_trampoline.c#L218

To use this, on Linux, build python 3.12 with frame pointers enabled, and run your python script with the `PYTHONPERFSUPPORT=1` environment variable set:

```
CFLAGS="-fno-omit-frame-pointer -mno-omit-leaf-frame-pointer" pyenv install 3.12
pyenv shell 3.12
samply record PYTHONPERFSUPPORT=1 python stuff.py
```