### PR TITLE
Use serde::ser::Serialize and serde::de::Deserialize instead of serde…

### DIFF
--- a/fxprof-processed-profile/src/library_info.rs
+++ b/fxprof-processed-profile/src/library_info.rs
@@ -1,8 +1,7 @@
 use std::sync::Arc;
 
 use debugid::DebugId;
-use serde::ser::SerializeMap;
-use serde::{Serialize, Serializer};
+use serde::ser::{Serialize, SerializeMap, Serializer};
 
 /// A library ("binary" / "module" / "DSO") which is loaded into a process.
 /// This can be the main executable file or a dynamic library, or any other

--- a/fxprof-processed-profile/src/markers.rs
+++ b/fxprof-processed-profile/src/markers.rs
@@ -3,8 +3,7 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use bitflags::bitflags;
-use serde::ser::{SerializeMap, SerializeSeq};
-use serde::Serialize;
+use serde::ser::{Serialize, SerializeMap, SerializeSeq};
 use serde_derive::Serialize;
 
 use super::profile::StringHandle;

--- a/fxprof-processed-profile/src/string_table.rs
+++ b/fxprof-processed-profile/src/string_table.rs
@@ -1,6 +1,6 @@
 use std::ops::Deref;
 
-use serde::{Serialize, Serializer};
+use serde::ser::{Serialize, Serializer};
 
 use crate::fast_hash_map::FastHashMap;
 

--- a/samply-api/src/hex.rs
+++ b/samply-api/src/hex.rs
@@ -24,7 +24,7 @@ pub fn from_prefixed_hex_str<'de, D>(deserializer: D) -> Result<u32, D::Error>
 where
     D: serde::Deserializer<'de>,
 {
-    use serde::Deserialize;
+    use serde::de::Deserialize;
     let s = String::deserialize(deserializer)?;
     let s = if let Some(s) = s.strip_prefix("0x") {
         s

--- a/samply/src/shared/symbol_precog.rs
+++ b/samply/src/shared/symbol_precog.rs
@@ -6,8 +6,8 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use debugid::DebugId;
-use serde::ser::{SerializeMap, SerializeSeq};
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde::de::{Deserialize, Deserializer};
+use serde::ser::{Serialize, SerializeMap, SerializeSeq, Serializer};
 use serde_derive::{Deserialize, Serialize};
 use serde_json::to_writer;
 use wholesym::SourceFilePath;

--- a/samply/src/windows/utility_process/file_channel.rs
+++ b/samply/src/windows/utility_process/file_channel.rs
@@ -27,7 +27,7 @@ use std::path::Path;
 use fs4::fs_std::FileExt;
 use fs4::lock_contended_error;
 use serde::de::DeserializeOwned;
-use serde::Serialize;
+use serde::ser::Serialize;
 
 #[derive(Debug)]
 struct FileMessageWriter<T> {

--- a/samply/src/windows/utility_process/traits.rs
+++ b/samply/src/windows/utility_process/traits.rs
@@ -3,7 +3,7 @@ use std::fmt::Debug;
 use std::path::Path;
 
 use serde::de::DeserializeOwned;
-use serde::Serialize;
+use serde::ser::Serialize;
 
 pub trait UtilityProcess {
     const PROCESS_TYPE: &'static str;


### PR DESCRIPTION
…::Serialize/Deserialize, so that everything still works if something in the dependency tree turns on serde's derive feature.