### PR TITLE
Fix some issues related to categories and subcategories in fxprof-processed-profile

### DIFF
--- a/fxprof-processed-profile/src/category.rs
+++ b/fxprof-processed-profile/src/category.rs
@@ -43,13 +43,13 @@ impl From<CategoryHandle> for CategoryPairHandle {
 
 /// The information about a category.
 #[derive(Debug)]
-pub struct Category {
+pub struct InternalCategory {
     pub name: String,
     pub color: CategoryColor,
     pub subcategories: Vec<String>,
 }
 
-impl Category {
+impl InternalCategory {
     /// Add a subcategory to this category.
     pub fn add_subcategory(&mut self, subcategory_name: String) -> SubcategoryIndex {
         let subcategory_index = SubcategoryIndex(u8::try_from(self.subcategories.len()).unwrap());
@@ -58,7 +58,7 @@ impl Category {
     }
 }
 
-impl Serialize for Category {
+impl Serialize for InternalCategory {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let mut subcategories = self.subcategories.clone();
         subcategories.push("Other".to_string());
@@ -77,7 +77,7 @@ pub enum Subcategory {
     Other(CategoryHandle),
 }
 
-pub struct SerializableSubcategoryColumn<'a>(pub &'a [Subcategory], pub &'a [Category]);
+pub struct SerializableSubcategoryColumn<'a>(pub &'a [Subcategory], pub &'a [InternalCategory]);
 
 impl Serialize for SerializableSubcategoryColumn<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {

--- a/fxprof-processed-profile/src/category.rs
+++ b/fxprof-processed-profile/src/category.rs
@@ -23,7 +23,7 @@ impl Serialize for CategoryHandle {
 ///
 /// Subategories can be created with [`Profile::add_subcategory`](crate::Profile::add_subcategory).
 #[derive(Debug, Clone, Copy, PartialOrd, Ord, PartialEq, Eq, Hash)]
-pub struct SubcategoryIndex(pub u8);
+pub struct SubcategoryIndex(pub u16);
 
 impl SubcategoryIndex {
     /// The "Other" subcategory. All categories have this subcategory as their first subcategory.
@@ -63,7 +63,7 @@ impl InternalCategory {
 
     /// Add a subcategory to this category.
     pub fn add_subcategory(&mut self, subcategory_name: String) -> SubcategoryIndex {
-        let subcategory_index = SubcategoryIndex(u8::try_from(self.subcategories.len()).unwrap());
+        let subcategory_index = SubcategoryIndex(u16::try_from(self.subcategories.len()).unwrap());
         self.subcategories.push(subcategory_name);
         subcategory_index
     }

--- a/fxprof-processed-profile/src/category_color.rs
+++ b/fxprof-processed-profile/src/category_color.rs
@@ -1,7 +1,7 @@
 use serde::ser::{Serialize, Serializer};
 
 /// One of the available colors for a category.
-#[derive(Debug, Clone, Copy, PartialOrd, Ord, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialOrd, Ord, PartialEq, Eq, Hash)]
 pub enum CategoryColor {
     Transparent,
     LightBlue,

--- a/fxprof-processed-profile/src/frame_table.rs
+++ b/fxprof-processed-profile/src/frame_table.rs
@@ -1,8 +1,6 @@
 use serde::ser::{Serialize, SerializeMap, SerializeSeq, Serializer};
 
-use crate::category::{
-    InternalCategory, CategoryHandle, CategoryPairHandle, SerializableSubcategoryColumn, Subcategory,
-};
+use crate::category::{CategoryHandle, CategoryPairHandle, SubcategoryIndex};
 use crate::fast_hash_map::FastHashMap;
 use crate::frame::FrameFlags;
 use crate::func_table::{FuncIndex, FuncTable};
@@ -16,7 +14,7 @@ use crate::thread_string_table::{ThreadInternalStringIndex, ThreadStringTable};
 pub struct FrameTable {
     addresses: Vec<Option<u32>>,
     categories: Vec<CategoryHandle>,
-    subcategories: Vec<Subcategory>,
+    subcategories: Vec<SubcategoryIndex>,
     funcs: Vec<FuncIndex>,
     native_symbols: Vec<Option<NativeSymbolIndex>>,
     internal_frame_to_frame_index: FastHashMap<InternalFrame, usize>,
@@ -86,11 +84,7 @@ impl FrameTable {
                 };
                 let func_index =
                     func_table.index_for_func(location_string_index, resource, frame.flags);
-                let CategoryPairHandle(category, subcategory_index) = frame.category_pair;
-                let subcategory = match subcategory_index {
-                    Some(index) => Subcategory::Normal(index),
-                    None => Subcategory::Other(category),
-                };
+                let CategoryPairHandle(category, subcategory) = frame.category_pair;
                 addresses.push(address);
                 categories.push(category);
                 subcategories.push(subcategory);
@@ -99,37 +93,22 @@ impl FrameTable {
                 frame_index
             })
     }
-
-    pub fn as_serializable<'a>(&'a self, categories: &'a [InternalCategory]) -> impl Serialize + 'a {
-        SerializableFrameTable {
-            table: self,
-            categories,
-        }
-    }
 }
 
-struct SerializableFrameTable<'a> {
-    table: &'a FrameTable,
-    categories: &'a [InternalCategory],
-}
-
-impl Serialize for SerializableFrameTable<'_> {
+impl Serialize for FrameTable {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let len = self.table.addresses.len();
+        let len = self.addresses.len();
         let mut map = serializer.serialize_map(None)?;
         map.serialize_entry("length", &len)?;
         map.serialize_entry(
             "address",
-            &SerializableFrameTableAddressColumn(&self.table.addresses),
+            &SerializableFrameTableAddressColumn(&self.addresses),
         )?;
         map.serialize_entry("inlineDepth", &SerializableSingleValueColumn(0u32, len))?;
-        map.serialize_entry("category", &self.table.categories)?;
-        map.serialize_entry(
-            "subcategory",
-            &SerializableSubcategoryColumn(&self.table.subcategories, self.categories),
-        )?;
-        map.serialize_entry("func", &self.table.funcs)?;
-        map.serialize_entry("nativeSymbol", &self.table.native_symbols)?;
+        map.serialize_entry("category", &self.categories)?;
+        map.serialize_entry("subcategory", &self.subcategories)?;
+        map.serialize_entry("func", &self.funcs)?;
+        map.serialize_entry("nativeSymbol", &self.native_symbols)?;
         map.serialize_entry("innerWindowID", &SerializableSingleValueColumn((), len))?;
         map.serialize_entry("implementation", &SerializableSingleValueColumn((), len))?;
         map.serialize_entry("line", &SerializableSingleValueColumn((), len))?;

--- a/fxprof-processed-profile/src/frame_table.rs
+++ b/fxprof-processed-profile/src/frame_table.rs
@@ -1,7 +1,7 @@
 use serde::ser::{Serialize, SerializeMap, SerializeSeq, Serializer};
 
 use crate::category::{
-    Category, CategoryHandle, CategoryPairHandle, SerializableSubcategoryColumn, Subcategory,
+    InternalCategory, CategoryHandle, CategoryPairHandle, SerializableSubcategoryColumn, Subcategory,
 };
 use crate::fast_hash_map::FastHashMap;
 use crate::frame::FrameFlags;
@@ -100,7 +100,7 @@ impl FrameTable {
             })
     }
 
-    pub fn as_serializable<'a>(&'a self, categories: &'a [Category]) -> impl Serialize + 'a {
+    pub fn as_serializable<'a>(&'a self, categories: &'a [InternalCategory]) -> impl Serialize + 'a {
         SerializableFrameTable {
             table: self,
             categories,
@@ -110,7 +110,7 @@ impl FrameTable {
 
 struct SerializableFrameTable<'a> {
     table: &'a FrameTable,
-    categories: &'a [Category],
+    categories: &'a [InternalCategory],
 }
 
 impl Serialize for SerializableFrameTable<'_> {

--- a/fxprof-processed-profile/src/profile.rs
+++ b/fxprof-processed-profile/src/profile.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use serde::ser::{Serialize, SerializeMap, SerializeSeq, Serializer};
 use serde_json::json;
 
-use crate::category::{InternalCategory, CategoryHandle, CategoryPairHandle};
+use crate::category::{CategoryHandle, CategoryPairHandle, InternalCategory};
 use crate::category_color::CategoryColor;
 use crate::counters::{Counter, CounterHandle};
 use crate::cpu_delta::CpuDelta;
@@ -121,7 +121,7 @@ pub struct Profile {
     pub(crate) global_libs: GlobalLibTable,
     pub(crate) kernel_libs: LibMappings<LibraryHandle>,
     pub(crate) categories: Vec<InternalCategory>, // append-only for stable CategoryHandles
-    pub(crate) processes: Vec<Process>,   // append-only for stable ProcessHandles
+    pub(crate) processes: Vec<Process>,           // append-only for stable ProcessHandles
     pub(crate) counters: Vec<Counter>,
     pub(crate) threads: Vec<Thread>, // append-only for stable ThreadHandles
     pub(crate) initial_visible_threads: Vec<ThreadHandle>,
@@ -160,11 +160,10 @@ impl Profile {
             processes: Vec::new(),
             string_table: GlobalStringTable::new(),
             marker_schemas: Vec::new(),
-            categories: vec![InternalCategory {
-                name: "Other".to_string(),
-                color: CategoryColor::Gray,
-                subcategories: Vec::new(),
-            }],
+            categories: vec![InternalCategory::new(
+                "Other".to_string(),
+                CategoryColor::Gray,
+            )],
             static_schema_marker_types: FastHashMap::default(),
             symbolicated: false,
             used_pids: FastHashMap::default(),
@@ -198,11 +197,8 @@ impl Profile {
     /// Categories are used for stack frames and markers, as part of a "category pair".
     pub fn add_category(&mut self, name: &str, color: CategoryColor) -> CategoryHandle {
         let handle = CategoryHandle(self.categories.len() as u16);
-        self.categories.push(InternalCategory {
-            name: name.to_string(),
-            color,
-            subcategories: Vec::new(),
-        });
+        self.categories
+            .push(InternalCategory::new(name.to_string(), color));
         handle
     }
 
@@ -212,7 +208,7 @@ impl Profile {
     /// its corresponding `CategoryPairHandle` for the default category using `category.into()`.
     pub fn add_subcategory(&mut self, category: CategoryHandle, name: &str) -> CategoryPairHandle {
         let subcategory = self.categories[category.0 as usize].add_subcategory(name.into());
-        CategoryPairHandle(category, Some(subcategory))
+        CategoryPairHandle(category, subcategory)
     }
 
     /// Add an empty process. The name, pid and start time can be changed afterwards,
@@ -986,7 +982,6 @@ impl Profile {
         SerializableProfileThreadsProperty {
             threads: &self.threads,
             processes: &self.processes,
-            categories: &self.categories,
             sorted_threads,
             marker_schemas: &self.marker_schemas,
             global_string_table: &self.string_table,
@@ -1104,7 +1099,6 @@ impl Serialize for SerializableProfileMeta<'_> {
 struct SerializableProfileThreadsProperty<'a> {
     threads: &'a [Thread],
     processes: &'a [Process],
-    categories: &'a [InternalCategory],
     sorted_threads: &'a [ThreadHandle],
     marker_schemas: &'a [InternalMarkerSchema],
     global_string_table: &'a GlobalStringTable,
@@ -1115,7 +1109,6 @@ impl Serialize for SerializableProfileThreadsProperty<'_> {
         let mut seq = serializer.serialize_seq(Some(self.threads.len()))?;
 
         for thread in self.sorted_threads {
-            let categories = self.categories;
             let thread = &self.threads[thread.0];
             let process = &self.processes[thread.process().0];
             let marker_schemas = self.marker_schemas;
@@ -1123,7 +1116,6 @@ impl Serialize for SerializableProfileThreadsProperty<'_> {
             seq.serialize_element(&SerializableProfileThread(
                 process,
                 thread,
-                categories,
                 marker_schemas,
                 global_string_table,
             ))?;
@@ -1154,27 +1146,19 @@ impl Serialize for SerializableProfileCountersProperty<'_> {
 struct SerializableProfileThread<'a>(
     &'a Process,
     &'a Thread,
-    &'a [InternalCategory],
     &'a [InternalMarkerSchema],
     &'a GlobalStringTable,
 );
 
 impl Serialize for SerializableProfileThread<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let SerializableProfileThread(
-            process,
-            thread,
-            categories,
-            marker_schemas,
-            global_string_table,
-        ) = self;
+        let SerializableProfileThread(process, thread, marker_schemas, global_string_table) = self;
         let process_start_time = process.start_time();
         let process_end_time = process.end_time();
         let process_name = process.name();
         let pid = process.pid();
         thread.serialize_with(
             serializer,
-            categories,
             process_start_time,
             process_end_time,
             process_name,

--- a/fxprof-processed-profile/src/profile.rs
+++ b/fxprof-processed-profile/src/profile.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use serde::ser::{Serialize, SerializeMap, SerializeSeq, Serializer};
 use serde_json::json;
 
-use crate::category::{Category, CategoryHandle, CategoryPairHandle};
+use crate::category::{InternalCategory, CategoryHandle, CategoryPairHandle};
 use crate::category_color::CategoryColor;
 use crate::counters::{Counter, CounterHandle};
 use crate::cpu_delta::CpuDelta;
@@ -120,7 +120,7 @@ pub struct Profile {
     pub(crate) interval: SamplingInterval,
     pub(crate) global_libs: GlobalLibTable,
     pub(crate) kernel_libs: LibMappings<LibraryHandle>,
-    pub(crate) categories: Vec<Category>, // append-only for stable CategoryHandles
+    pub(crate) categories: Vec<InternalCategory>, // append-only for stable CategoryHandles
     pub(crate) processes: Vec<Process>,   // append-only for stable ProcessHandles
     pub(crate) counters: Vec<Counter>,
     pub(crate) threads: Vec<Thread>, // append-only for stable ThreadHandles
@@ -160,7 +160,7 @@ impl Profile {
             processes: Vec::new(),
             string_table: GlobalStringTable::new(),
             marker_schemas: Vec::new(),
-            categories: vec![Category {
+            categories: vec![InternalCategory {
                 name: "Other".to_string(),
                 color: CategoryColor::Gray,
                 subcategories: Vec::new(),
@@ -198,7 +198,7 @@ impl Profile {
     /// Categories are used for stack frames and markers, as part of a "category pair".
     pub fn add_category(&mut self, name: &str, color: CategoryColor) -> CategoryHandle {
         let handle = CategoryHandle(self.categories.len() as u16);
-        self.categories.push(Category {
+        self.categories.push(InternalCategory {
             name: name.to_string(),
             color,
             subcategories: Vec::new(),
@@ -1104,7 +1104,7 @@ impl Serialize for SerializableProfileMeta<'_> {
 struct SerializableProfileThreadsProperty<'a> {
     threads: &'a [Thread],
     processes: &'a [Process],
-    categories: &'a [Category],
+    categories: &'a [InternalCategory],
     sorted_threads: &'a [ThreadHandle],
     marker_schemas: &'a [InternalMarkerSchema],
     global_string_table: &'a GlobalStringTable,
@@ -1154,7 +1154,7 @@ impl Serialize for SerializableProfileCountersProperty<'_> {
 struct SerializableProfileThread<'a>(
     &'a Process,
     &'a Thread,
-    &'a [Category],
+    &'a [InternalCategory],
     &'a [InternalMarkerSchema],
     &'a GlobalStringTable,
 );

--- a/fxprof-processed-profile/src/thread.rs
+++ b/fxprof-processed-profile/src/thread.rs
@@ -3,7 +3,7 @@ use std::cmp::Ordering;
 
 use serde::ser::{SerializeMap, Serializer};
 
-use crate::category::Category;
+use crate::category::InternalCategory;
 use crate::cpu_delta::CpuDelta;
 use crate::frame_table::{FrameTable, InternalFrame};
 use crate::func_table::FuncTable;
@@ -214,7 +214,7 @@ impl Thread {
     pub fn serialize_with<S: Serializer>(
         &self,
         serializer: S,
-        categories: &[Category],
+        categories: &[InternalCategory],
         process_start_time: Timestamp,
         process_end_time: Option<Timestamp>,
         process_name: &str,

--- a/fxprof-processed-profile/src/thread.rs
+++ b/fxprof-processed-profile/src/thread.rs
@@ -3,7 +3,6 @@ use std::cmp::Ordering;
 
 use serde::ser::{SerializeMap, Serializer};
 
-use crate::category::InternalCategory;
 use crate::cpu_delta::CpuDelta;
 use crate::frame_table::{FrameTable, InternalFrame};
 use crate::func_table::FuncTable;
@@ -214,7 +213,6 @@ impl Thread {
     pub fn serialize_with<S: Serializer>(
         &self,
         serializer: S,
-        categories: &[InternalCategory],
         process_start_time: Timestamp,
         process_end_time: Option<Timestamp>,
         process_name: &str,
@@ -232,7 +230,7 @@ impl Thread {
         let thread_unregister_time = self.end_time;
 
         let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("frameTable", &self.frame_table.as_serializable(categories))?;
+        map.serialize_entry("frameTable", &self.frame_table)?;
         map.serialize_entry("funcTable", &self.func_table)?;
         map.serialize_entry(
             "markers",

--- a/fxprof-processed-profile/tests/integration_tests/main.rs
+++ b/fxprof-processed-profile/tests/integration_tests/main.rs
@@ -1021,7 +1021,8 @@ fn profile_with_js() {
     );
 
     let some_label_string = profile.intern_string("Some label string");
-    let category = profile.add_category("Regular", CategoryColor::Green);
+    let category = profile.add_category("Cycle Collection", CategoryColor::Orange);
+    let category_pair = profile.add_subcategory(category, "Graph Reduction");
     let s1 = profile.intern_stack_frames(
         thread,
         vec![
@@ -1032,7 +1033,7 @@ fn profile_with_js() {
             },
             FrameInfo {
                 frame: Frame::ReturnAddress(0x7f76b7ffc0e7),
-                category_pair: category.into(),
+                category_pair,
                 flags: FrameFlags::empty(),
             },
         ]
@@ -1061,10 +1062,11 @@ fn profile_with_js() {
                   ]
                 },
                 {
-                  "name": "Regular",
-                  "color": "green",
+                  "name": "Cycle Collection",
+                  "color": "orange",
                   "subcategories": [
-                    "Other"
+                    "Other",
+                    "Graph Reduction"
                   ]
                 }
               ],
@@ -1112,7 +1114,7 @@ fn profile_with_js() {
                   ],
                   "subcategory": [
                     0,
-                    0
+                    1
                   ],
                   "func": [
                     0,


### PR DESCRIPTION
The old code was putting the "Other" subcategory at the end of every category's subcategory list, whereas the front-end expects that subcategory to be at the beginning of the list.