### PR TITLE
Skip remaining iterations on Windows too

### DIFF
--- a/samply/src/windows/profiler.rs
+++ b/samply/src/windows/profiler.rs
@@ -110,7 +110,11 @@ pub fn start_recording(
                 // give us a chance to stop xperf.
                 let exit_status = child.wait().unwrap();
                 if !exit_status.success() {
-                    eprintln!("Child process exited with {:?}", exit_status);
+                    eprintln!(
+                        "Skipping remaining iterations due to non-success exit status: \"{}\"",
+                        exit_status
+                    );
+                    break;
                 }
             }
 


### PR DESCRIPTION
On Linux and Mac, remaining iterations are skipped if the command returns non-success exit status. Do the same on Windows.