### PR TITLE
Use object's support for zstd compressed DWARF

### DIFF
--- a/samply-symbols/src/dwarf.rs
+++ b/samply-symbols/src/dwarf.rs
@@ -97,24 +97,11 @@ where
             size: file_range.uncompressed_size,
             _phantom: PhantomData,
         }),
-        CompressionFormat::Zlib => {
-            let compressed_bytes = data
-                .read_bytes_at(file_range.offset, file_range.compressed_size)
-                .ok()?;
-
-            let mut decompressed = Vec::with_capacity(file_range.uncompressed_size as usize);
-            let mut decompress = flate2::Decompress::new(true);
-            decompress
-                .decompress_vec(
-                    compressed_bytes,
-                    &mut decompressed,
-                    flate2::FlushDecompress::Finish,
-                )
-                .ok()?;
-
-            Some(SingleSectionData::Owned(decompressed))
+        _ => {
+            let compressed = file_range.data(data).ok()?;
+            let decompressed = compressed.decompress().ok()?;
+            Some(SingleSectionData::Owned(decompressed.into_owned()))
         }
-        _ => None,
     }
 }
 


### PR DESCRIPTION
This compression method was [introduced to ELF in 2022](https://maskray.me/blog/2022-09-09-zstd-compressed-debug-sections) and toolchain support for it is slowly spreading. For example, Ubuntu 24.04 now has versions of binutils, GCC, and LLVM that can read and write it. I was experimenting with this and (long story short) found out that it breaks symbolication in samply. On a Rust program compiled with `-Clink-arg=-Wl,--compress-debug-sections=zstd`, my system's `addr2line` (binutils 2.42) can give file paths and line numbers while `wholesym-addr2line` fails and reports `??:?`.

It turns out to be an easy fix because the version + feature flags of `object` used by samply-symbols already has support for reading zstd-compressed sections, it just wasn't used. I decided to use their convenience function for both zstd and zlib formats because it has some additional error checks (defending against incorrect or impossibly large uncompressed size) not present in samply's zlib handling.