### PR TITLE
Implement Profile APIs for marker graphs, counter colors, sample weight types, and initially visible+selected threads

### DIFF
--- a/fxprof-processed-profile/src/counters.rs
+++ b/fxprof-processed-profile/src/counters.rs
@@ -1,6 +1,6 @@
 use serde::ser::{Serialize, SerializeMap, Serializer};
 
-use crate::{ProcessHandle, Timestamp};
+use crate::{GraphColor, ProcessHandle, Timestamp};
 
 /// A counter. Can be created with [`Profile::add_counter`](crate::Profile::add_counter).
 #[derive(Debug, Clone, Copy, PartialOrd, Ord, PartialEq, Eq, Hash)]
@@ -14,6 +14,7 @@ pub struct Counter {
     process: ProcessHandle,
     pid: String,
     samples: CounterSamples,
+    color: Option<GraphColor>,
 }
 
 impl Counter {
@@ -31,6 +32,7 @@ impl Counter {
             process,
             pid: pid.to_owned(),
             samples: CounterSamples::new(),
+            color: None,
         }
     }
 
@@ -46,6 +48,10 @@ impl Counter {
     ) {
         self.samples
             .add_sample(timestamp, value_delta, number_of_operations_delta)
+    }
+
+    pub fn set_color(&mut self, color: GraphColor) {
+        self.color = Some(color);
     }
 
     pub fn as_serializable(&self, main_thread_index: usize) -> impl Serialize + '_ {
@@ -71,6 +77,9 @@ impl Serialize for SerializableCounter<'_> {
         map.serialize_entry("mainThreadIndex", &self.main_thread_index)?;
         map.serialize_entry("pid", &self.counter.pid)?;
         map.serialize_entry("samples", &self.counter.samples)?;
+        if let Some(color) = self.counter.color {
+            map.serialize_entry("color", &color)?;
+        }
         map.end()
     }
 }

--- a/fxprof-processed-profile/src/lib.rs
+++ b/fxprof-processed-profile/src/lib.rs
@@ -68,12 +68,13 @@ pub use global_lib_table::{LibraryHandle, UsedLibraryAddressesIterator};
 pub use lib_mappings::LibMappings;
 pub use library_info::{LibraryInfo, Symbol, SymbolTable};
 pub use markers::{
-    Marker, MarkerFieldFormat, MarkerFieldFormatKind, MarkerFieldSchema, MarkerHandle,
-    MarkerLocation, MarkerSchema, MarkerStaticField, MarkerTiming, MarkerTypeHandle,
-    StaticSchemaMarker,
+    GraphColor, Marker, MarkerFieldFormat, MarkerFieldFormatKind, MarkerFieldSchema,
+    MarkerGraphSchema, MarkerGraphType, MarkerHandle, MarkerLocation, MarkerSchema,
+    MarkerStaticField, MarkerTiming, MarkerTypeHandle, StaticSchemaMarker,
 };
 pub use process::ThreadHandle;
 pub use profile::{FrameHandle, Profile, SamplingInterval, StackHandle, StringHandle};
 pub use reference_timestamp::ReferenceTimestamp;
+pub use sample_table::WeightType;
 pub use thread::ProcessHandle;
 pub use timestamp::*;

--- a/fxprof-processed-profile/src/profile.rs
+++ b/fxprof-processed-profile/src/profile.rs
@@ -423,7 +423,11 @@ impl Profile {
         self.threads[thread.0].set_tid(tid);
     }
 
-    /// Set whether to render markers in a thread's timeline view.
+    /// Set whether to show a timeline view displaying [`MarkerLocation::TimelineOverview`](crate::MarkerLocation::TimelineOverview)
+    /// markers for this thread.
+    ///
+    /// Main threads always have such a timeline view and always display such markers,
+    /// but non-main threads only do so when specified using this method.
     pub fn set_thread_show_markers_in_timeline(&mut self, thread: ThreadHandle, v: bool) {
         self.threads[thread.0].set_show_markers_in_timeline(v);
     }
