### PR TITLE
Add a way to limit the disk usage of symbol files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,6 +19,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
+name = "ahash"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -626,6 +638,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
 
 [[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -874,11 +892,29 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
 dependencies = [
  "foldhash",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -1029,7 +1065,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.15.0",
 ]
 
 [[package]]
@@ -1119,6 +1155,17 @@ dependencies = [
  "bitflags",
  "libc",
  "redox_syscall",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -1366,7 +1413,7 @@ checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
 dependencies = [
  "crc32fast",
  "flate2",
- "hashbrown",
+ "hashbrown 0.15.0",
  "indexmap",
  "memchr",
  "ruzstd",
@@ -1832,6 +1879,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+]
+
+[[package]]
+name = "rusqlite_migration"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "923b42e802f7dc20a0a6b5e097ba7c83fe4289da07e49156fecf6af08aa9cd1c"
+dependencies = [
+ "log",
+ "rusqlite",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1975,6 +2046,7 @@ dependencies = [
  "rand",
  "rangemap",
  "runas",
+ "samply-quota-manager",
  "serde",
  "serde_derive",
  "serde_json",
@@ -2008,6 +2080,17 @@ dependencies = [
  "yaxpeax-arch",
  "yaxpeax-arm",
  "yaxpeax-x86",
+]
+
+[[package]]
+name = "samply-quota-manager"
+version = "0.1.0"
+dependencies = [
+ "bytesize",
+ "log",
+ "rusqlite",
+ "rusqlite_migration",
+ "tokio",
 ]
 
 [[package]]
@@ -2501,6 +2584,18 @@ checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
 dependencies = [
  "getrandom",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "fxprof-processed-profile",
     "gecko_profile",
     "samply-api",
+    "samply-quota-manager",
     "samply-symbols",
     "samply",
     "wholesym",

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "advisory-db": {
       "flake": false,
       "locked": {
-        "lastModified": 1707242268,
-        "narHash": "sha256-CnhguwxWxHQx1yt3IDL0OBn8xgMBErLAZT/pTYAJH7s=",
+        "lastModified": 1732530460,
+        "narHash": "sha256-1SceEHyFdHnoWE/AnoDZRu/9+Ift3Oc1+iQzmbP7OBU=",
         "owner": "rustsec",
         "repo": "advisory-db",
-        "rev": "f48f2ed5e03b1fb21fa180be42781447119df362",
+        "rev": "4676c5529dd5319b9962e42bf984797f0dd57f5b",
         "type": "github"
       },
       "original": {
@@ -17,17 +17,12 @@
       }
     },
     "crane": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
       "locked": {
-        "lastModified": 1707075082,
-        "narHash": "sha256-PUplk5F5jlIyofxqn/xEDN9pbjrd0tnkd0pDsZ52db0=",
+        "lastModified": 1732407143,
+        "narHash": "sha256-qJOGDT6PACoX+GbNH2PPx2ievlmtT1NVeTB80EkRLys=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "7d5b46c17d857ee9ddb2e8d88185729a3e5637b6",
+        "rev": "f2b4b472983817021d9ffb60838b2b36b9376b20",
         "type": "github"
       },
       "original": {
@@ -41,11 +36,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1705309234,
-        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -56,11 +51,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1707205916,
-        "narHash": "sha256-fmRJilYGlB7VCt3XsdYxrA0u8e/K84O5xYucerUY0iM=",
+        "lastModified": 1732238832,
+        "narHash": "sha256-sQxuJm8rHY20xq6Ah+GwIUkF95tWjGRd1X8xF+Pkk38=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8cc79aa39bbc6eaedaf286ae655b224c71e02907",
+        "rev": "8edf06bea5bcbee082df1b7369ff973b91618b8d",
         "type": "github"
       },
       "original": {
@@ -81,19 +76,16 @@
     },
     "rust-overlay": {
       "inputs": {
-        "flake-utils": [
-          "flake-utils"
-        ],
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1707271822,
-        "narHash": "sha256-/DZsoPH5GBzOpVEGz5PgJ7vh8Q6TcrJq5u8FcBjqAfI=",
+        "lastModified": 1732588352,
+        "narHash": "sha256-J2/hxOO1VtBA/u+a+9E+3iJpWT3xsBdghgYAVfoGCJo=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "7a94fe7690d2bdfe1aab475382a505e14dc114a6",
+        "rev": "414e748aae5c9e6ca63c5aafffda03e5dad57ceb",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,6 @@
 
     crane = {
       url = "github:ipetkov/crane";
-      inputs.nixpkgs.follows = "nixpkgs";
     };
 
     flake-utils.url = "github:numtide/flake-utils";
@@ -20,7 +19,6 @@
       url = "github:oxalica/rust-overlay";
       inputs = {
         nixpkgs.follows = "nixpkgs";
-        flake-utils.follows = "flake-utils";
       };
     };
 

--- a/samply-quota-manager/Cargo.toml
+++ b/samply-quota-manager/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "samply-quota-manager"
+version = "0.1.0"
+authors = ["Markus Stange <mstange.moz@gmail.com>"]
+license = "MIT OR Apache-2.0"
+edition = "2021"
+rust-version = "1.77" # needed by rusqlite_migration
+description = "Limit the total size of a directory by deleting least-recently-used files"
+repository = "https://github.com/mstange/samply/"
+readme = "README.md"
+
+[dependencies]
+bytesize = "1.3.0"
+log = "0.4.21"
+tokio = { version = "1.39", features = ["rt", "rt-multi-thread", "sync", "macros"] }
+rusqlite = { version = "0.32.0", features = ["bundled"] }
+rusqlite_migration = "1.2.0"

--- a/samply-quota-manager/README.md
+++ b/samply-quota-manager/README.md
@@ -1,0 +1,2 @@
+# samply-quota-manager
+

--- a/samply-quota-manager/src/file_inventory.rs
+++ b/samply-quota-manager/src/file_inventory.rs
@@ -1,0 +1,328 @@
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use rusqlite::{params, Connection, OpenFlags, Transaction};
+
+/// Stores information about files (size, last access time) in a sqlite DB.
+///
+/// It only cares about files in the "managed directory". All file paths
+/// are stored as relative paths relative to that directory.
+///
+/// You tell the inventory when files are added / deleted / accessed.
+///
+/// When the time comes to enforce a limit on the total size or max age,
+/// you can ask it for a list of files to delete.
+///
+/// The inventory never touches files directly, other than the sqlite DB file.
+/// It just stores and queries information.
+pub struct FileInventory {
+    /// The path of the managed directory.
+    root_path: PathBuf,
+    /// The database connection.
+    db_connection: rusqlite::Connection,
+}
+
+/// Information about a file that `FileInventory` keeps track of.
+pub struct FileInfo {
+    pub path: PathBuf,
+    pub size_in_bytes: u64,
+    pub creation_time: SystemTime,
+    pub last_access_time: SystemTime,
+}
+
+impl FileInventory {
+    /// Creates a `FileInventory` instance, with the managed directory being passed
+    /// in `root_path`. The information is stored in a sqlite file at `db_path`.
+    ///
+    /// If the database at `db_path` does not exist, this function calls the
+    /// `list_existing_files_fn` callback so that it can populate the new database.
+    pub fn new<F>(
+        root_path: &Path,
+        db_path: &Path,
+        list_existing_files_fn: F,
+    ) -> rusqlite_migration::Result<Self>
+    where
+        F: Fn() -> Vec<FileInfo> + Send + Sync + 'static,
+    {
+        let root_path = root_path
+            .canonicalize()
+            .unwrap_or_else(|_| root_path.to_path_buf());
+        let db_connection = Self::init_db_at(&root_path, db_path, list_existing_files_fn)?;
+
+        Ok(Self {
+            root_path,
+            db_connection,
+        })
+    }
+
+    fn init_db_at<F>(
+        root_path: &Path,
+        db_path: &Path,
+        list_existing_files_fn: F,
+    ) -> rusqlite_migration::Result<rusqlite::Connection>
+    where
+        F: Fn() -> Vec<FileInfo> + Send + Sync + 'static,
+    {
+        use rusqlite_migration::{Migrations, M};
+
+        let list_existing_files_fn = Arc::new(list_existing_files_fn);
+        let root_path = root_path.to_path_buf();
+
+        let migrations = Migrations::new(vec![
+            M::up_with_hook(
+                r#"
+                    CREATE TABLE "files"
+                    (
+                        [Path] TEXT NOT NULL,
+                        [Size] INT NOT NULL,
+                        [CreationTime] INT NOT NULL,
+                        [LastAccessTime] INT NOT NULL,
+                        PRIMARY KEY ([Path])
+                    );
+                    CREATE INDEX idx_files_LastAccessTime ON "files" ([LastAccessTime]);
+                "#,
+                move |transaction: &Transaction| {
+                    let existing_files = list_existing_files_fn();
+                    Self::insert_existing_files(&root_path, transaction, existing_files);
+                    Ok(())
+                },
+            ),
+            // Future migrations can be added here.
+        ]);
+
+        let mut conn = Connection::open_with_flags(
+            db_path,
+            OpenFlags::SQLITE_OPEN_CREATE
+                | OpenFlags::SQLITE_OPEN_READ_WRITE
+                | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+        )?;
+        conn.pragma_update_and_check(None, "journal_mode", "WAL", |_| Ok(()))?;
+        conn.pragma_update(None, "synchronous", "NORMAL")?;
+        migrations.to_latest(&mut conn)?;
+
+        Ok(conn)
+    }
+
+    fn insert_existing_files(
+        root_path: &Path,
+        transaction: &Transaction,
+        existing_files: Vec<FileInfo>,
+    ) {
+        let mut stmt = transaction
+            .prepare(
+                r#"
+                    INSERT INTO files (Path, Size, CreationTime, LastAccessTime)
+                    VALUES (?1, ?2, ?3, ?4)
+                    ON CONFLICT(Path) DO UPDATE SET
+                        Size=?2,
+                        CreationTime=?3,
+                        LastAccessTime=?4;
+                "#,
+            )
+            .unwrap();
+        for file_info in existing_files {
+            let FileInfo {
+                path,
+                size_in_bytes,
+                creation_time,
+                last_access_time,
+            } = file_info;
+            let path = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+            let Ok(relative_path) = path.strip_prefix(root_path) else {
+                continue;
+            };
+
+            stmt.execute(params![
+                relative_path.to_string_lossy(),
+                size_in_bytes,
+                creation_time.duration_since(UNIX_EPOCH).unwrap().as_secs() as i64,
+                last_access_time
+                    .duration_since(UNIX_EPOCH)
+                    .unwrap()
+                    .as_secs() as i64
+            ])
+            .unwrap();
+        }
+    }
+
+    fn relative_path_under_managed_directory(&self, path: &Path) -> Option<PathBuf> {
+        let path = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+        let relative_path = path.strip_prefix(&self.root_path).ok()?;
+        Some(relative_path.to_path_buf())
+    }
+
+    fn to_absolute_path(&self, relative_path: &Path) -> PathBuf {
+        let abs_path = self.root_path.join(relative_path).canonicalize().unwrap();
+        assert!(abs_path.starts_with(&self.root_path));
+        abs_path
+    }
+
+    /// Notifies the inventory that a file has been created.
+    ///
+    /// If the path is not under the "managed directory", this call is ignored.
+    pub fn on_file_created(&mut self, path: &Path, size_in_bytes: u64, creation_time: SystemTime) {
+        let Some(relative_path) = self.relative_path_under_managed_directory(path) else {
+            return;
+        };
+
+        let creation_time = creation_time.duration_since(UNIX_EPOCH).unwrap().as_secs() as i64;
+        let last_access_time = creation_time;
+
+        let mut stmt = self
+            .db_connection
+            .prepare_cached(
+                r#"
+                    INSERT INTO files (Path, Size, CreationTime, LastAccessTime)
+                    VALUES (?1, ?2, ?3, ?4)
+                    ON CONFLICT(Path) DO UPDATE SET
+                        Size=?2,
+                        CreationTime=?3,
+                        LastAccessTime=?4;
+                "#,
+            )
+            .unwrap();
+        stmt.execute(params![
+            relative_path.to_string_lossy(),
+            size_in_bytes as i64,
+            creation_time,
+            last_access_time
+        ])
+        .unwrap();
+    }
+
+    /// Notifies the inventory that a file has been accessed.
+    ///
+    /// If the path is not under the "managed directory", this call is ignored.
+    pub fn on_file_accessed(&mut self, path: &Path, access_time: SystemTime) {
+        let Some(relative_path) = self.relative_path_under_managed_directory(path) else {
+            return;
+        };
+
+        let access_time = access_time.duration_since(UNIX_EPOCH).unwrap().as_secs() as i64;
+
+        let mut stmt = self
+            .db_connection
+            .prepare_cached("UPDATE files SET LastAccessTime = ?1 WHERE Path = ?2")
+            .unwrap();
+        stmt.execute(params![access_time, relative_path.to_string_lossy()])
+            .unwrap();
+    }
+
+    /// Notifies the inventory that a file has been deleted.
+    ///
+    /// If the path is not under the "managed directory", this call is ignored.
+    pub fn on_file_deleted(&mut self, path: &Path) {
+        let Some(relative_path) = self.relative_path_under_managed_directory(path) else {
+            return;
+        };
+
+        let mut stmt = self
+            .db_connection
+            .prepare_cached("DELETE FROM files WHERE Path = ?1")
+            .unwrap();
+        stmt.execute(params![relative_path.to_string_lossy()])
+            .unwrap();
+    }
+
+    /// Notifies the inventory that no file has been observed at the path.
+    ///
+    /// If the path is not under the "managed directory", this call is ignored.
+    pub fn on_file_found_to_be_absent(&mut self, path: &Path) {
+        self.on_file_deleted(path);
+    }
+
+    /// Returns the total size of all files under the managed directory. This only uses
+    /// the information stored in the database, it doesn't look at the file system.
+    pub fn total_size_in_bytes(&self) -> u64 {
+        let total_size: i64 = self
+            .db_connection
+            .query_row("SELECT SUM(Size) FROM files", [], |row| row.get(0))
+            .unwrap_or(0);
+        total_size as u64
+    }
+
+    fn file_info_from_row(&self, row: &rusqlite::Row) -> rusqlite::Result<FileInfo> {
+        let relative_path: String = row.get(0)?;
+        let size: i64 = row.get(1)?;
+        let creation_time: i64 = row.get(2)?;
+        let last_access_time: i64 = row.get(3)?;
+        let path = self.to_absolute_path(Path::new(&relative_path));
+        Ok(FileInfo {
+            path,
+            size_in_bytes: size.try_into().unwrap(),
+            creation_time: SqliteTime(creation_time).into(),
+            last_access_time: SqliteTime(last_access_time).into(),
+        })
+    }
+
+    /// Returns a list of file paths. Deleting all the listed files will reduce
+    /// the total size of the managed directory below `max_size_bytes`, assuming
+    /// that the information stored in the DB is complete and accurate.
+    pub fn get_files_to_delete_to_enforce_max_size(&self, max_size_bytes: u64) -> Vec<FileInfo> {
+        let total_size = self.total_size_in_bytes();
+        let Some(mut excess_bytes) = total_size.checked_sub(max_size_bytes) else {
+            // Nothing needs to be deleted.
+            return vec![];
+        };
+
+        let mut stmt = self
+            .db_connection
+            .prepare_cached("SELECT Path, Size, CreationTime, LastAccessTime FROM files ORDER BY LastAccessTime ASC")
+            .unwrap();
+
+        let files = stmt
+            .query_map([], |row| self.file_info_from_row(row))
+            .unwrap()
+            .filter_map(Result::ok);
+
+        let mut files_to_delete = vec![];
+
+        for file_info in files {
+            let size = file_info.size_in_bytes;
+
+            files_to_delete.push(file_info);
+            excess_bytes = excess_bytes.saturating_sub(size);
+            if excess_bytes == 0 {
+                break;
+            }
+        }
+
+        files_to_delete
+    }
+
+    /// Returns a list of file paths, listing all the files whose last access time (as
+    /// stored by the inventory) is older than `max_age_seconds`.
+    pub fn get_files_last_accessed_before(&self, cutoff_time: SystemTime) -> Vec<FileInfo> {
+        let mut stmt = self
+            .db_connection
+            .prepare_cached("SELECT Path, Size, CreationTime, LastAccessTime FROM files WHERE LastAccessTime < ?1")
+            .unwrap();
+
+        let files_to_delete = stmt
+            .query_map([SqliteTime::from(cutoff_time).0], |row| {
+                self.file_info_from_row(row)
+            })
+            .unwrap()
+            .filter_map(Result::ok)
+            .collect();
+
+        files_to_delete
+    }
+}
+
+struct SqliteTime(pub i64);
+
+impl From<SqliteTime> for SystemTime {
+    fn from(value: SqliteTime) -> Self {
+        let dur = Duration::from_secs(u64::try_from(value.0).unwrap());
+        UNIX_EPOCH.checked_add(dur).unwrap()
+    }
+}
+
+impl From<SystemTime> for SqliteTime {
+    fn from(value: SystemTime) -> Self {
+        let dur = value.duration_since(UNIX_EPOCH).unwrap();
+        Self(dur.as_secs().try_into().unwrap())
+    }
+}

--- a/samply-quota-manager/src/lib.rs
+++ b/samply-quota-manager/src/lib.rs
@@ -1,0 +1,8 @@
+//! This is an internal crate for managing downloaded symbol files.
+//!
+//!
+
+mod file_inventory;
+mod quota_manager;
+
+pub use quota_manager::*;

--- a/samply-quota-manager/src/quota_manager.rs
+++ b/samply-quota-manager/src/quota_manager.rs
@@ -1,0 +1,288 @@
+use std::collections::VecDeque;
+use std::fs;
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, SystemTime};
+
+use bytesize::ByteSize;
+use tokio::sync::Notify;
+use tokio::task::JoinHandle;
+
+use super::file_inventory::{FileInfo, FileInventory};
+
+/// Evicts least-recently-used files in a managed directory when asked to do so.
+///
+/// `QuotaManager` does not observe file system mutations! You have to tell it
+/// about any files you create or delete in this directory. It stores this
+/// information in a sqlite database file at a path of your choosing.
+pub struct QuotaManager {
+    settings: Arc<Mutex<EvictionSettings>>,
+    inventory: Arc<Mutex<FileInventory>>,
+    /// Sent from QuotaManager::finish
+    stop_signal_sender: tokio::sync::oneshot::Sender<()>,
+    /// Sent whenever a file is added. A `Notify` has the semantics
+    /// we want if the sender side notifies more frequently than the
+    /// receiver side can check; multiple notifications are coalesced
+    /// into one.
+    eviction_signal_sender: Arc<tokio::sync::Notify>,
+    /// The join handle for the tokio task that receives the signals
+    /// and deletes the files. Stored here so that finish() can block on it.
+    join_handle: JoinHandle<()>,
+}
+
+/// Used to initiate a [`QuotaManager`] eviction, and to tell it about
+/// the creation and access of files. `Send` and `Sync`.
+pub struct QuotaManagerNotifier {
+    inventory: Arc<Mutex<FileInventory>>,
+    eviction_signal_sender: Arc<tokio::sync::Notify>,
+}
+
+impl Clone for QuotaManagerNotifier {
+    fn clone(&self) -> Self {
+        Self {
+            inventory: self.inventory.clone(),
+            eviction_signal_sender: self.eviction_signal_sender.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+struct EvictionSettings {
+    max_size_bytes: Option<u64>,
+    max_age_seconds: Option<u64>,
+}
+
+impl QuotaManager {
+    /// Create an instance for the managed directory given by `root_path`.
+    ///
+    /// Uses the database at `db_path` to store information about the files
+    /// under this directory, and creates it if it doesn't exist yet,
+    /// prepopulating it with information about the current files in the
+    /// managed directory.
+    pub fn new(root_path: &Path, db_path: &Path) -> Self {
+        let root_path = root_path.to_path_buf();
+        let root_path_clone = root_path.clone();
+        let inventory = FileInventory::new(&root_path, db_path, move || {
+            Self::list_existing_files_sync(&root_path_clone)
+        })
+        .unwrap();
+        let inventory = Arc::new(Mutex::new(inventory));
+        let settings = Arc::new(Mutex::new(EvictionSettings::default()));
+
+        let (stop_signal_sender, stop_signal_receiver) = tokio::sync::oneshot::channel();
+        let eviction_signal_sender = Arc::new(Notify::new());
+
+        let eviction_thread_runner = QuotaManagerEvictionThread {
+            stop_signal_receiver,
+            eviction_signal_receiver: eviction_signal_sender.clone(),
+            inventory: Arc::clone(&inventory),
+            settings: Arc::clone(&settings),
+        };
+
+        let join_handle = tokio::spawn(eviction_thread_runner.run());
+
+        Self {
+            settings,
+            inventory,
+            stop_signal_sender,
+            eviction_signal_sender,
+            join_handle,
+        }
+    }
+
+    /// Returns a new `QuotaManagerNotifier`. This is how you tell this
+    /// `QuotaManager` about file creations / accesses
+    pub fn notifier(&self) -> QuotaManagerNotifier {
+        QuotaManagerNotifier {
+            inventory: Arc::clone(&self.inventory),
+            eviction_signal_sender: Arc::clone(&self.eviction_signal_sender),
+        }
+    }
+
+    /// Stops the background task that does the evictions, and waits for
+    /// any currently-running eviction to finish.
+    pub async fn finish(self) {
+        let _ = self.stop_signal_sender.send(());
+        self.join_handle.await.unwrap()
+    }
+
+    /// Change the desired maximum total size of the managed directory, in bytes.
+    ///
+    /// Respected during the next eviction.
+    pub fn set_max_total_size(&self, max_size_bytes: Option<u64>) {
+        self.settings.lock().unwrap().max_size_bytes = max_size_bytes;
+    }
+
+    /// Change the desired maximum age of tracked files in the managed directory,
+    /// in seconds.
+    ///
+    /// Respected during the next eviction.
+    pub fn set_max_age(&self, max_age_seconds: Option<u64>) {
+        self.settings.lock().unwrap().max_age_seconds = max_age_seconds;
+    }
+
+    fn list_existing_files_sync(dir: &Path) -> Vec<FileInfo> {
+        let mut files = Vec::new();
+        let mut dirs_to_visit = VecDeque::new();
+        dirs_to_visit.push_back(dir.to_path_buf());
+
+        while let Some(current_dir) = dirs_to_visit.pop_front() {
+            let entries = match fs::read_dir(&current_dir) {
+                Ok(entries) => entries,
+                Err(e) => {
+                    log::error!("Failed to read directory {:?}: {}", current_dir, e);
+                    continue;
+                }
+            };
+            for entry in entries {
+                let path = match entry {
+                    Ok(entry) => entry.path(),
+                    Err(e) => {
+                        log::error!("Failed to read directory entry in {:?}: {}", current_dir, e);
+                        continue;
+                    }
+                };
+
+                if path.is_dir() {
+                    dirs_to_visit.push_back(path);
+                    continue;
+                }
+                if !path.is_file() {
+                    continue;
+                }
+
+                let metadata = match fs::metadata(&path) {
+                    Ok(metadata) => metadata,
+                    Err(e) => {
+                        log::error!("Failed to query file size for {:?}: {}", path, e);
+                        continue;
+                    }
+                };
+                files.push(FileInfo {
+                    path,
+                    size_in_bytes: metadata.len(),
+                    creation_time: metadata.created().ok().unwrap_or_else(SystemTime::now),
+                    last_access_time: metadata.accessed().ok().unwrap_or_else(SystemTime::now),
+                });
+            }
+        }
+        log::info!("Found {} existing files in {:?}", files.len(), dir);
+        files
+    }
+}
+
+struct QuotaManagerEvictionThread {
+    stop_signal_receiver: tokio::sync::oneshot::Receiver<()>,
+    eviction_signal_receiver: Arc<tokio::sync::Notify>,
+    settings: Arc<Mutex<EvictionSettings>>,
+    inventory: Arc<Mutex<FileInventory>>,
+}
+
+impl QuotaManagerEvictionThread {
+    pub async fn run(mut self) {
+        loop {
+            tokio::select! {
+                _ = &mut self.stop_signal_receiver => {
+                    return;
+                }
+                _ = self.eviction_signal_receiver.notified() => {
+                    self.perform_eviction_if_needed().await;
+                }
+            }
+        }
+    }
+
+    async fn perform_eviction_if_needed(&self) {
+        let settings = *self.settings.lock().unwrap();
+        let total_size_before = self.inventory.lock().unwrap().total_size_in_bytes();
+        log::info!("Current total size: {}", ByteSize(total_size_before));
+
+        let files_to_delete_for_enforcing_max_size = match settings.max_size_bytes {
+            Some(max_size_bytes) => {
+                let inventory = self.inventory.lock().unwrap();
+                inventory.get_files_to_delete_to_enforce_max_size(max_size_bytes)
+            }
+            None => vec![],
+        };
+
+        if !files_to_delete_for_enforcing_max_size.is_empty() {
+            self.delete_files(files_to_delete_for_enforcing_max_size)
+                .await;
+            let total_size = self.inventory.lock().unwrap().total_size_in_bytes();
+            log::info!("Current total size: {}", ByteSize(total_size));
+        }
+
+        let files_to_delete_for_enforcing_max_age = match settings.max_age_seconds {
+            Some(max_age_seconds) => {
+                let cutoff_time = SystemTime::now() - Duration::from_secs(max_age_seconds);
+                let inventory = self.inventory.lock().unwrap();
+                inventory.get_files_last_accessed_before(cutoff_time)
+            }
+            None => vec![],
+        };
+
+        if !files_to_delete_for_enforcing_max_age.is_empty() {
+            self.delete_files(files_to_delete_for_enforcing_max_age)
+                .await;
+            let total_size = self.inventory.lock().unwrap().total_size_in_bytes();
+            log::info!("Current total size: {}", ByteSize(total_size));
+        }
+    }
+
+    async fn delete_files(&self, files: Vec<FileInfo>) {
+        for file_info in files {
+            log::info!(
+                "Deleting file {:?} ({})",
+                file_info.path,
+                ByteSize(file_info.size_in_bytes)
+            );
+            match tokio::fs::remove_file(&file_info.path).await {
+                Ok(()) => {
+                    let mut inventory = self.inventory.lock().unwrap();
+                    inventory.on_file_deleted(&file_info.path);
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                    let mut inventory = self.inventory.lock().unwrap();
+                    inventory.on_file_found_to_be_absent(&file_info.path);
+                }
+                Err(e) => {
+                    log::error!("Error when deleting {:?}: {}", file_info.path, e);
+                }
+            }
+            // TODO: delete containing directory if empty
+        }
+    }
+}
+
+impl QuotaManagerNotifier {
+    /// Trigger an eviction. The eviction runs asynchronously in a single
+    /// shared eviction task and uses the current eviction settings.
+    pub fn trigger_eviction_if_needed(&self) {
+        self.eviction_signal_sender.notify_one();
+    }
+
+    /// You must call this whenever a new file gets added to the managed directory.
+    ///
+    /// Calls for files outside the managed directory are ignored.
+    pub fn on_file_created(&self, path: &Path, size_in_bytes: u64, creation_time: SystemTime) {
+        let mut inventory = self.inventory.lock().unwrap();
+        inventory.on_file_created(path, size_in_bytes, creation_time);
+    }
+
+    /// You must call this whenever a file in the managed directory is accessed.
+    ///
+    /// Calls for files outside the managed directory are ignored.
+    pub fn on_file_accessed(&self, path: &Path, access_time: SystemTime) {
+        let mut inventory = self.inventory.lock().unwrap();
+        inventory.on_file_accessed(path, access_time);
+    }
+
+    /// You usually don't need to call this because we expect you to leave any
+    /// deleting to the [`QuotaManager`]. But if you do delete any files in the
+    /// managed directory yourself, call this method so that the [`QuotaManager`]
+    /// can update its information.
+    pub fn on_file_deleted(&self, path: &Path) {
+        let mut inventory = self.inventory.lock().unwrap();
+        inventory.on_file_deleted(path);
+    }
+}

--- a/samply/Cargo.toml
+++ b/samply/Cargo.toml
@@ -3,7 +3,7 @@ name = "samply"
 version = "0.12.0"
 authors = ["Markus Stange <mstange@themasta.com>"]
 edition = "2021"
-rust-version = "1.75" # needed by wholesym -> fs4
+rust-version = "1.77" # needed by samply-quota-manager -> rusqlite_migration
 license = "MIT OR Apache-2.0"
 description = "A command line profiler for macOS and Linux."
 repository = "https://github.com/mstange/samply/"
@@ -52,6 +52,7 @@ cfg-if = "1.0.0"
 fs4 = "0.9"
 humantime = "2.1.0"
 shlex = "1.3.0"
+samply-quota-manager = { version = "0.1.0", path = "../samply-quota-manager" }
 
 [target.'cfg(any(target_os = "android", target_os = "macos", target_os = "linux"))'.dependencies]
 

--- a/samply/src/shared/mod.rs
+++ b/samply/src/shared/mod.rs
@@ -16,6 +16,7 @@ pub mod recycling;
 pub mod save_profile;
 pub mod stack_converter;
 pub mod stack_depth_limiting_frame_iter;
+pub mod symbol_manager_observer;
 pub mod symbol_precog;
 pub mod symbol_props;
 pub mod synthetic_jit_library;

--- a/samply/src/shared/symbol_manager_observer.rs
+++ b/samply/src/shared/symbol_manager_observer.rs
@@ -1,0 +1,103 @@
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::Mutex;
+use std::time::SystemTime;
+
+use samply_quota_manager::QuotaManagerNotifier;
+use wholesym::{DownloadError, SymbolManagerObserver};
+
+pub struct SamplySymbolManagerObserver {
+    verbose: bool,
+    quota_manager_notifiers: Vec<QuotaManagerNotifier>,
+    urls: Mutex<HashMap<u64, String>>,
+}
+
+impl SamplySymbolManagerObserver {
+    pub fn new(verbose: bool, quota_manager_notifiers: Vec<QuotaManagerNotifier>) -> Self {
+        Self {
+            verbose,
+            quota_manager_notifiers,
+            urls: Mutex::new(HashMap::new()),
+        }
+    }
+}
+
+impl SymbolManagerObserver for SamplySymbolManagerObserver {
+    fn on_new_download_before_connect(&self, download_id: u64, url: &str) {
+        if self.verbose {
+            eprintln!("Connecting to {}...", url);
+        }
+        self.urls
+            .lock()
+            .unwrap()
+            .insert(download_id, url.to_owned());
+    }
+
+    fn on_download_started(&self, download_id: u64) {
+        if self.verbose {
+            let urls = self.urls.lock().unwrap();
+            let url = urls.get(&download_id).unwrap();
+            eprintln!("Downloading from {}...", url);
+        }
+    }
+
+    fn on_download_progress(
+        &self,
+        _download_id: u64,
+        _bytes_so_far: u64,
+        _total_bytes: Option<u64>,
+    ) {
+    }
+
+    fn on_download_completed(
+        &self,
+        download_id: u64,
+        _uncompressed_size_in_bytes: u64,
+        _time_until_headers: std::time::Duration,
+        _time_until_completed: std::time::Duration,
+    ) {
+        if self.verbose {
+            let url = self.urls.lock().unwrap().remove(&download_id).unwrap();
+            eprintln!("Finished download from {}.", url);
+        }
+    }
+
+    fn on_download_failed(&self, download_id: u64, reason: DownloadError) {
+        if self.verbose {
+            let url = self.urls.lock().unwrap().remove(&download_id).unwrap();
+            eprintln!("Failed to download from {url}: {reason}.");
+        }
+    }
+
+    fn on_download_canceled(&self, download_id: u64) {
+        if self.verbose {
+            let url = self.urls.lock().unwrap().remove(&download_id).unwrap();
+            eprintln!("Canceled download from {}.", url);
+        }
+    }
+
+    fn on_file_created(&self, path: &Path, size_in_bytes: u64) {
+        if self.verbose {
+            eprintln!("Created new file at {path:?} (size: {size_in_bytes} bytes).");
+        }
+        for notifier in &self.quota_manager_notifiers {
+            notifier.on_file_created(path, size_in_bytes, SystemTime::now());
+            notifier.trigger_eviction_if_needed();
+        }
+    }
+
+    fn on_file_accessed(&self, path: &Path) {
+        if self.verbose {
+            eprintln!("Checking if {path:?} exists... yes");
+        }
+        for notifier in &self.quota_manager_notifiers {
+            notifier.on_file_accessed(path, SystemTime::now());
+        }
+    }
+
+    fn on_file_missed(&self, path: &Path) {
+        if self.verbose {
+            eprintln!("Checking if {path:?} exists... no");
+        }
+    }
+}


### PR DESCRIPTION
This enforces a max age of two weeks and a max total size of 10GB for symbol files downloaded to symbol directories managed by samply. This is the next step towards shipping with a useful default symbol server configuration on Windows.