### PR TITLE
Some fxprof-processed-profile API changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -784,6 +784,7 @@ dependencies = [
  "assert-json-diff",
  "bitflags",
  "debugid",
+ "indexmap",
  "rustc-hash",
  "serde",
  "serde_derive",
@@ -1160,6 +1161,7 @@ checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
+ "serde",
 ]
 
 [[package]]

--- a/fxprof-processed-profile/Cargo.toml
+++ b/fxprof-processed-profile/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fxprof-processed-profile"
 version = "0.8.1"
 edition = "2021"
-rust-version = "1.60" # needed by bytesize
+rust-version = "1.63" # needed by indexmap
 authors = ["Markus Stange <mstange.moz@gmail.com>"]
 license = "MIT OR Apache-2.0"
 description = "Create profiles in the Firefox Profiler's processed profile JSON format."
@@ -16,6 +16,7 @@ serde = "1.0.204"
 serde_derive = "1.0.188"
 debugid = "0.8.0"
 rustc-hash = "2"
+indexmap = { version = "2.7", features = ["serde"] }
 
 [dev-dependencies]
 assert-json-diff = "2.0.1"

--- a/fxprof-processed-profile/README.md
+++ b/fxprof-processed-profile/README.md
@@ -20,8 +20,8 @@ let process = profile.add_process("App process", 54132, Timestamp::from_millis_s
 let thread = profile.add_thread(process, 54132000, Timestamp::from_millis_since_reference(0.0), true);
 profile.set_thread_name(thread, "Main thread");
 let stack_frames = vec![
-    FrameInfo { frame: Frame::Label(profile.handle_for_string("Root node")), category_pair: CategoryHandle::OTHER.into(), flags: FrameFlags::empty() },
-    FrameInfo { frame: Frame::Label(profile.handle_for_string("First callee")), category_pair: CategoryHandle::OTHER.into(), flags: FrameFlags::empty() }
+    FrameInfo { frame: Frame::Label(profile.handle_for_string("Root node")), subcategory: CategoryHandle::OTHER.into(), flags: FrameFlags::empty() },
+    FrameInfo { frame: Frame::Label(profile.handle_for_string("First callee")), subcategory: CategoryHandle::OTHER.into(), flags: FrameFlags::empty() }
 ];
 let stack = profile.handle_for_stack_frames(thread, stack_frames.into_iter());
 profile.add_sample(thread, Timestamp::from_millis_since_reference(0.0), stack, CpuDelta::ZERO, 1);

--- a/fxprof-processed-profile/README.md
+++ b/fxprof-processed-profile/README.md
@@ -20,10 +20,10 @@ let process = profile.add_process("App process", 54132, Timestamp::from_millis_s
 let thread = profile.add_thread(process, 54132000, Timestamp::from_millis_since_reference(0.0), true);
 profile.set_thread_name(thread, "Main thread");
 let stack_frames = vec![
-    FrameInfo { frame: Frame::Label(profile.intern_string("Root node")), category_pair: CategoryHandle::OTHER.into(), flags: FrameFlags::empty() },
-    FrameInfo { frame: Frame::Label(profile.intern_string("First callee")), category_pair: CategoryHandle::OTHER.into(), flags: FrameFlags::empty() }
+    FrameInfo { frame: Frame::Label(profile.handle_for_string("Root node")), category_pair: CategoryHandle::OTHER.into(), flags: FrameFlags::empty() },
+    FrameInfo { frame: Frame::Label(profile.handle_for_string("First callee")), category_pair: CategoryHandle::OTHER.into(), flags: FrameFlags::empty() }
 ];
-let stack = profile.intern_stack_frames(thread, stack_frames.into_iter());
+let stack = profile.handle_for_stack_frames(thread, stack_frames.into_iter());
 profile.add_sample(thread, Timestamp::from_millis_since_reference(0.0), stack, CpuDelta::ZERO, 1);
 
 let writer = std::io::BufWriter::new(output_file);

--- a/fxprof-processed-profile/src/category.rs
+++ b/fxprof-processed-profile/src/category.rs
@@ -3,16 +3,36 @@ use std::hash::Hash;
 use indexmap::Equivalent;
 use serde::ser::{Serialize, SerializeMap, Serializer};
 
+use crate::Profile;
+
 use super::category_color::CategoryColor;
 use super::fast_hash_map::FastIndexSet;
 
+/// Implemented by [`Category`], [`Subcategory`], [`CategoryHandle`] and [`SubcategoryHandle`].
+pub trait IntoSubcategoryHandle {
+    /// Returns the corresponding [`SubcategoryHandle`].
+    fn into_subcategory_handle(self, profile: &mut Profile) -> SubcategoryHandle;
+}
+
+/// A profiling category. Has a name and a color.
+///
+/// Used to categorize stack frames and markers in the front-end. The category's
+/// color is used in the activity graph and in the call tree, and in a few other places.
 #[derive(Debug, Clone, Copy, PartialOrd, Ord, PartialEq, Eq, Hash)]
 pub struct Category<'a>(pub &'a str, pub CategoryColor);
 
-/// A profiling category, obtained from [`Profile::handle_for_category`](crate::Profile::handle_for_category).
+impl IntoSubcategoryHandle for Category<'_> {
+    fn into_subcategory_handle(self, profile: &mut Profile) -> SubcategoryHandle {
+        let category_handle = profile.handle_for_category(self);
+        category_handle.into()
+    }
+}
+
+/// The handle for a [`Category`], obtained from [`Profile::handle_for_category`](crate::Profile::handle_for_category).
 ///
-/// Used to categorize stack frames and markers in the front-end. Every category has a color;
-/// the color is used in the activity graph and in the call tree, and in a few other places.
+/// Storing and reusing the handle avoids repeated lookups and can improve performance.
+///
+/// The handle is specific to a [`Profile`] instance and cannot be reused across profiles.
 #[derive(Debug, Clone, Copy, PartialOrd, Ord, PartialEq, Eq, Hash)]
 pub struct CategoryHandle(pub(crate) u16);
 
@@ -21,9 +41,30 @@ impl CategoryHandle {
     pub const OTHER: Self = CategoryHandle(0);
 }
 
+impl IntoSubcategoryHandle for CategoryHandle {
+    fn into_subcategory_handle(self, _profile: &mut Profile) -> SubcategoryHandle {
+        self.into()
+    }
+}
+
 impl Serialize for CategoryHandle {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         self.0.serialize(serializer)
+    }
+}
+
+/// A named subcategory of a [`Category`], for fine-grained annotation of stack frames.
+///
+/// If you don't need named subcategories, you can just pass a [`Category`] or a
+/// [`CategoryHandle`] in any place where an [`IntoSubcategoryHandle`] is expected;
+/// this will give you the category's default subcategory.
+pub struct Subcategory<'a>(pub Category<'a>, pub &'a str);
+
+impl IntoSubcategoryHandle for Subcategory<'_> {
+    fn into_subcategory_handle(self, profile: &mut Profile) -> SubcategoryHandle {
+        let Subcategory(category, subcategory_name) = self;
+        let category_handle = profile.handle_for_category(category);
+        profile.handle_for_subcategory(category_handle, subcategory_name)
     }
 }
 
@@ -35,15 +76,26 @@ impl SubcategoryIndex {
     pub const OTHER: Self = SubcategoryIndex(0);
 }
 
-/// A subcategory of a [`CategoryHandle`], used to annotate stack frames.
+/// A handle for a [`Subcategory`], or for the default subcategory of a [`CategoryHandle`].
+///
+/// Used to annotate stack frames.
 ///
 /// Every [`CategoryHandle`] can be turned into a [`SubcategoryHandle`] by calling `.into()` -
 /// this will give you the default subcategory of that category.
 ///
 /// Subcategory handles for named subcategories can be obtained from
 /// [`Profile::handle_for_subcategory`](crate::Profile::handle_for_subcategory).
+/// Storing and reusing the handle avoids repeated lookups and can improve performance.
+///
+/// The handle is specific to a Profile instance and cannot be reused across profiles.
 #[derive(Debug, Clone, Copy, PartialOrd, Ord, PartialEq, Eq, Hash)]
 pub struct SubcategoryHandle(pub(crate) CategoryHandle, pub(crate) SubcategoryIndex);