@@ -893,6 +897,29 @@ impl Profile {
     ///
     /// Setting to true prevents the Firefox Profiler from attempting to
     /// resolve symbols.
+    ///
+    /// By default, this is set to false. This causes the Firefox Profiler
+    /// to look up symbols for any address-based [`Frame`], i.e. any frame
+    /// which is not a [`Frame::Label`].
+    ///
+    /// If you use address-based frames and supply your own symbols using
+    /// [`Profile::add_lib`] or [`Profile::set_lib_symbol_table`], you can
+    /// choose to set this to true and avoid another symbol lookup, or you
+    /// can leave it set to false if there is a way to obtain richer symbol
+    /// information than the information supplied in those symbol tables.
+    ///
+    /// For example, when samply creates a profile which includes JIT frames,
+    /// and there is a Jitdump file with symbol information about those JIT
+    /// frames, samply uses [`Profile::set_lib_symbol_table`] to provide
+    /// the function names for the JIT functions. But it does not call
+    /// [`Profile::set_symbolicated`] with true, because the Jitdump files may
+    /// include additional information that's not in the [`SymbolTable`],
+    /// specifically the Jitdump file may have file name and line number information.
+    /// This information is only added into the profile by the Firefox Profiler's
+    /// resolution of symbols: The Firefox Profiler requests symbol information
+    /// for the JIT frame addresses from samply's symbol server, at which point
+    /// samply obtains the richer information from the Jitdump file and returns
+    /// it via the symbol server response.
     pub fn set_symbolicated(&mut self, v: bool) {
         self.symbolicated = v;
     }

--- a/fxprof-processed-profile/src/sample_table.rs
+++ b/fxprof-processed-profile/src/sample_table.rs
@@ -24,63 +24,27 @@ pub struct SampleTable {
     last_sample_timestamp: Timestamp,
 }
 
-/// Profile samples can come in a variety of forms and represent different information.
-/// The Gecko Profiler by default uses sample counts, as it samples on a fixed interval.
-/// These samples are all weighted equally by default, with a weight of one. However in
-/// comparison profiles, some weights are negative, creating a "diff" profile.
-///
-/// In addition, tracing formats can fit into the sample-based format by reporting
-/// the "self time" of the profile. Each of these "self time" samples would then
-/// provide the weight, in duration. Currently, the tracing format assumes that
-/// the timing comes in milliseconds (see 'tracing-ms') but if needed, microseconds
-/// or nanoseconds support could be added.
-///
-/// e.g. The following tracing data could be represented as samples:
-///
-/// ```ignore
-///     0 1 2 3 4 5 6 7 8 9 10
-///     | | | | | | | | | | |
-///     - - - - - - - - - - -
-///     A A A A A A A A A A A
-///         B B D D D D
-///         C C E E E E
-/// ```
-/// This chart represents the self time.
-/// ```ignore
-///     0 1 2 3 4 5 6 7 8 9 10
-///     | | | | | | | | | | |
-///     A A C C E E E E A A A
-/// ```
-/// And finally this is what the samples table would look like.
-/// ```ignore
-///     SamplesTable = {
-///       time:   [0,   2,   4, 8],
-///       stack:  [A, ABC, ADE, A],
-///       weight: [2,   2,   4, 3],
-///     }
-/// ```
-///
-/// JS type definition:
-/// ```ts
-/// export type WeightType = 'samples' | 'tracing-ms' | 'bytes';
-/// ```
-///
-/// Documentation and code from:
-/// <https://github.com/firefox-devtools/profiler/blob/7bf02b3f747a33a8c166c533dc29304fde725517/src/types/profile.js#L127>
+/// Specifies the meaning of the "weight" value of a thread's samples.
 #[derive(Debug, Clone)]
 pub enum WeightType {
-    /// The weight is an integer multiplier.
+    /// The weight is an integer multiplier. For example, "this stack was
+    /// observed n times when sampling at the specified interval."
     ///
     /// This affects the total + self score of each call node in the call tree,
     /// and the order in the tree because the tree is ordered from large "totals"
     /// to small "totals".
     /// It also affects the width of the sample's stack's box in the flame graph.
     Samples,
-    /// Each sample will have a weight in terms of (fractional) milliseconds.
-    /// Not supported by fxprof-processed-profile at the moment.
-    #[allow(dead_code)]
+    /// The weight is a duration in (fractional) milliseconds.
+    ///
+    /// Note that, since [`Profile::add_sample`](crate::Profile::add_sample) currently
+    /// only accepts integer weight values, the usefulness of `TracingMs` is
+    /// currently limited.
     TracingMs,
-    /// Each sample will have a weight in terms of bytes allocated.
+    /// The weight of each sample is a value in bytes.
+    ///
+    /// This can be used for profiles with allocation stacks. It can also be used
+    /// for "size" profiles which give a bytes breakdown of the contents of a file.
     Bytes,
 }
 

--- a/fxprof-processed-profile/src/sample_table.rs
+++ b/fxprof-processed-profile/src/sample_table.rs
@@ -13,7 +13,7 @@ use crate::Timestamp;
 /// it in the profile.
 #[derive(Debug, Clone)]
 pub struct SampleTable {
-    sample_type: WeightType,
+    sample_weight_type: WeightType,
     sample_weights: Vec<i32>,
     sample_timestamps: Vec<Timestamp>,
     /// An index into the thread's stack table for each sample. `None` means the empty stack.
@@ -107,7 +107,7 @@ impl Serialize for WeightType {
 impl SampleTable {
     pub fn new() -> Self {
         Self {
-            sample_type: WeightType::Samples,
+            sample_weight_type: WeightType::Samples,
             sample_weights: Vec::new(),
             sample_timestamps: Vec::new(),
             sample_stack_indexes: Vec::new(),
@@ -134,6 +134,10 @@ impl SampleTable {
         self.last_sample_timestamp = timestamp;
     }
 
+    pub fn set_weight_type(&mut self, t: WeightType) {
+        self.sample_weight_type = t;
+    }
+
     pub fn modify_last_sample(&mut self, timestamp: Timestamp, weight: i32) {
         *self.sample_weights.last_mut().unwrap() += weight;
         *self.sample_timestamps.last_mut().unwrap() = timestamp;
@@ -145,7 +149,7 @@ impl Serialize for SampleTable {
         let len = self.sample_timestamps.len();
         let mut map = serializer.serialize_map(None)?;
         map.serialize_entry("length", &len)?;
-        map.serialize_entry("weightType", &self.sample_type.to_string())?;
+        map.serialize_entry("weightType", &self.sample_weight_type.to_string())?;
 
         if self.sorted_by_time {
             map.serialize_entry("stack", &self.sample_stack_indexes)?;

--- a/samply/src/linux_shared/converter.rs
+++ b/samply/src/linux_shared/converter.rs
@@ -1916,6 +1916,7 @@ impl StaticSchemaMarker for MmapMarker {
                 searchable: true,
             }],
             static_fields: vec![],
+            graphs: vec![],
         }
     }
 

--- a/samply/src/shared/jit_function_add_marker.rs
+++ b/samply/src/shared/jit_function_add_marker.rs
@@ -26,6 +26,7 @@ impl StaticSchemaMarker for JitFunctionAddMarker {
                 label: "Description".into(),
                 value: "Emitted when a JIT function is added to the process.".into(),
             }],
+            graphs: vec![],
         }
     }
 

--- a/samply/src/shared/per_cpu.rs
+++ b/samply/src/shared/per_cpu.rs
@@ -171,6 +171,7 @@ impl StaticSchemaMarker for ThreadNameMarkerForCpuTrack {
                 searchable: true,
             }],
             static_fields: vec![],
+            graphs: vec![],
         }
     }
 
