### PR TITLE
Fix repeated external object file reads with async lookup

### DIFF
--- a/samply-api/src/symbolicate/mod.rs
+++ b/samply-api/src/symbolicate/mod.rs
@@ -114,7 +114,7 @@ impl<'a, H: FileAndPathHelper> SymbolicateApi<'a, H> {
         }
 
         // Look up any addresses whose debug info is in an external file.
-        // The symbol_manager caches the most recent external file, so we sort our
+        // The symbol_map caches the most recent external file, so we sort our
         // external addresses by ExternalFileAddressRef before we do the lookup,
         // in order to get the best hit rate in lookup_external.
         external_addresses.sort_unstable_by(|(_, a), (_, b)| a.cmp(b));

--- a/samply-symbols/src/symbol_map.rs
+++ b/samply-symbols/src/symbol_map.rs
@@ -16,6 +16,13 @@ pub trait SymbolMapTrait {
 
     fn iter_symbols(&self) -> Box<dyn Iterator<Item = (u32, Cow<'_, str>)> + '_>;
 
+    /// Look up information for an address synchronously.
+    ///
+    /// If the information is known to be in an external file, and this file is
+    /// already cached within this symbol map, then that cached information is
+    /// consulted as part of this lookup_sync invocation. This method only returns
+    /// `FramesLookupResult::External` if the caller actually needs to supply new
+    /// file contents with a follow-up call to `try_lookup_external_with_file_contents`.
     fn lookup_sync(&self, address: LookupAddress) -> Option<SyncAddressInfo>;
 }
 

--- a/samply-symbols/src/symbol_map_object.rs
+++ b/samply-symbols/src/symbol_map_object.rs
@@ -579,6 +579,12 @@ where
         if frames.is_none() {
             frames = self.frames_lookup_for_object_map_references(svma);
         }
+        if let Some(FramesLookupResult::External(external_file_address_ref)) = frames {
+            frames = self.try_lookup_external_impl(
+                &external_file_address_ref,
+                ExternalLookupRequest::ReplyIfYouHaveOrTellMeWhatYouNeed,
+            );
+        }
         Some(SyncAddressInfo { symbol, frames })
     }
 }

--- a/samply/src/linux_shared/convert_regs.rs
+++ b/samply/src/linux_shared/convert_regs.rs
@@ -27,7 +27,7 @@ impl ConvertRegs for ConvertRegsX86_64 {
     }
 
     fn regs_mask() -> u64 {
-        1 << PERF_REG_X86_IP | 1 << PERF_REG_X86_SP | 1 << PERF_REG_X86_BP
+        (1 << PERF_REG_X86_IP) | (1 << PERF_REG_X86_SP) | (1 << PERF_REG_X86_BP)
     }
 }
 
@@ -44,9 +44,9 @@ impl ConvertRegs for ConvertRegsAarch64 {
     }
 
     fn regs_mask() -> u64 {
-        1 << PERF_REG_ARM64_PC
-            | 1 << PERF_REG_ARM64_LR
-            | 1 << PERF_REG_ARM64_SP
-            | 1 << PERF_REG_ARM64_X29
+        (1 << PERF_REG_ARM64_PC)
+            | (1 << PERF_REG_ARM64_LR)
+            | (1 << PERF_REG_ARM64_SP)
+            | (1 << PERF_REG_ARM64_X29)
     }
 }


### PR DESCRIPTION
When used on macOS with debug info in .o files, `symbol_map.lookup(...).await` was re-reading the external file over and over even when it was cached inside the symbol map.

This didn't affect samply symbolication or samply-api because samply-api doesn't use the async `lookup` method, it uses `lookup_sync` and calls `lookup_external` manually.