### PR TITLE
Fix process renaming with --reuse-threads.

### DIFF
--- a/samply/src/linux_shared/processes.rs
+++ b/samply/src/linux_shared/processes.rs
@@ -213,20 +213,19 @@ where
                 }
 
                 if let Some(process_recycler) = self.process_recycler.as_mut() {
-                    let Some(process_recycling_data) = process_recycler.recycle_by_name(&name)
-                    else {
+                    if let Some(process_recycling_data) = process_recycler.recycle_by_name(&name) {
+                        let (old_recycling_data, old_name) =
+                            process.rename_with_recycling(name, process_recycling_data);
+                        if let Some(old_name) = old_name {
+                            process_recycler.add_to_pool(&old_name, old_recycling_data);
+                        }
                         return;
-                    };
-                    let (old_recycling_data, old_name) =
-                        process.rename_with_recycling(name, process_recycling_data);
-                    if let Some(old_name) = old_name {
-                        process_recycler.add_to_pool(&old_name, old_recycling_data);
                     }
-                } else {
-                    let main_thread_label_frame =
-                        make_thread_label_frame(profile, Some(&name), pid, pid);
-                    process.rename_without_recycling(name, main_thread_label_frame, profile);
                 }
+
+                let main_thread_label_frame =
+                    make_thread_label_frame(profile, Some(&name), pid, pid);
+                process.rename_without_recycling(name, main_thread_label_frame, profile);
             }
         }
     }


### PR DESCRIPTION
In simpleperf profiles from Android, running samply import --reuse-threads resulted in profiles with bad process names.
The processes get their names with a COMM event that's not an exec event - on Android you rarely ever exec. All app processes are forked from the zygote process and then renamed to the app name. We weren't propagating the name change into the process in the case where we have a recycler but couldn't find an existing process for the new name.