### PR TITLE
Add ignore exit code flag

### DIFF
--- a/samply/src/linux/profiler.rs
+++ b/samply/src/linux/profiler.rs
@@ -71,6 +71,7 @@ pub fn start_recording(
         command_name,
         args,
         iteration_count,
+        ignore_exit_code,
     } = process_launch_props;
 
     if profile_creation_props.coreclr.any_enabled() {
@@ -191,7 +192,7 @@ pub fn start_recording(
             WaitStatus::Exited(_pid, exit_code) => ExitStatus::from_raw(*exit_code).success(),
             _ => false,
         };
-        if !previous_run_exited_with_success {
+        if !ignore_exit_code && !previous_run_exited_with_success {
             eprintln!(
                 "Skipping remaining iterations due to non-success exit status: {wait_status:?}"
             );

--- a/samply/src/mac/process_launcher.rs
+++ b/samply/src/mac/process_launcher.rs
@@ -28,6 +28,7 @@ pub struct TaskLauncher {
     args: Vec<OsString>,
     child_env: Vec<(OsString, OsString)>,
     iteration_count: u32,
+    ignore_exit_code: bool,
 }
 
 impl RootTaskRunner for TaskLauncher {
@@ -41,7 +42,7 @@ impl RootTaskRunner for TaskLauncher {
         let mut exit_status = root_child.wait().expect("couldn't wait for child");
 
         for i in 2..=self.iteration_count {
-            if !exit_status.success() {
+            if self.ignore_exit_code && !exit_status.success() {
                 eprintln!(
                     "Skipping remaining iterations due to non-success exit status: \"{}\"",
                     exit_status
@@ -65,6 +66,7 @@ impl TaskLauncher {
         program: S,
         args: I,
         iteration_count: u32,
+        ignore_exit_code: bool,
         env_vars: &[(OsString, OsString)],
         extra_env_vars: &[(OsString, OsString)],
     ) -> Result<TaskLauncher, MachError>

--- a/samply/src/mac/process_launcher.rs
+++ b/samply/src/mac/process_launcher.rs
@@ -93,6 +93,7 @@ impl TaskLauncher {
             args,
             child_env,
             iteration_count,
+            ignore_exit_code,
         })
     }
 

--- a/samply/src/mac/process_launcher.rs
+++ b/samply/src/mac/process_launcher.rs
@@ -42,7 +42,7 @@ impl RootTaskRunner for TaskLauncher {
         let mut exit_status = root_child.wait().expect("couldn't wait for child");
 
         for i in 2..=self.iteration_count {
-            if self.ignore_exit_code && !exit_status.success() {
+            if !self.ignore_exit_code && !exit_status.success() {
                 eprintln!(
                     "Skipping remaining iterations due to non-success exit status: \"{}\"",
                     exit_status

--- a/samply/src/mac/profiler.rs
+++ b/samply/src/mac/profiler.rs
@@ -44,6 +44,7 @@ pub fn start_recording(
                 command_name,
                 args,
                 iteration_count,
+                ignore_exit_code,
             } = process_launch_props;
 
             let task_launcher = if profile_creation_props.coreclr.any_enabled() {
@@ -62,6 +63,7 @@ pub fn start_recording(
                     &command_name,
                     &args,
                     iteration_count,
+                    ignore_exit_code,
                     &env_vars,
                     task_accepter.extra_env_vars(),
                 )?
@@ -70,6 +72,7 @@ pub fn start_recording(
                     &command_name,
                     &args,
                     iteration_count,
+                    ignore_exit_code,
                     &env_vars,
                     task_accepter.extra_env_vars(),
                 )?

--- a/samply/src/main.rs
+++ b/samply/src/main.rs
@@ -203,6 +203,10 @@ struct RecordArgs {
     #[arg(long, default_value = "1")]
     iteration_count: u32,
 
+    /// Ignore exit code and continue running when iteration_count > 0
+    #[arg(short, long)]
+    ignore_exit_code: bool,
+
     #[command(flatten)]
     profile_creation_args: ProfileCreationArgs,
 
@@ -647,6 +651,7 @@ impl RecordArgs {
             command_name,
             args,
             iteration_count,
+            ignore_exit_code: self.ignore_exit_code,
         };
 
         RecordingMode::Launch(launch_props)

--- a/samply/src/shared/recording_props.rs
+++ b/samply/src/shared/recording_props.rs
@@ -118,4 +118,5 @@ pub struct ProcessLaunchProps {
     pub command_name: OsString,
     pub args: Vec<OsString>,
     pub iteration_count: u32,
+    pub ignore_exit_code: bool,
 }

--- a/samply/src/windows/profiler.rs
+++ b/samply/src/windows/profiler.rs
@@ -100,10 +100,6 @@ pub fn start_recording(
 
                 pids.push(child.id());
 
-                if process_launch_props.ignore_exit_code {
-                    continue;
-                }
-
                 // Wait for the child to exit.
                 //
                 // TODO: Do the child waiting and the xperf control on different threads,
@@ -113,7 +109,7 @@ pub fn start_recording(
                 // press Ctrl+C again, which would immediately terminate this process and not
                 // give us a chance to stop xperf.
                 let exit_status = child.wait().unwrap();
-                if !exit_status.success() {
+                if !process_launch_props.ignore_exit_code && !exit_status.success() {
                     eprintln!(
                         "Skipping remaining iterations due to non-success exit status: \"{}\"",
                         exit_status

--- a/samply/src/windows/profiler.rs
+++ b/samply/src/windows/profiler.rs
@@ -100,6 +100,10 @@ pub fn start_recording(
 
                 pids.push(child.id());
 
+                if process_launch_props.ignore_exit_code {
+                    continue;
+                }
+
                 // Wait for the child to exit.
                 //
                 // TODO: Do the child waiting and the xperf control on different threads,


### PR DESCRIPTION
Add `ignore_exit_code` flag so that iteration count can continue even if the process returned a non-zero exit code (which is common on linters / verifiers etc)