+
+impl IntoSubcategoryHandle for SubcategoryHandle {
+    fn into_subcategory_handle(self, _profile: &mut Profile) -> SubcategoryHandle {
+        self
+    }
+}
 
 impl From<CategoryHandle> for SubcategoryHandle {
     fn from(category: CategoryHandle) -> Self {

--- a/fxprof-processed-profile/src/fast_hash_map.rs
+++ b/fxprof-processed-profile/src/fast_hash_map.rs
@@ -1,5 +1,5 @@
-use rustc_hash::FxHashMap;
 use indexmap::IndexSet;
+use rustc_hash::FxHashMap;
 
 pub type FastHashMap<K, V> = FxHashMap<K, V>;
 pub type FastIndexSet<V> = IndexSet<V, rustc_hash::FxBuildHasher>;

--- a/fxprof-processed-profile/src/fast_hash_map.rs
+++ b/fxprof-processed-profile/src/fast_hash_map.rs
@@ -1,3 +1,5 @@
 use rustc_hash::FxHashMap;
+use indexmap::IndexSet;
 
 pub type FastHashMap<K, V> = FxHashMap<K, V>;
+pub type FastIndexSet<V> = IndexSet<V, rustc_hash::FxBuildHasher>;

--- a/fxprof-processed-profile/src/frame.rs
+++ b/fxprof-processed-profile/src/frame.rs
@@ -1,6 +1,6 @@
 use bitflags::bitflags;
 
-use crate::category::CategoryPairHandle;
+use crate::category::SubcategoryHandle;
 use crate::global_lib_table::LibraryHandle;
 use crate::profile::StringHandle;
 
@@ -55,8 +55,8 @@ pub enum Frame {
 pub struct FrameInfo {
     /// The absolute address or label of this frame.
     pub frame: Frame,
-    /// The category pair of this frame.
-    pub category_pair: CategoryPairHandle,
+    /// The subcategory of this frame.
+    pub subcategory: SubcategoryHandle,
     /// The flags of this frame. Use `FrameFlags::empty()` if unsure.
     pub flags: FrameFlags,
 }

--- a/fxprof-processed-profile/src/frame.rs
+++ b/fxprof-processed-profile/src/frame.rs
@@ -46,7 +46,7 @@ pub enum Frame {
     /// has already been resolved to a `LibraryHandle`.
     RelativeAddressFromAdjustedReturnAddress(LibraryHandle, u32),
     /// A string, containing an index returned by
-    /// [`Profile::intern_string`](crate::Profile::intern_string).
+    /// [`Profile::handle_for_string`](crate::Profile::handle_for_string).
     Label(StringHandle),
 }
 

--- a/fxprof-processed-profile/src/frame_table.rs
+++ b/fxprof-processed-profile/src/frame_table.rs
@@ -1,6 +1,6 @@
 use serde::ser::{Serialize, SerializeMap, SerializeSeq, Serializer};
 
-use crate::category::{CategoryHandle, CategoryPairHandle, SubcategoryIndex};
+use crate::category::{CategoryHandle, SubcategoryHandle, SubcategoryIndex};
 use crate::fast_hash_map::FastHashMap;
 use crate::frame::FrameFlags;
 use crate::func_table::{FuncIndex, FuncTable};
@@ -84,7 +84,7 @@ impl FrameTable {
                 };
                 let func_index =
                     func_table.index_for_func(location_string_index, resource, frame.flags);
-                let CategoryPairHandle(category, subcategory) = frame.category_pair;
+                let SubcategoryHandle(category, subcategory) = frame.subcategory;
                 addresses.push(address);
                 categories.push(category);
                 subcategories.push(subcategory);
@@ -134,7 +134,7 @@ impl Serialize for SerializableFrameTableAddressColumn<'_> {
 #[derive(Debug, Clone, PartialOrd, Ord, PartialEq, Eq, Hash)]
 pub struct InternalFrame {
     pub location: InternalFrameLocation,
-    pub category_pair: CategoryPairHandle,
+    pub subcategory: SubcategoryHandle,
     pub flags: FrameFlags,
 }
 

--- a/fxprof-processed-profile/src/lib.rs
+++ b/fxprof-processed-profile/src/lib.rs
@@ -19,10 +19,10 @@
 //! let thread = profile.add_thread(process, 54132000, Timestamp::from_millis_since_reference(0.0), true);
 //! profile.set_thread_name(thread, "Main thread");
 //! let stack_frames = vec![
-//!     FrameInfo { frame: Frame::Label(profile.intern_string("Root node")), category_pair: CategoryHandle::OTHER.into(), flags: FrameFlags::empty() },
-//!     FrameInfo { frame: Frame::Label(profile.intern_string("First callee")), category_pair: CategoryHandle::OTHER.into(), flags: FrameFlags::empty() }
+//!     FrameInfo { frame: Frame::Label(profile.handle_for_string("Root node")), category_pair: CategoryHandle::OTHER.into(), flags: FrameFlags::empty() },
+//!     FrameInfo { frame: Frame::Label(profile.handle_for_string("First callee")), category_pair: CategoryHandle::OTHER.into(), flags: FrameFlags::empty() }
 //! ];
-//! let stack = profile.intern_stack_frames(thread, stack_frames.into_iter());
+//! let stack = profile.handle_for_stack_frames(thread, stack_frames.into_iter());
 //! profile.add_sample(thread, Timestamp::from_millis_since_reference(0.0), stack, CpuDelta::ZERO, 1);
 //!
 //! let writer = std::io::BufWriter::new(output_file);

--- a/fxprof-processed-profile/src/lib.rs
+++ b/fxprof-processed-profile/src/lib.rs
@@ -19,8 +19,8 @@
 //! let thread = profile.add_thread(process, 54132000, Timestamp::from_millis_since_reference(0.0), true);
 //! profile.set_thread_name(thread, "Main thread");
 //! let stack_frames = vec![
-//!     FrameInfo { frame: Frame::Label(profile.handle_for_string("Root node")), category_pair: CategoryHandle::OTHER.into(), flags: FrameFlags::empty() },
-//!     FrameInfo { frame: Frame::Label(profile.handle_for_string("First callee")), category_pair: CategoryHandle::OTHER.into(), flags: FrameFlags::empty() }
+//!     FrameInfo { frame: Frame::Label(profile.handle_for_string("Root node")), subcategory: CategoryHandle::OTHER.into(), flags: FrameFlags::empty() },
+//!     FrameInfo { frame: Frame::Label(profile.handle_for_string("First callee")), subcategory: CategoryHandle::OTHER.into(), flags: FrameFlags::empty() }
 //! ];
 //! let stack = profile.handle_for_stack_frames(thread, stack_frames.into_iter());
 //! profile.add_sample(thread, Timestamp::from_millis_since_reference(0.0), stack, CpuDelta::ZERO, 1);
@@ -59,7 +59,7 @@ mod thread;
 mod thread_string_table;
 mod timestamp;
 
-pub use category::{CategoryHandle, CategoryPairHandle};
+pub use category::{Category, CategoryHandle, SubcategoryHandle};
 pub use category_color::CategoryColor;
 pub use counters::CounterHandle;
 pub use cpu_delta::CpuDelta;

--- a/fxprof-processed-profile/src/lib.rs
+++ b/fxprof-processed-profile/src/lib.rs
@@ -59,7 +59,9 @@ mod thread;
 mod thread_string_table;
 mod timestamp;
 
-pub use category::{Category, CategoryHandle, SubcategoryHandle};
+pub use category::{
+    Category, CategoryHandle, IntoSubcategoryHandle, Subcategory, SubcategoryHandle,
+};
 pub use category_color::CategoryColor;
 pub use counters::CounterHandle;
 pub use cpu_delta::CpuDelta;

--- a/fxprof-processed-profile/src/marker_table.rs
+++ b/fxprof-processed-profile/src/marker_table.rs
@@ -58,7 +58,6 @@ impl MarkerTable {
         schema: &InternalMarkerSchema,
         marker: T,
         timing: MarkerTiming,
-        category: CategoryHandle,
         thread_string_table: &mut ThreadStringTable,
         global_string_table: &mut GlobalStringTable,
     ) -> MarkerHandle {
@@ -68,7 +67,7 @@ impl MarkerTable {
             MarkerTiming::IntervalStart(s) => (Some(s), None, Phase::IntervalStart),
             MarkerTiming::IntervalEnd(e) => (None, Some(e), Phase::IntervalEnd),
         };
-        self.marker_categories.push(category);
+        self.marker_categories.push(schema.category());
         self.marker_name_string_indexes.push(name_string_index);
         self.marker_starts.push(s);
         self.marker_ends.push(e);

--- a/fxprof-processed-profile/src/thread.rs
+++ b/fxprof-processed-profile/src/thread.rs
@@ -15,7 +15,7 @@ use crate::sample_table::{NativeAllocationsTable, SampleTable, WeightType};
 use crate::stack_table::StackTable;
 use crate::string_table::{GlobalStringIndex, GlobalStringTable};
 use crate::thread_string_table::{ThreadInternalStringIndex, ThreadStringTable};
-use crate::{CategoryHandle, Marker, MarkerHandle, MarkerTiming, MarkerTypeHandle, Timestamp};
+use crate::{Marker, MarkerHandle, MarkerTiming, MarkerTypeHandle, Timestamp};
 
 /// A process. Can be created with [`Profile::add_process`](crate::Profile::add_process).
 #[derive(Debug, Clone, Copy, PartialOrd, Ord, PartialEq, Eq, Hash)]
@@ -169,7 +169,6 @@ impl Thread {
         schema: &InternalMarkerSchema,
         marker: T,
         timing: MarkerTiming,
-        category: CategoryHandle,
         global_string_table: &mut GlobalStringTable,
     ) -> MarkerHandle {
         self.markers.add_marker(
@@ -178,7 +177,6 @@ impl Thread {
             schema,
             marker,
             timing,
-            category,
             &mut self.string_table,
             global_string_table,
         )

--- a/fxprof-processed-profile/tests/integration_tests/main.rs
+++ b/fxprof-processed-profile/tests/integration_tests/main.rs
@@ -4,14 +4,14 @@ use std::time::Duration;
 use assert_json_diff::assert_json_eq;
 use debugid::DebugId;
 use fxprof_processed_profile::{
-    CategoryColor, CategoryHandle, CpuDelta, Frame, FrameFlags, FrameInfo, GraphColor, LibraryInfo,
-    MarkerFieldFlags, MarkerFieldFormat, MarkerGraphType, MarkerTiming, Profile,
+    Category, CategoryColor, CategoryHandle, CpuDelta, Frame, FrameFlags, FrameInfo, GraphColor,
+    LibraryInfo, MarkerFieldFlags, MarkerFieldFormat, MarkerGraphType, MarkerTiming, Profile,
     ReferenceTimestamp, SamplingInterval, StaticSchemaMarker, StaticSchemaMarkerField,
     StaticSchemaMarkerGraph, StringHandle, Symbol, SymbolTable, Timestamp, WeightType,
 };
 use serde_json::json;
 
-// TODO: Add tests for CategoryPairHandle, ProcessHandle, ThreadHandle
+// TODO: Add tests for SubcategoryHandle, ProcessHandle, ThreadHandle
 
 /// An example marker type with some text content.
 #[derive(Debug, Clone)]
@@ -192,7 +192,7 @@ fn profile_without_js() {
         0x000055ba9f07e000,
         (0x000055ba9ebf6000u64 - 0x000055ba9eb4d000u64) as u32,
     );
-    let category = profile.add_category("Regular", CategoryColor::Blue);
+    let category = profile.handle_for_category(Category("Regular", CategoryColor::Blue));
     let s1 = profile.handle_for_stack_frames(
         thread,
         vec![
@@ -216,7 +216,7 @@ fn profile_without_js() {
         })
         .map(|frame| FrameInfo {
             frame,
-            category_pair: category.into(),
+            subcategory: category.into(),
             flags: FrameFlags::empty(),
         }),
     );
@@ -250,7 +250,7 @@ fn profile_without_js() {
         })
         .map(|frame| FrameInfo {
             frame,
-            category_pair: category.into(),
+            subcategory: category.into(),
             flags: FrameFlags::empty(),
         }),
     );
@@ -284,7 +284,7 @@ fn profile_without_js() {
         })
         .map(|frame| FrameInfo {
             frame,
-            category_pair: category.into(),
+            subcategory: category.into(),
             flags: FrameFlags::empty(),
         }),
     );
@@ -999,19 +999,19 @@ fn profile_with_js() {
     );
 
     let some_label_string = profile.handle_for_string("Some label string");
-    let category = profile.add_category("Cycle Collection", CategoryColor::Orange);
-    let category_pair = profile.add_subcategory(category, "Graph Reduction");
+    let category = profile.handle_for_category(Category("Cycle Collection", CategoryColor::Orange));
+    let subcategory = profile.handle_for_subcategory(category, "Graph Reduction");
     let s1 = profile.handle_for_stack_frames(
         thread,
         vec![
             FrameInfo {
                 frame: Frame::Label(some_label_string),
-                category_pair: category.into(),
+                subcategory: category.into(),
                 flags: FrameFlags::IS_JS,
             },
             FrameInfo {
                 frame: Frame::ReturnAddress(0x7f76b7ffc0e7),
-                category_pair,
+                subcategory,
                 flags: FrameFlags::empty(),
             },
         ]

--- a/fxprof-processed-profile/tests/integration_tests/main.rs
+++ b/fxprof-processed-profile/tests/integration_tests/main.rs
@@ -97,7 +97,7 @@ fn profile_without_js() {
         }];
 
         fn name(&self, profile: &mut Profile) -> StringHandle {
-            profile.intern_string("CustomName")
+            profile.handle_for_string("CustomName")
         }
 
         fn category(&self, _profile: &mut Profile) -> CategoryHandle {
@@ -193,7 +193,7 @@ fn profile_without_js() {
         (0x000055ba9ebf6000u64 - 0x000055ba9eb4d000u64) as u32,
     );
     let category = profile.add_category("Regular", CategoryColor::Blue);
-    let s1 = profile.intern_stack_frames(
+    let s1 = profile.handle_for_stack_frames(
         thread,
         vec![
             0x7f76b7ffc0e7,
@@ -227,7 +227,7 @@ fn profile_without_js() {
         CpuDelta::ZERO,
         1,
     );
-    let s2 = profile.intern_stack_frames(
+    let s2 = profile.handle_for_stack_frames(
         thread,
         vec![
             0x55ba9eda018e,
@@ -261,7 +261,7 @@ fn profile_without_js() {
         CpuDelta::ZERO,
         1,
     );
-    let s3 = profile.intern_stack_frames(
+    let s3 = profile.handle_for_stack_frames(
         thread,
         vec![
             0x7f76b7f019c6,
@@ -297,8 +297,8 @@ fn profile_without_js() {
     );
 
     let text_marker = TextMarker {
-        name: profile.intern_string("Experimental"),
-        text: profile.intern_string("Hello world!"),
+        name: profile.handle_for_string("Experimental"),
+        text: profile.handle_for_string("Hello world!"),
     };
     profile.add_marker(
         thread,
@@ -306,9 +306,9 @@ fn profile_without_js() {
         text_marker,
     );
     let custom_marker = CustomMarker {
-        event_name: profile.intern_string("My event"),
+        event_name: profile.handle_for_string("My event"),
         allocation_size: 512000,
-        url: profile.intern_string("https://mozilla.org/"),
+        url: profile.handle_for_string("https://mozilla.org/"),
         latency: Duration::from_millis(123),
     };
     profile.add_marker(
@@ -998,10 +998,10 @@ fn profile_with_js() {
         true,
     );
 
-    let some_label_string = profile.intern_string("Some label string");
+    let some_label_string = profile.handle_for_string("Some label string");
     let category = profile.add_category("Cycle Collection", CategoryColor::Orange);
     let category_pair = profile.add_subcategory(category, "Graph Reduction");
-    let s1 = profile.intern_stack_frames(
+    let s1 = profile.handle_for_stack_frames(
         thread,
         vec![
             FrameInfo {

--- a/fxprof-processed-profile/tests/integration_tests/main.rs
+++ b/fxprof-processed-profile/tests/integration_tests/main.rs
@@ -4,8 +4,8 @@ use std::time::Duration;
 use assert_json_diff::assert_json_eq;
 use debugid::DebugId;
 use fxprof_processed_profile::{
-    Category, CategoryColor, CategoryHandle, CpuDelta, Frame, FrameFlags, FrameInfo, GraphColor,
-    LibraryInfo, MarkerFieldFlags, MarkerFieldFormat, MarkerGraphType, MarkerTiming, Profile,
+    Category, CategoryColor, CpuDelta, Frame, FrameFlags, FrameInfo, GraphColor, LibraryInfo,
+    MarkerFieldFlags, MarkerFieldFormat, MarkerGraphType, MarkerTiming, Profile,
     ReferenceTimestamp, SamplingInterval, StaticSchemaMarker, StaticSchemaMarkerField,
     StaticSchemaMarkerGraph, StringHandle, Symbol, SymbolTable, Timestamp, WeightType,
 };
@@ -22,6 +22,7 @@ pub struct TextMarker {
 
 impl StaticSchemaMarker for TextMarker {
     const UNIQUE_MARKER_TYPE_NAME: &'static str = "Text";
+    const CATEGORY: Category<'static> = Category("Other", CategoryColor::Gray);
     const CHART_LABEL: Option<&'static str> = Some("{marker.data.name}");
     const TABLE_LABEL: Option<&'static str> = Some("{marker.name} - {marker.data.name}");
     const FIELDS: &'static [StaticSchemaMarkerField] = &[StaticSchemaMarkerField {
@@ -33,10 +34,6 @@ impl StaticSchemaMarker for TextMarker {
 
     fn name(&self, _profile: &mut Profile) -> StringHandle {
         self.name
-    }
-
-    fn category(&self, _profile: &mut Profile) -> CategoryHandle {
-        CategoryHandle::OTHER
     }
 
     fn string_field_value(&self, _field_index: u32) -> StringHandle {
@@ -58,6 +55,7 @@ fn profile_without_js() {
     }
     impl StaticSchemaMarker for CustomMarker {
         const UNIQUE_MARKER_TYPE_NAME: &'static str = "custom";
+        const CATEGORY: Category<'static> = Category("Other", CategoryColor::Gray);
         const TOOLTIP_LABEL: Option<&'static str> = Some("Custom tooltip label");
 
         const FIELDS: &'static [StaticSchemaMarkerField] = &[
@@ -98,10 +96,6 @@ fn profile_without_js() {
 
         fn name(&self, profile: &mut Profile) -> StringHandle {
             profile.handle_for_string("CustomName")
-        }
-
-        fn category(&self, _profile: &mut Profile) -> CategoryHandle {
-            CategoryHandle::OTHER
         }
 
         fn string_field_value(&self, field_index: u32) -> StringHandle {

--- a/gecko_profile/src/lib.rs
+++ b/gecko_profile/src/lib.rs
@@ -31,7 +31,7 @@ pub struct StringIndex(u32);
 pub enum Frame {
     /// An instruction pointer address / return address
     Address(u64),
-    /// A string, containing an index returned by ThreadBuilder::intern_string
+    /// A string, containing an index returned by ThreadBuilder::handle_for_string
     Label(StringIndex),
 }
 
@@ -280,7 +280,7 @@ impl ThreadBuilder {
         self.index
     }
 
-    pub fn intern_string(&mut self, s: &str) -> StringIndex {
+    pub fn handle_for_string(&mut self, s: &str) -> StringIndex {
         self.string_table.index_for_string(s)
     }
 

--- a/samply/src/linux_shared/converter.rs
+++ b/samply/src/linux_shared/converter.rs
@@ -573,7 +573,7 @@ where
             RssStatMember::AnonymousSwapEntries => "RSS Stat SHMEMPAGES",
             RssStatMember::ResidentSharedMemoryPages => "RSS Stat SWAPENTS",
         };
-        let name = self.profile.intern_string(name);
+        let name = self.profile.handle_for_string(name);
         let marker_handle = self.profile.add_marker(
             thread_handle,
             timing,
@@ -629,7 +629,7 @@ where
         let unresolved_stack = self.unresolved_stacks.convert(stack.into_iter().rev());
         if let Some(name) = self.event_names.get(attr_index) {
             let timing = MarkerTiming::Instant(timestamp);
-            let name = self.profile.intern_string(name);
+            let name = self.profile.handle_for_string(name);
             let marker_handle =
                 self.profile
                     .add_marker(thread_handle, timing, OtherEventMarker(name));
@@ -1735,7 +1735,7 @@ where
         let timestamp = self.timestamp_converter.convert_time(timestamp);
         let path = self
             .profile
-            .intern_string(&String::from_utf8_lossy(path_slice));
+            .handle_for_string(&String::from_utf8_lossy(path_slice));
         self.profile.add_marker(
             thread.profile_thread,
             MarkerTiming::Instant(timestamp),
@@ -1911,7 +1911,7 @@ impl StaticSchemaMarker for MmapMarker {
     }];
 
     fn name(&self, profile: &mut Profile) -> StringHandle {
-        profile.intern_string("mmap")
+        profile.handle_for_string("mmap")
     }
 
     fn category(&self, _profile: &mut Profile) -> CategoryHandle {

--- a/samply/src/linux_shared/converter.rs
+++ b/samply/src/linux_shared/converter.rs
@@ -7,10 +7,10 @@ use byteorder::LittleEndian;
 use debugid::DebugId;
 use framehop::{ExplicitModuleSectionInfo, FrameAddress, Module, Unwinder};
 use fxprof_processed_profile::{
-    CategoryColor, CategoryHandle, CategoryPairHandle, CpuDelta, LibraryHandle, LibraryInfo,
+    Category, CategoryColor, CategoryHandle, CpuDelta, LibraryHandle, LibraryInfo,
     MarkerFieldFlags, MarkerFieldFormat, MarkerTiming, Profile, ReferenceTimestamp,
-    SamplingInterval, StaticSchemaMarker, StaticSchemaMarkerField, StringHandle, SymbolTable,
-    ThreadHandle,
+    SamplingInterval, StaticSchemaMarker, StaticSchemaMarkerField, StringHandle, SubcategoryHandle,
+    SymbolTable, ThreadHandle,
 };
 use linux_perf_data::linux_perf_event_reader::TaskWasPreempted;
 use linux_perf_data::simpleperf_dso_type::{DSO_DEX_FILE, DSO_KERNEL, DSO_KERNEL_MODULE};
@@ -159,8 +159,8 @@ where
         let mut simpleperf_symbol_tables_jit = HashMap::new();
         let mut simpleperf_symbol_tables_kernel_image = None;
         let mut simpleperf_symbol_tables_kernel_modules = HashMap::new();
-        let simpleperf_jit_category: CategoryPairHandle = profile
-            .add_category("JIT app cache", CategoryColor::Green)
+        let simpleperf_jit_category: SubcategoryHandle = profile
+            .handle_for_category(Category("JIT app cache", CategoryColor::Green))
             .into();
         let allow_jit_function_recycling = profile_creation_props.reuse_threads;
         let simpleperf_jit_app_cache_library = SyntheticJitLibrary::new(
@@ -170,10 +170,12 @@ where
             allow_jit_function_recycling,
         );
         if let Some(simpleperf_symbol_tables) = simpleperf_symbol_tables {
-            let dex_category: CategoryPairHandle =
-                profile.add_category("DEX", CategoryColor::Green).into();
-            let oat_category: CategoryPairHandle =
-                profile.add_category("OAT", CategoryColor::Green).into();
+            let dex_category: SubcategoryHandle = profile
+                .handle_for_category(Category("DEX", CategoryColor::Green))
+                .into();
+            let oat_category: SubcategoryHandle = profile
+                .handle_for_category(Category("OAT", CategoryColor::Green))
+                .into();
             for f in simpleperf_symbol_tables {
                 if f.r#type == DSO_KERNEL {
                     simpleperf_symbol_tables_kernel_image = Some(f.symbol);
@@ -1876,7 +1878,7 @@ struct SymbolTableFromSimpleperf {
     min_vaddr: u64,
     file_offset_of_min_vaddr_in_elf_file: Option<u64>,
     symbol_table: Arc<SymbolTable>,
-    category: Option<CategoryPairHandle>,
+    category: Option<SubcategoryHandle>,
     art_info: Option<AndroidArtInfo>,
 }
 

--- a/samply/src/linux_shared/converter.rs
+++ b/samply/src/linux_shared/converter.rs
@@ -7,10 +7,10 @@ use byteorder::LittleEndian;
 use debugid::DebugId;
 use framehop::{ExplicitModuleSectionInfo, FrameAddress, Module, Unwinder};
 use fxprof_processed_profile::{
-    Category, CategoryColor, CategoryHandle, CpuDelta, LibraryHandle, LibraryInfo,
-    MarkerFieldFlags, MarkerFieldFormat, MarkerTiming, Profile, ReferenceTimestamp,
-    SamplingInterval, StaticSchemaMarker, StaticSchemaMarkerField, StringHandle, SubcategoryHandle,
-    SymbolTable, ThreadHandle,
+    Category, CategoryColor, CpuDelta, LibraryHandle, LibraryInfo, MarkerFieldFlags,
+    MarkerFieldFormat, MarkerTiming, Profile, ReferenceTimestamp, SamplingInterval,
+    StaticSchemaMarker, StaticSchemaMarkerField, StringHandle, SubcategoryHandle, SymbolTable,
+    ThreadHandle,
 };
 use linux_perf_data::linux_perf_event_reader::TaskWasPreempted;
 use linux_perf_data::simpleperf_dso_type::{DSO_DEX_FILE, DSO_KERNEL, DSO_KERNEL_MODULE};
@@ -1905,6 +1905,8 @@ struct MmapMarker(StringHandle);
 impl StaticSchemaMarker for MmapMarker {
     const UNIQUE_MARKER_TYPE_NAME: &'static str = "mmap";
 
+    const CATEGORY: Category<'static> = Category("Other", CategoryColor::Gray);
+
     const FIELDS: &'static [StaticSchemaMarkerField] = &[StaticSchemaMarkerField {
         key: "name",
         label: "Details",
@@ -1914,10 +1916,6 @@ impl StaticSchemaMarker for MmapMarker {
 
     fn name(&self, profile: &mut Profile) -> StringHandle {
         profile.handle_for_string("mmap")
-    }
-
-    fn category(&self, _profile: &mut Profile) -> CategoryHandle {
-        CategoryHandle::OTHER
     }
 
     fn string_field_value(&self, _field_index: u32) -> StringHandle {

--- a/samply/src/linux_shared/process.rs
+++ b/samply/src/linux_shared/process.rs
@@ -304,8 +304,8 @@ where
             let main_thread = self.threads.main_thread.profile_thread;
             let timing = MarkerTiming::Instant(profile_timestamp);
             let name = match symbol_name {
-                Some(name) => profile.intern_string(name),
-                None => profile.intern_string("<unknown>"),
+                Some(name) => profile.handle_for_string(name),
+                None => profile.handle_for_string("<unknown>"),
             };
             profile.add_marker(main_thread, timing, JitFunctionAddMarker(name));
         }

--- a/samply/src/linux_shared/process_threads.rs
+++ b/samply/src/linux_shared/process_threads.rs
@@ -214,7 +214,7 @@ pub fn make_thread_label_frame(
         Some(name) => format!("{name} (pid: {pid}, tid: {tid})"),
         None => format!("Thread {tid} (pid: {pid}, tid: {tid})"),
     };
-    let thread_label = profile.intern_string(&s);
+    let thread_label = profile.handle_for_string(&s);
     FrameInfo {
         frame: Frame::Label(thread_label),
         category_pair: CategoryHandle::OTHER.into(),

--- a/samply/src/linux_shared/process_threads.rs
+++ b/samply/src/linux_shared/process_threads.rs
@@ -217,7 +217,7 @@ pub fn make_thread_label_frame(
     let thread_label = profile.handle_for_string(&s);
     FrameInfo {
         frame: Frame::Label(thread_label),
-        category_pair: CategoryHandle::OTHER.into(),
+        subcategory: CategoryHandle::OTHER.into(),
         flags: FrameFlags::empty(),
     }
 }

--- a/samply/src/linux_shared/processes.rs
+++ b/samply/src/linux_shared/processes.rs
@@ -2,7 +2,7 @@ use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 
 use framehop::Unwinder;
-use fxprof_processed_profile::{CategoryColor, Profile, Timestamp};
+use fxprof_processed_profile::{Category, CategoryColor, Profile, Timestamp};
 
 use super::process::Process;
 use super::process_threads::make_thread_label_frame;
@@ -253,8 +253,12 @@ where
             }
         }
 
-        let user_category = profile.add_category("User", CategoryColor::Yellow).into();
-        let kernel_category = profile.add_category("Kernel", CategoryColor::Orange).into();
+        let user_category = profile
+            .handle_for_category(Category("User", CategoryColor::Yellow))
+            .into();
+        let kernel_category = profile
+            .handle_for_category(Category("Kernel", CategoryColor::Orange))
+            .into();
         let mut stack_frame_scratch_buf = Vec::new();
         for process_sample_data in self.process_sample_datas {
             process_sample_data.flush_samples_to_profile(

--- a/samply/src/mac/sampler.rs
+++ b/samply/src/mac/sampler.rs
@@ -4,7 +4,9 @@ use std::time::{Duration, SystemTime};
 use std::{mem, thread};
 
 use crossbeam_channel::Receiver;
-use fxprof_processed_profile::{CategoryColor, CategoryPairHandle, Profile, ReferenceTimestamp};
+use fxprof_processed_profile::{
+    Category, CategoryColor, Profile, ReferenceTimestamp, SubcategoryHandle,
+};
 use mach2::port::mach_port_t;
 
 use super::error::SamplingError;
@@ -76,8 +78,9 @@ impl Sampler {
         let mut jit_category_manager =
             crate::shared::jit_category_manager::JitCategoryManager::new();
 
-        let default_category =
-            CategoryPairHandle::from(profile.add_category("User", CategoryColor::Yellow));
+        let default_category = SubcategoryHandle::from(
+            profile.handle_for_category(Category("User", CategoryColor::Yellow)),
+        );
 
         let root_task_init = match self.task_receiver.recv() {
             Ok(TaskInitOrShutdown::TaskInit(task_init)) => task_init,

--- a/samply/src/mac/task_profiler.rs
+++ b/samply/src/mac/task_profiler.rs
@@ -809,7 +809,7 @@ fn make_thread_label_frame(
         Some(name) => format!("{name} (pid: {pid}, tid: {tid})"),
         None => format!("Thread {tid} (pid: {pid}, tid: {tid})"),
     };
-    let thread_label = profile.intern_string(&s);
+    let thread_label = profile.handle_for_string(&s);
     FrameInfo {
         frame: Frame::Label(thread_label),
         category_pair: CategoryHandle::OTHER.into(),

--- a/samply/src/mac/task_profiler.rs
+++ b/samply/src/mac/task_profiler.rs
@@ -812,7 +812,7 @@ fn make_thread_label_frame(
     let thread_label = profile.handle_for_string(&s);
     FrameInfo {
         frame: Frame::Label(thread_label),
-        category_pair: CategoryHandle::OTHER.into(),
+        subcategory: CategoryHandle::OTHER.into(),
         flags: FrameFlags::empty(),
     }
 }

--- a/samply/src/shared/jit_function_add_marker.rs
+++ b/samply/src/shared/jit_function_add_marker.rs
@@ -1,5 +1,5 @@
 use fxprof_processed_profile::{
-    CategoryHandle, MarkerFieldFlags, MarkerFieldFormat, Profile, StaticSchemaMarker,
+    Category, CategoryColor, MarkerFieldFlags, MarkerFieldFormat, Profile, StaticSchemaMarker,
     StaticSchemaMarkerField, StringHandle,
 };
 
@@ -9,6 +9,7 @@ pub struct JitFunctionAddMarker(pub StringHandle);
 impl StaticSchemaMarker for JitFunctionAddMarker {
     const UNIQUE_MARKER_TYPE_NAME: &'static str = "JitFunctionAdd";
 
+    const CATEGORY: Category<'static> = Category("Other", CategoryColor::Gray);
     const DESCRIPTION: Option<&'static str> =
         Some("Emitted when a JIT function is added to the process.");
 
@@ -25,10 +26,6 @@ impl StaticSchemaMarker for JitFunctionAddMarker {
 
     fn name(&self, profile: &mut Profile) -> StringHandle {
         profile.handle_for_string("JitFunctionAdd")
-    }
-
-    fn category(&self, _profile: &mut Profile) -> CategoryHandle {
-        CategoryHandle::OTHER
     }
 
     fn string_field_value(&self, _field_index: u32) -> StringHandle {

--- a/samply/src/shared/jit_function_add_marker.rs
+++ b/samply/src/shared/jit_function_add_marker.rs
@@ -24,7 +24,7 @@ impl StaticSchemaMarker for JitFunctionAddMarker {
     }];
 
     fn name(&self, profile: &mut Profile) -> StringHandle {
-        profile.intern_string("JitFunctionAdd")
+        profile.handle_for_string("JitFunctionAdd")
     }
 
     fn category(&self, _profile: &mut Profile) -> CategoryHandle {

--- a/samply/src/shared/jitdump_manager.rs
+++ b/samply/src/shared/jitdump_manager.rs
@@ -193,7 +193,7 @@ impl SingleJitDumpProcessor {
                     if should_add_marker {
                         let timestamp =
                             timestamp_converter.convert_time(raw_jitdump_record.timestamp);
-                        let symbol_name_handle = profile.intern_string(symbol_name);
+                        let symbol_name_handle = profile.handle_for_string(symbol_name);
                         profile.add_marker(
                             self.thread_handle,
                             MarkerTiming::Instant(timestamp),

--- a/samply/src/shared/lib_mappings.rs
+++ b/samply/src/shared/lib_mappings.rs
@@ -1,13 +1,13 @@
 use std::iter::Peekable;
 
-use fxprof_processed_profile::{CategoryPairHandle, LibMappings, LibraryHandle};
+use fxprof_processed_profile::{LibMappings, LibraryHandle, SubcategoryHandle};
 
 use super::jit_category_manager::JsFrame;
 
 #[derive(Debug, Clone)]
 pub struct LibMappingInfo {
     pub lib_handle: LibraryHandle,
-    pub category: Option<CategoryPairHandle>,
+    pub category: Option<SubcategoryHandle>,
     pub js_frame: Option<JsFrame>,
     pub art_info: Option<AndroidArtInfo>,
 }
@@ -33,7 +33,7 @@ impl LibMappingInfo {
     }
 
     #[allow(unused)]
-    pub fn new_lib_with_category(lib_handle: LibraryHandle, category: CategoryPairHandle) -> Self {
+    pub fn new_lib_with_category(lib_handle: LibraryHandle, category: SubcategoryHandle) -> Self {
         Self {
             lib_handle,
             category: Some(category),
@@ -44,7 +44,7 @@ impl LibMappingInfo {
 
     pub fn new_jit_function(
         lib_handle: LibraryHandle,
-        category: CategoryPairHandle,
+        category: SubcategoryHandle,
         js_frame: Option<JsFrame>,
     ) -> Self {
         Self {
@@ -66,7 +66,7 @@ impl LibMappingInfo {
 
     pub fn new_java_mapping(
         lib_handle: LibraryHandle,
-        category: Option<CategoryPairHandle>,
+        category: Option<SubcategoryHandle>,
     ) -> Self {
         Self {
             lib_handle,

--- a/samply/src/shared/per_cpu.rs
+++ b/samply/src/shared/per_cpu.rs
@@ -83,8 +83,8 @@ impl Cpu {
                 );
             }
             let switch_out_reason = match preempted {
-                true => profile.intern_string("preempted"),
-                false => profile.intern_string("blocked"),
+                true => profile.handle_for_string("preempted"),
+                false => profile.handle_for_string("blocked"),
             };
             profile.add_marker(
                 thread_handle,
@@ -114,7 +114,7 @@ impl Cpus {
     pub fn new(start_time: Timestamp, profile: &mut Profile) -> Self {
         let process_handle = profile.add_process("CPU", 0, start_time);
         let combined_thread_handle = profile.add_thread(process_handle, 0, start_time, true);
-        let idle_string = profile.intern_string("<Idle>");
+        let idle_string = profile.handle_for_string("<Idle>");
         let idle_frame_label = FrameInfo {
             frame: Frame::Label(idle_string),
             category_pair: CategoryHandle::OTHER.into(),
@@ -144,7 +144,7 @@ impl Cpus {
             let name = format!("CPU {i}");
             profile.set_thread_name(thread, &name);
             self.cpus
-                .push(Cpu::new(profile.intern_string(&name), thread));
+                .push(Cpu::new(profile.handle_for_string(&name), thread));
         }
         &mut self.cpus[cpu]
     }
@@ -216,7 +216,7 @@ impl StaticSchemaMarker for OnCpuMarkerForThreadTrack {
     ];
 
     fn name(&self, profile: &mut Profile) -> StringHandle {
-        profile.intern_string("Running on CPU")
+        profile.handle_for_string("Running on CPU")
     }
 
     fn category(&self, _profile: &mut Profile) -> CategoryHandle {

--- a/samply/src/shared/per_cpu.rs
+++ b/samply/src/shared/per_cpu.rs
@@ -117,7 +117,7 @@ impl Cpus {
         let idle_string = profile.handle_for_string("<Idle>");
         let idle_frame_label = FrameInfo {
             frame: Frame::Label(idle_string),
-            category_pair: CategoryHandle::OTHER.into(),
+            subcategory: CategoryHandle::OTHER.into(),
             flags: FrameFlags::empty(),
         };
         Self {

--- a/samply/src/shared/per_cpu.rs
+++ b/samply/src/shared/per_cpu.rs
@@ -1,7 +1,7 @@
 use fxprof_processed_profile::{
-    CategoryHandle, Frame, FrameFlags, FrameInfo, MarkerFieldFlags, MarkerFieldFormat,
-    MarkerTiming, ProcessHandle, Profile, StaticSchemaMarker, StaticSchemaMarkerField,
-    StringHandle, ThreadHandle, Timestamp,
+    Category, CategoryColor, CategoryHandle, Frame, FrameFlags, FrameInfo, MarkerFieldFlags,
+    MarkerFieldFormat, MarkerTiming, ProcessHandle, Profile, StaticSchemaMarker,
+    StaticSchemaMarkerField, StringHandle, ThreadHandle, Timestamp,
 };
 
 use crate::shared::context_switch::ThreadContextSwitchData;
@@ -157,6 +157,8 @@ pub struct ThreadNameMarkerForCpuTrack(pub StringHandle, pub StringHandle);
 impl StaticSchemaMarker for ThreadNameMarkerForCpuTrack {
     const UNIQUE_MARKER_TYPE_NAME: &'static str = "ContextSwitch";
 
+    const CATEGORY: Category<'static> = Category("Other", CategoryColor::Gray);
+
     const CHART_LABEL: Option<&'static str> = Some("{marker.data.thread}");
     const TOOLTIP_LABEL: Option<&'static str> = Some("{marker.data.thread}");
     const TABLE_LABEL: Option<&'static str> = Some("{marker.name} - {marker.data.thread}");
@@ -170,10 +172,6 @@ impl StaticSchemaMarker for ThreadNameMarkerForCpuTrack {
 
     fn name(&self, _profile: &mut Profile) -> StringHandle {
         self.0
-    }
-
-    fn category(&self, _profile: &mut Profile) -> CategoryHandle {
-        CategoryHandle::OTHER
     }
 
     fn string_field_value(&self, _field_index: u32) -> StringHandle {
@@ -194,6 +192,8 @@ pub struct OnCpuMarkerForThreadTrack {
 
 impl StaticSchemaMarker for OnCpuMarkerForThreadTrack {
     const UNIQUE_MARKER_TYPE_NAME: &'static str = "OnCpu";
+
+    const CATEGORY: Category<'static> = Category("Other", CategoryColor::Gray);
 
     const CHART_LABEL: Option<&'static str> = Some("{marker.data.cpu}");
     const TOOLTIP_LABEL: Option<&'static str> = Some("{marker.data.cpu}");
@@ -217,10 +217,6 @@ impl StaticSchemaMarker for OnCpuMarkerForThreadTrack {
 
     fn name(&self, profile: &mut Profile) -> StringHandle {
         profile.handle_for_string("Running on CPU")
-    }
-
-    fn category(&self, _profile: &mut Profile) -> CategoryHandle {
-        CategoryHandle::OTHER
     }
 
     fn string_field_value(&self, field_index: u32) -> StringHandle {

--- a/samply/src/shared/process_sample_data.rs
+++ b/samply/src/shared/process_sample_data.rs
@@ -1,7 +1,7 @@
 use fxprof_processed_profile::{
-    CategoryHandle, LibMappings, MarkerFieldFlags, MarkerFieldFormat, MarkerTiming, Profile,
-    StaticSchemaMarker, StaticSchemaMarkerField, StringHandle, SubcategoryHandle, ThreadHandle,
-    Timestamp,
+    Category, CategoryColor, LibMappings, MarkerFieldFlags, MarkerFieldFormat, MarkerTiming,
+    Profile, StaticSchemaMarker, StaticSchemaMarkerField, StringHandle, SubcategoryHandle,
+    ThreadHandle, Timestamp,
 };
 
 use super::lib_mappings::{LibMappingInfo, LibMappingOpQueue, LibMappingsHierarchy};
@@ -144,6 +144,8 @@ impl RssStatMarker {
 impl StaticSchemaMarker for RssStatMarker {
     const UNIQUE_MARKER_TYPE_NAME: &'static str = "RSS Anon";
 
+    const CATEGORY: Category<'static> = Category("Other", CategoryColor::Gray);
+
     const CHART_LABEL: Option<&'static str> = Some("{marker.data.totalBytes}");
     const TOOLTIP_LABEL: Option<&'static str> = Some("{marker.data.totalBytes}");
     const TABLE_LABEL: Option<&'static str> =
@@ -171,10 +173,6 @@ impl StaticSchemaMarker for RssStatMarker {
         self.name
     }
 
-    fn category(&self, _profile: &mut Profile) -> CategoryHandle {
-        CategoryHandle::OTHER
-    }
-
     fn string_field_value(&self, _field_index: u32) -> StringHandle {
         unreachable!()
     }
@@ -194,6 +192,8 @@ pub struct OtherEventMarker(pub StringHandle);
 impl StaticSchemaMarker for OtherEventMarker {
     const UNIQUE_MARKER_TYPE_NAME: &'static str = "Other event";
 
+    const CATEGORY: Category<'static> = Category("Other", CategoryColor::Gray);
+
     const DESCRIPTION: Option<&'static str> =
         Some("Emitted for any records in a perf.data file which don't map to a known event.");
 
@@ -201,10 +201,6 @@ impl StaticSchemaMarker for OtherEventMarker {
 
     fn name(&self, _profile: &mut Profile) -> StringHandle {
         self.0
-    }
-
-    fn category(&self, _profile: &mut Profile) -> CategoryHandle {
-        CategoryHandle::OTHER
     }
 
     fn string_field_value(&self, _field_index: u32) -> StringHandle {
@@ -221,6 +217,8 @@ pub struct UserTimingMarker(pub StringHandle);
 
 impl StaticSchemaMarker for UserTimingMarker {
     const UNIQUE_MARKER_TYPE_NAME: &'static str = "UserTiming";
+
+    const CATEGORY: Category<'static> = Category("Other", CategoryColor::Gray);
 
     const DESCRIPTION: Option<&'static str> =
         Some("Emitted for performance.mark and performance.measure.");
@@ -240,10 +238,6 @@ impl StaticSchemaMarker for UserTimingMarker {
         profile.handle_for_string("UserTiming")
     }
 
-    fn category(&self, _profile: &mut Profile) -> CategoryHandle {
-        CategoryHandle::OTHER
-    }
-
     fn string_field_value(&self, _field_index: u32) -> StringHandle {
         self.0
     }
@@ -258,6 +252,8 @@ pub struct SchedSwitchMarkerOnCpuTrack;
 impl StaticSchemaMarker for SchedSwitchMarkerOnCpuTrack {
     const UNIQUE_MARKER_TYPE_NAME: &'static str = "sched_switch";
 
+    const CATEGORY: Category<'static> = Category("Other", CategoryColor::Gray);
+
     const DESCRIPTION: Option<&'static str> =
         Some("Emitted just before a running thread gets moved off-cpu.");
 
@@ -265,10 +261,6 @@ impl StaticSchemaMarker for SchedSwitchMarkerOnCpuTrack {
 
     fn name(&self, profile: &mut Profile) -> StringHandle {
         profile.handle_for_string("sched_switch")
-    }
-
-    fn category(&self, _profile: &mut Profile) -> CategoryHandle {
-        CategoryHandle::OTHER
     }
 
     fn string_field_value(&self, _field_index: u32) -> StringHandle {
@@ -288,6 +280,8 @@ pub struct SchedSwitchMarkerOnThreadTrack {
 impl StaticSchemaMarker for SchedSwitchMarkerOnThreadTrack {
     const UNIQUE_MARKER_TYPE_NAME: &'static str = "sched_switch";
 
+    const CATEGORY: Category<'static> = Category("Other", CategoryColor::Gray);
+
     const DESCRIPTION: Option<&'static str> =
         Some("Emitted just before a running thread gets moved off-cpu.");
 
@@ -300,10 +294,6 @@ impl StaticSchemaMarker for SchedSwitchMarkerOnThreadTrack {
 
     fn name(&self, profile: &mut Profile) -> StringHandle {
         profile.handle_for_string("sched_switch")
-    }
-
-    fn category(&self, _profile: &mut Profile) -> CategoryHandle {
-        CategoryHandle::OTHER
     }
 
     fn string_field_value(&self, _field_index: u32) -> StringHandle {
@@ -321,6 +311,8 @@ pub struct SimpleMarker(pub StringHandle);
 impl StaticSchemaMarker for SimpleMarker {
     const UNIQUE_MARKER_TYPE_NAME: &'static str = "SimpleMarker";
 
+    const CATEGORY: Category<'static> = Category("Other", CategoryColor::Gray);
+
     const DESCRIPTION: Option<&'static str> =
         Some("Emitted for marker spans in a markers text file.");
 
@@ -337,10 +329,6 @@ impl StaticSchemaMarker for SimpleMarker {
 
     fn name(&self, profile: &mut Profile) -> StringHandle {
         profile.handle_for_string("SimpleMarker")
-    }
-
-    fn category(&self, _profile: &mut Profile) -> CategoryHandle {
-        CategoryHandle::OTHER
     }
 
     fn string_field_value(&self, _field_index: u32) -> StringHandle {

--- a/samply/src/shared/process_sample_data.rs
+++ b/samply/src/shared/process_sample_data.rs
@@ -102,7 +102,7 @@ impl ProcessSampleData {
                 extra_label_frame,
             );
             let frames = StackDepthLimitingFrameIter::new(profile, frames, user_category);
-            let stack_handle = profile.intern_stack_frames(thread_handle, frames);
+            let stack_handle = profile.handle_for_stack_frames(thread_handle, frames);
             match sample_or_marker {
                 SampleOrMarker::Sample(SampleData { cpu_delta, weight }) => {
                     profile.add_sample(thread_handle, timestamp, stack_handle, cpu_delta, weight);
@@ -114,7 +114,7 @@ impl ProcessSampleData {
         }
 
         for marker in marker_spans {
-            let marker_name_string_index = profile.intern_string(&marker.name);
+            let marker_name_string_index = profile.handle_for_string(&marker.name);
             profile.add_marker(
                 marker.thread_handle,
                 MarkerTiming::Interval(marker.start_time, marker.end_time),
@@ -237,7 +237,7 @@ impl StaticSchemaMarker for UserTimingMarker {
     }];
 
     fn name(&self, profile: &mut Profile) -> StringHandle {
-        profile.intern_string("UserTiming")
+        profile.handle_for_string("UserTiming")
     }
 
     fn category(&self, _profile: &mut Profile) -> CategoryHandle {
@@ -264,7 +264,7 @@ impl StaticSchemaMarker for SchedSwitchMarkerOnCpuTrack {
     const FIELDS: &'static [StaticSchemaMarkerField] = &[];
 
     fn name(&self, profile: &mut Profile) -> StringHandle {
-        profile.intern_string("sched_switch")
+        profile.handle_for_string("sched_switch")
     }
 
     fn category(&self, _profile: &mut Profile) -> CategoryHandle {
@@ -299,7 +299,7 @@ impl StaticSchemaMarker for SchedSwitchMarkerOnThreadTrack {
     }];
 
     fn name(&self, profile: &mut Profile) -> StringHandle {
-        profile.intern_string("sched_switch")
+        profile.handle_for_string("sched_switch")
     }
 
     fn category(&self, _profile: &mut Profile) -> CategoryHandle {
@@ -336,7 +336,7 @@ impl StaticSchemaMarker for SimpleMarker {
     }];
 
     fn name(&self, profile: &mut Profile) -> StringHandle {
-        profile.intern_string("SimpleMarker")
+        profile.handle_for_string("SimpleMarker")
     }
 
     fn category(&self, _profile: &mut Profile) -> CategoryHandle {

--- a/samply/src/shared/process_sample_data.rs
+++ b/samply/src/shared/process_sample_data.rs
@@ -1,6 +1,6 @@
 use fxprof_processed_profile::{
-    CategoryHandle, CategoryPairHandle, LibMappings, MarkerFieldFlags, MarkerFieldFormat,
-    MarkerTiming, Profile, StaticSchemaMarker, StaticSchemaMarkerField, StringHandle, ThreadHandle,
+    CategoryHandle, LibMappings, MarkerFieldFlags, MarkerFieldFormat, MarkerTiming, Profile,
+    StaticSchemaMarker, StaticSchemaMarkerField, StringHandle, SubcategoryHandle, ThreadHandle,
     Timestamp,
 };
 
@@ -62,8 +62,8 @@ impl ProcessSampleData {
     pub fn flush_samples_to_profile(
         self,
         profile: &mut Profile,
-        user_category: CategoryPairHandle,
-        kernel_category: CategoryPairHandle,
+        user_category: SubcategoryHandle,
+        kernel_category: SubcategoryHandle,
         stack_frame_scratch_buf: &mut Vec<StackFrame>,
         stacks: &UnresolvedStacks,
     ) {

--- a/samply/src/shared/stack_converter.rs
+++ b/samply/src/shared/stack_converter.rs
@@ -1,6 +1,6 @@
 use std::collections::VecDeque;
 
-use fxprof_processed_profile::{CategoryPairHandle, Frame, FrameFlags, FrameInfo};
+use fxprof_processed_profile::{Frame, FrameFlags, FrameInfo, SubcategoryHandle};
 
 use super::jit_category_manager::{JsFrame, JsName};
 use super::lib_mappings::{AndroidArtInfo, LibMappingsHierarchy};
@@ -8,8 +8,8 @@ use super::types::{StackFrame, StackMode};
 
 #[derive(Debug)]
 pub struct StackConverter {
-    user_category: CategoryPairHandle,
-    kernel_category: CategoryPairHandle,
+    user_category: SubcategoryHandle,
+    kernel_category: SubcategoryHandle,
     libart_frame_buffer: VecDeque<SecondPassFrameInfo>,
 }
 
@@ -22,7 +22,7 @@ struct FirstPassFrameInfo {
 #[derive(Debug)]
 struct SecondPassFrameInfo {
     location: Frame,
-    category: CategoryPairHandle,
+    category: SubcategoryHandle,
     js_frame: Option<JsFrame>,
     art_info: Option<AndroidArtInfo>,
 }
@@ -32,8 +32,8 @@ struct FirstPassIter<I: Iterator<Item = StackFrame>>(I);
 struct SecondPassIter<'a, I: Iterator<Item = FirstPassFrameInfo>> {
     inner: I,
     lib_mappings: &'a LibMappingsHierarchy,
-    user_category: CategoryPairHandle,
-    kernel_category: CategoryPairHandle,
+    user_category: SubcategoryHandle,
+    kernel_category: SubcategoryHandle,
 }
 
 struct LibartFilteringIter<'c, I: Iterator<Item = SecondPassFrameInfo>> {
@@ -204,7 +204,7 @@ impl<I: Iterator<Item = SecondPassFrameInfo>> Iterator for ConvertedStackIter<I>
 
         let mut frame_info = FrameInfo {
             frame: location,
-            category_pair: category,
+            subcategory: category,
             flags: FrameFlags::empty(),
         };
 
@@ -242,7 +242,7 @@ impl<I: Iterator<Item = SecondPassFrameInfo>> Iterator for ConvertedStackIter<I>
             // We don't treat Spidermonkey "self-hosted" functions as JS (e.g. filter/map/push).
             let prepended_js_frame = FrameInfo {
                 frame: Frame::Label(js_name),
-                category_pair: category,
+                subcategory: category,
                 flags: FrameFlags::IS_JS,
             };
             let buffered_frame = std::mem::replace(&mut frame_info, prepended_js_frame);
@@ -254,7 +254,7 @@ impl<I: Iterator<Item = SecondPassFrameInfo>> Iterator for ConvertedStackIter<I>
 }
 
 impl StackConverter {
-    pub fn new(user_category: CategoryPairHandle, kernel_category: CategoryPairHandle) -> Self {
+    pub fn new(user_category: SubcategoryHandle, kernel_category: SubcategoryHandle) -> Self {
         Self {
             user_category,
             kernel_category,

--- a/samply/src/shared/stack_depth_limiting_frame_iter.rs
+++ b/samply/src/shared/stack_depth_limiting_frame_iter.rs
@@ -1,5 +1,5 @@
 use fxprof_processed_profile::{
-    CategoryPairHandle, Frame, FrameFlags, FrameInfo, Profile, StringHandle,
+    Frame, FrameFlags, FrameInfo, Profile, StringHandle, SubcategoryHandle,
 };
 
 /// Returns `Some((start_index, count))` if part of the stack should be elided
@@ -36,7 +36,7 @@ fn test_should_elide_frames() {
 
 pub struct StackDepthLimitingFrameIter<I: Iterator<Item = FrameInfo>> {
     inner: I,
-    category: CategoryPairHandle,
+    category: SubcategoryHandle,
     state: StackDepthLimitingFrameIterState,
 }
 
@@ -57,7 +57,7 @@ enum StackDepthLimitingFrameIterState {
 }
 
 impl<I: Iterator<Item = FrameInfo>> StackDepthLimitingFrameIter<I> {
-    pub fn new(profile: &mut Profile, iter: I, category: CategoryPairHandle) -> Self {
+    pub fn new(profile: &mut Profile, iter: I, category: SubcategoryHandle) -> Self {
         // Check if part of the stack should be elided, to limit the stack depth.
         // Without such a limit, profiles with deep recursion may become too big
         // to be processed.
@@ -122,7 +122,7 @@ impl<I: Iterator<Item = FrameInfo>> Iterator for StackDepthLimitingFrameIter<I> 
                 };
                 return Some(FrameInfo {
                     frame,
-                    category_pair: self.category,
+                    subcategory: self.category,
                     flags: FrameFlags::empty(),
                 });
             }

--- a/samply/src/shared/stack_depth_limiting_frame_iter.rs
+++ b/samply/src/shared/stack_depth_limiting_frame_iter.rs
@@ -69,7 +69,7 @@ impl<I: Iterator<Item = FrameInfo>> StackDepthLimitingFrameIter<I> {
         {
             let first_frame_after_elision = first_elided_frame + elided_count;
             let elision_frame_string =
-                profile.intern_string(&format!("({elided_count} frames elided)"));
+                profile.handle_for_string(&format!("({elided_count} frames elided)"));
             StackDepthLimitingFrameIterState::BeforeElidedPiece {
                 index: 0,
                 first_elided_frame,

--- a/samply/src/shared/symbol_precog.rs
+++ b/samply/src/shared/symbol_precog.rs
@@ -40,11 +40,11 @@ impl StringTable {
             string_map: HashMap::new(),
             strings: Vec::new(),
         };
-        result.intern_string("UNKNOWN"); // always at index 0
+        result.handle_for_string("UNKNOWN"); // always at index 0
         result
     }
 
-    fn intern_string(&mut self, string: &str) -> StringTableIndex {
+    fn handle_for_string(&mut self, string: &str) -> StringTableIndex {
         let index = match self.string_map.get(string) {
             Some(&index) => index,
             None => {
@@ -100,11 +100,11 @@ impl InternedFrameDebugInfo {
         let function = frame
             .function
             .as_ref()
-            .map(|name| strtab.intern_string(name));
+            .map(|name| strtab.handle_for_string(name));
         let file = frame
             .file_path
             .as_ref()
-            .map(|name| strtab.intern_string(name.raw_path()));
+            .map(|name| strtab.handle_for_string(name.raw_path()));
         InternedFrameDebugInfo {
             function,
             file,
@@ -130,7 +130,7 @@ struct InternedSymbolInfo {
 
 impl InternedSymbolInfo {
     fn new(info: &wholesym::AddressInfo, strtab: &mut StringTable) -> InternedSymbolInfo {
-        let symbol = strtab.intern_string(&info.symbol.name);
+        let symbol = strtab.handle_for_string(&info.symbol.name);
         let frames = info.frames.as_ref().map(|frames| {
             frames
                 .iter()

--- a/samply/src/shared/synthetic_jit_library.rs
+++ b/samply/src/shared/synthetic_jit_library.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use debugid::DebugId;
 use fxprof_processed_profile::{
-    CategoryPairHandle, LibraryHandle, LibraryInfo, Profile, Symbol, SymbolTable,
+    LibraryHandle, LibraryInfo, Profile, SubcategoryHandle, Symbol, SymbolTable,
 };
 
 use super::types::FastHashMap;
@@ -10,7 +10,7 @@ use super::types::FastHashMap;
 #[derive(Debug)]
 pub struct SyntheticJitLibrary {
     lib_handle: LibraryHandle,
-    default_category: CategoryPairHandle,
+    default_category: SubcategoryHandle,
     next_relative_address: u32,
     symbols: Vec<Symbol>,
     recycler: Option<FastHashMap<(String, u32), u32>>,
@@ -19,7 +19,7 @@ pub struct SyntheticJitLibrary {
 impl SyntheticJitLibrary {
     pub fn new(
         name: String,
-        default_category: CategoryPairHandle,
+        default_category: SubcategoryHandle,
         profile: &mut Profile,
         allow_recycling: bool,
     ) -> Self {
@@ -79,7 +79,7 @@ impl SyntheticJitLibrary {
         self.lib_handle
     }
 
-    pub fn default_category(&self) -> CategoryPairHandle {
+    pub fn default_category(&self) -> SubcategoryHandle {
         self.default_category
     }
 

--- a/samply/src/windows/coreclr.rs
+++ b/samply/src/windows/coreclr.rs
@@ -241,7 +241,7 @@ impl StaticSchemaMarker for CoreClrGcAllocMarker {
     ];
 
     fn name(&self, profile: &mut Profile) -> StringHandle {
-        profile.intern_string("GC Alloc")
+        profile.handle_for_string("GC Alloc")
     }
 
     fn category(&self, _profile: &mut Profile) -> CategoryHandle {
@@ -558,7 +558,7 @@ pub fn handle_coreclr_event(
                     let total_size: u64 = parser.parse("TotalSizeForTypeSample");
 
                     let category = context.known_category(KnownCategory::CoreClrGc);
-                    let clr_type = context.intern_profile_string(&format!("0x{:x}", type_id));
+                    let clr_type = context.handle_for_profile_string(&format!("0x{:x}", type_id));
                     let mh = context.add_thread_instant_marker(
                         timestamp_raw,
                         tid,
@@ -579,8 +579,8 @@ pub fn handle_coreclr_event(
                     });
 
                     let category = context.known_category(KnownCategory::CoreClrGc);
-                    let name = context.intern_profile_string("GC Trigger");
-                    let description = context.intern_profile_string(&format!(
+                    let name = context.handle_for_profile_string("GC Trigger");
+                    let description = context.handle_for_profile_string(&format!(
                         "GC Trigger: {}",
                         DisplayUnknownIfNone(&reason)
                     ));
@@ -626,8 +626,8 @@ pub fn handle_coreclr_event(
 
                     if let Some(info) = coreclr_context.remove_gc_marker(tid, "GCSuspendEE") {
                         let category = context.known_category(KnownCategory::CoreClrGc);
-                        let name = context.intern_profile_string(&info.name);
-                        let description = context.intern_profile_string(&info.description);
+                        let name = context.handle_for_profile_string(&info.name);
+                        let description = context.handle_for_profile_string(&info.description);
                         context.add_thread_interval_marker(
                             info.start_timestamp_raw,
                             timestamp_raw,
@@ -682,8 +682,8 @@ pub fn handle_coreclr_event(
                     //let depth: u32 = parser.parse("Depth");
                     if let Some(info) = coreclr_context.remove_gc_marker(tid, "GC") {
                         let category = context.known_category(KnownCategory::CoreClrGc);
-                        let name = context.intern_profile_string(&info.name);
-                        let description = context.intern_profile_string(&info.description);
+                        let name = context.handle_for_profile_string(&info.name);
+                        let description = context.handle_for_profile_string(&info.description);
                         context.add_thread_interval_marker(
                             info.start_timestamp_raw,
                             timestamp_raw,
@@ -725,8 +725,8 @@ pub fn handle_coreclr_event(
 
     if !handled && coreclr_context.unknown_event_markers {
         let text = event_properties_to_string(s, parser, None);
-        let name = context.intern_profile_string(s.name().split_once('/').unwrap().1);
-        let description = context.intern_profile_string(&text);
+        let name = context.handle_for_profile_string(s.name().split_once('/').unwrap().1);
+        let description = context.handle_for_profile_string(&text);
         let marker_handle = context.add_thread_instant_marker(
             timestamp_raw,
             tid,

--- a/samply/src/windows/coreclr.rs
+++ b/samply/src/windows/coreclr.rs
@@ -9,11 +9,13 @@ use num_traits::FromPrimitive;
 
 use super::elevated_helper::ElevatedRecordingProps;
 use crate::shared::recording_props::{CoreClrProfileProps, ProfileCreationProps};
-use crate::windows::profile_context::{KnownCategory, ProfileContext};
+use crate::windows::profile_context::ProfileContext;
 
 use super::etw_reader::event_properties_to_string;
 use super::etw_reader::parser::{Parser, TryParse};
 use super::etw_reader::schema::TypedEvent;
+
+const CORE_CLR_GC_CATEGORY: Category<'static> = Category("CoreCLR GC", CategoryColor::Red);
 
 struct SavedMarkerInfo {
     start_timestamp_raw: u64,
@@ -208,11 +210,12 @@ impl Display for GcType {
 }
 // String is type name
 #[derive(Debug, Clone)]
-pub struct CoreClrGcAllocMarker(StringHandle, f64, CategoryHandle);
+pub struct CoreClrGcAllocMarker(StringHandle, f64);
 
 impl StaticSchemaMarker for CoreClrGcAllocMarker {
     const UNIQUE_MARKER_TYPE_NAME: &'static str = "GC Alloc";
 
+    const CATEGORY: Category<'static> = CORE_CLR_GC_CATEGORY;
     const DESCRIPTION: Option<&'static str> = Some("GC Allocation.");
 
     const LOCATIONS: MarkerLocations = MarkerLocations::MARKER_CHART
@@ -244,10 +247,6 @@ impl StaticSchemaMarker for CoreClrGcAllocMarker {
         profile.handle_for_string("GC Alloc")
     }
 
-    fn category(&self, _profile: &mut Profile) -> CategoryHandle {
-        self.2
-    }
-
     fn string_field_value(&self, _field_index: u32) -> StringHandle {
         self.0
     }
@@ -258,11 +257,12 @@ impl StaticSchemaMarker for CoreClrGcAllocMarker {
 }
 
 #[derive(Debug, Clone)]
-pub struct CoreClrGcEventMarker(StringHandle, StringHandle, CategoryHandle);
+pub struct CoreClrGcEventMarker(StringHandle, StringHandle);
 
 impl StaticSchemaMarker for CoreClrGcEventMarker {
     const UNIQUE_MARKER_TYPE_NAME: &'static str = "GC Event";
 
+    const CATEGORY: Category<'static> = CORE_CLR_GC_CATEGORY;
     const DESCRIPTION: Option<&'static str> = Some("Generic GC Event.");
 
     const LOCATIONS: MarkerLocations = MarkerLocations::MARKER_CHART
@@ -282,10 +282,6 @@ impl StaticSchemaMarker for CoreClrGcEventMarker {
 
     fn name(&self, _profile: &mut Profile) -> StringHandle {
         self.0
-    }
-
-    fn category(&self, _profile: &mut Profile) -> CategoryHandle {
-        self.2
     }
 
     fn string_field_value(&self, _field_index: u32) -> StringHandle {
@@ -557,12 +553,11 @@ pub fn handle_coreclr_event(
                     let _object_count: u32 = parser.parse("ObjectCountForTypeSample");
                     let total_size: u64 = parser.parse("TotalSizeForTypeSample");
 
-                    let category = context.known_category(KnownCategory::CoreClrGc);
                     let clr_type = context.handle_for_profile_string(&format!("0x{:x}", type_id));
                     let mh = context.add_thread_instant_marker(
                         timestamp_raw,
                         tid,
-                        CoreClrGcAllocMarker(clr_type, total_size as f64, category),
+                        CoreClrGcAllocMarker(clr_type, total_size as f64),
                     );
                     coreclr_context.set_last_event_for_thread(tid, mh);
                     handled = true;
@@ -578,7 +573,6 @@ pub fn handle_coreclr_event(
                         None
                     });
 
-                    let category = context.known_category(KnownCategory::CoreClrGc);
                     let name = context.handle_for_profile_string("GC Trigger");
                     let description = context.handle_for_profile_string(&format!(
                         "GC Trigger: {}",
@@ -587,7 +581,7 @@ pub fn handle_coreclr_event(
                     let mh = context.add_thread_instant_marker(
                         timestamp_raw,
                         tid,
-                        CoreClrGcEventMarker(name, description, category),
+                        CoreClrGcEventMarker(name, description),
                     );
                     coreclr_context.set_last_event_for_thread(tid, mh);
                     handled = true;
@@ -625,14 +619,13 @@ pub fn handle_coreclr_event(
                     }
 
                     if let Some(info) = coreclr_context.remove_gc_marker(tid, "GCSuspendEE") {
-                        let category = context.known_category(KnownCategory::CoreClrGc);
                         let name = context.handle_for_profile_string(&info.name);
                         let description = context.handle_for_profile_string(&info.description);
                         context.add_thread_interval_marker(
                             info.start_timestamp_raw,
                             timestamp_raw,
                             tid,
-                            CoreClrGcEventMarker(name, description, category),
+                            CoreClrGcEventMarker(name, description),
                         );
                     }
                     handled = true;
@@ -681,14 +674,13 @@ pub fn handle_coreclr_event(
                     //let count: u32 = parser.parse("Count");
                     //let depth: u32 = parser.parse("Depth");
                     if let Some(info) = coreclr_context.remove_gc_marker(tid, "GC") {
-                        let category = context.known_category(KnownCategory::CoreClrGc);
                         let name = context.handle_for_profile_string(&info.name);
                         let description = context.handle_for_profile_string(&info.description);
                         context.add_thread_interval_marker(
                             info.start_timestamp_raw,
                             timestamp_raw,
                             tid,
-                            CoreClrGcEventMarker(name, description, category),
+                            CoreClrGcEventMarker(name, description),
                         );
                     }
                     handled = true;
@@ -743,6 +735,7 @@ pub struct OtherClrMarker(StringHandle, StringHandle);
 impl StaticSchemaMarker for OtherClrMarker {
     const UNIQUE_MARKER_TYPE_NAME: &'static str = "OtherClrMarker";
 
+    const CATEGORY: Category<'static> = Category("Other", CategoryColor::Gray);
     const DESCRIPTION: Option<&'static str> = Some("CoreCLR marker of unknown type.");
 
     const CHART_LABEL: Option<&'static str> = Some("{marker.data.name}");
@@ -758,10 +751,6 @@ impl StaticSchemaMarker for OtherClrMarker {
 
     fn name(&self, _profile: &mut Profile) -> StringHandle {
         self.0
-    }
-
-    fn category(&self, _profile: &mut Profile) -> CategoryHandle {
-        CategoryHandle::OTHER
     }
 
     fn string_field_value(&self, _field_index: u32) -> StringHandle {

--- a/samply/src/windows/etw_gecko.rs
+++ b/samply/src/windows/etw_gecko.rs
@@ -9,7 +9,7 @@ use uuid::Uuid;
 use super::coreclr::CoreClrContext;
 use super::profile_context::ProfileContext;
 use crate::windows::coreclr;
-use crate::windows::profile_context::{KnownCategory, PeInfo};
+use crate::windows::profile_context::PeInfo;
 
 use super::etw_reader::parser::{Address, Parser, TryParse};
 use super::etw_reader::schema::SchemaLocator;
@@ -410,7 +410,6 @@ fn process_trace(
                     tid,
                     s.name().strip_suffix("/win:Stop").unwrap(),
                     text,
-                    KnownCategory::D3DVideoSubmitDecoderBuffers,
                 );
             }
             marker_name if marker_name.starts_with("Mozilla.FirefoxTraceLogger/") => {

--- a/samply/src/windows/etw_gecko.rs
+++ b/samply/src/windows/etw_gecko.rs
@@ -443,7 +443,7 @@ fn process_trace(
                         "EndTime",
                         "Phase",
                         "InnerWindowId",
-                        "CategoryPair",
+                        "Subcategory",
                     ]),
                 );
                 context.handle_firefox_marker(

--- a/samply/src/windows/profile_context.rs
+++ b/samply/src/windows/profile_context.rs
@@ -2225,7 +2225,7 @@ pub fn make_thread_label_frame(
     let thread_label = profile.handle_for_string(&s);
     FrameInfo {
         frame: Frame::Label(thread_label),
-        category_pair: CategoryHandle::OTHER.into(),
+        subcategory: CategoryHandle::OTHER.into(),
         flags: FrameFlags::empty(),
     }
 }

--- a/samply/src/windows/profile_context.rs
+++ b/samply/src/windows/profile_context.rs
@@ -665,8 +665,8 @@ impl ProfileContext {
         self.categories.get(known_category, &mut self.profile)
     }
 
-    pub fn intern_profile_string(&mut self, s: &str) -> StringHandle {
-        self.profile.intern_string(s)
+    pub fn handle_for_profile_string(&mut self, s: &str) -> StringHandle {
+        self.profile.handle_for_string(s)
     }
 
     pub fn add_thread_instant_marker(
@@ -1570,7 +1570,7 @@ impl ProfileContext {
             const FIELDS: &'static [StaticSchemaMarkerField] = &[];
 
             fn name(&self, profile: &mut Profile) -> StringHandle {
-                profile.intern_string("Vsync")
+                profile.handle_for_string("Vsync")
             }
 
             fn category(&self, _profile: &mut Profile) -> CategoryHandle {
@@ -1677,7 +1677,7 @@ impl ProfileContext {
                     let begin_timestamp = self
                         .timestamp_converter
                         .convert_time(idle_cpu_sample.begin_timestamp);
-                    let stack = self.profile.intern_stack_frames(
+                    let stack = self.profile.handle_for_stack_frames(
                         cpu.thread_handle,
                         std::iter::once(idle_frame_label.clone()),
                     );
@@ -1776,7 +1776,7 @@ impl ProfileContext {
         let info = LibMappingInfo::new_jit_function(lib.lib_handle(), category, js_frame);
 
         if self.profile_creation_props.should_emit_jit_markers {
-            let name_handle = self.profile.intern_string(&method_name);
+            let name_handle = self.profile.handle_for_string(&method_name);
             let timestamp = self.timestamp_converter.convert_time(timestamp_raw);
             self.profile.add_marker(
                 process.main_thread_handle,
@@ -1873,8 +1873,10 @@ impl ProfileContext {
         };
 
         let category = self.categories.get(known_category, &mut self.profile);
-        let name = self.profile.intern_string(name.split_once('/').unwrap().1);
-        let description = self.profile.intern_string(&text);
+        let name = self
+            .profile
+            .handle_for_string(name.split_once('/').unwrap().1);
+        let description = self.profile.handle_for_string(&text);
         self.profile.add_marker(
             thread_handle,
             timing,
@@ -1933,23 +1935,25 @@ impl ProfileContext {
         };
 
         if marker_name == "UserTiming" {
-            let name = self.profile.intern_string(&maybe_user_timing_name.unwrap());
+            let name = self
+                .profile
+                .handle_for_string(&maybe_user_timing_name.unwrap());
             self.profile
                 .add_marker(thread_handle, timing, UserTimingMarker(name));
         } else if marker_name == "SimpleMarker" || marker_name == "Text" || marker_name == "tracing"
         {
             let marker_name = self
                 .profile
-                .intern_string(&maybe_explicit_marker_name.unwrap());
-            let description = self.profile.intern_string(&text);
+                .handle_for_string(&maybe_explicit_marker_name.unwrap());
+            let description = self.profile.handle_for_string(&text);
             self.profile.add_marker(
                 thread_handle,
                 timing,
                 FreeformMarker(marker_name, description, CategoryHandle::OTHER),
             );
         } else {
-            let marker_name = self.profile.intern_string(marker_name);
-            let description = self.profile.intern_string(&text);
+            let marker_name = self.profile.handle_for_string(marker_name);
+            let description = self.profile.handle_for_string(&text);
             self.profile.add_marker(
                 thread_handle,
                 timing,
@@ -1982,12 +1986,12 @@ impl ProfileContext {
         };
         let keyword = KeywordNames::from_bits(keyword_bitfield).unwrap();
         if keyword == KeywordNames::blink_user_timing {
-            let name = self.profile.intern_string(marker_name);
+            let name = self.profile.handle_for_string(marker_name);
             self.profile
                 .add_marker(thread_handle, timing, UserTimingMarker(name));
         } else {
-            let marker_name = self.profile.intern_string(marker_name);
-            let description = self.profile.intern_string(&text);
+            let marker_name = self.profile.handle_for_string(marker_name);
+            let description = self.profile.handle_for_string(&text);
             self.profile.add_marker(
                 thread_handle,
                 timing,
@@ -2017,8 +2021,8 @@ impl ProfileContext {
         let category = self
             .categories
             .get(KnownCategory::Unknown, &mut self.profile);
-        let marker_name = self.profile.intern_string(task_and_op);
-        let description = self.profile.intern_string(&stringified_properties);
+        let marker_name = self.profile.handle_for_string(task_and_op);
+        let description = self.profile.handle_for_string(&stringified_properties);
         self.profile.add_marker(
             thread_handle,
             timing,
@@ -2218,7 +2222,7 @@ pub fn make_thread_label_frame(
         Some(name) => format!("{name} (pid: {pid}, tid: {tid})"),
         None => format!("Thread {tid} (pid: {pid}, tid: {tid})"),
     };
-    let thread_label = profile.intern_string(&s);
+    let thread_label = profile.handle_for_string(&s);
     FrameInfo {
         frame: Frame::Label(thread_label),
         category_pair: CategoryHandle::OTHER.into(),


### PR DESCRIPTION
- Rename `intern_string` to `handle_for_string`. Do the same for `intern_frame`, `intern_stack` and so on.
- Change `add_category` and `add_subcategory` to `handle_for_category` and `handle_for_subcategory`.
- For markers, make the category part of the schema. Add a static `Category` type to make this possible for `StaticSchemaMarker`.