@@ -225,6 +226,7 @@ impl StaticSchemaMarker for OnCpuMarkerForThreadTrack {
                 },
             ],
             static_fields: vec![],
+            graphs: vec![],
         }
     }
 

--- a/samply/src/shared/process_sample_data.rs
+++ b/samply/src/shared/process_sample_data.rs
@@ -171,6 +171,7 @@ impl StaticSchemaMarker for RssStatMarker {
                 label: "Description".into(),
                 value: "Emitted when the kmem:rss_stat tracepoint is hit.".into(),
             }],
+            graphs: vec![],
         }
     }
 
@@ -215,6 +216,7 @@ impl StaticSchemaMarker for OtherEventMarker {
                     "Emitted for any records in a perf.data file which don't map to a known event."
                         .into(),
             }],
+            graphs: vec![],
         }
     }
 
@@ -258,6 +260,7 @@ impl StaticSchemaMarker for UserTimingMarker {
                 label: "Description".into(),
                 value: "Emitted for performance.mark and performance.measure.".into(),
             }],
+            graphs: vec![],
         }
     }
 
@@ -295,6 +298,7 @@ impl StaticSchemaMarker for SchedSwitchMarkerOnCpuTrack {
                 label: "Description".into(),
                 value: "Emitted just before a running thread gets moved off-cpu.".into(),
             }],
+            graphs: vec![],
         }
     }
 
@@ -340,6 +344,7 @@ impl StaticSchemaMarker for SchedSwitchMarkerOnThreadTrack {
                 label: "Description".into(),
                 value: "Emitted just before a running thread gets moved off-cpu.".into(),
             }],
+            graphs: vec![],
         }
     }
 
@@ -383,6 +388,7 @@ impl StaticSchemaMarker for SimpleMarker {
                 label: "Description".into(),
                 value: "Emitted for marker spans in a markers text file.".into(),
             }],
+            graphs: vec![],
         }
     }
 

--- a/samply/src/windows/coreclr.rs
+++ b/samply/src/windows/coreclr.rs
@@ -243,6 +243,7 @@ impl StaticSchemaMarker for CoreClrGcAllocMarker {
                 label: "Description".into(),
                 value: "GC Allocation.".into(),
             }],
+            graphs: vec![],
         }
     }
 
@@ -290,6 +291,7 @@ impl StaticSchemaMarker for CoreClrGcEventMarker {
                 label: "Description".into(),
                 value: "Generic GC Event.".into(),
             }],
+            graphs: vec![],
         }
     }
 
@@ -773,6 +775,7 @@ impl StaticSchemaMarker for OtherClrMarker {
                 label: "Description".into(),
                 value: "CoreCLR marker of unknown type.".into(),
             }],
+            graphs: vec![],
         }
     }
 

--- a/samply/src/windows/profile_context.rs
+++ b/samply/src/windows/profile_context.rs
@@ -1576,6 +1576,7 @@ impl ProfileContext {
                     table_label: Some("{marker.name}".into()),
                     fields: vec![],
                     static_fields: vec![],
+                    graphs: vec![],
                 }
             }
 
@@ -2256,6 +2257,7 @@ impl StaticSchemaMarker for FreeformMarker {
                 searchable: true,
             }],
             static_fields: vec![],
+            graphs: vec![],
         }
     }
 


### PR DESCRIPTION
These changes to the `fxprof-processed-profile` crate are from @indygreg's [profile-add-fields](https://github.com/indygreg/samply/compare/profile-add-fields) branch. I've merged his changes and tweaked the comments.