### PR TITLE
Enable --unstable-presymbolicate for 'samply import'

### DIFF
--- a/samply/src/main.rs
+++ b/samply/src/main.rs
@@ -812,6 +812,7 @@ fn convert_perf_data_file_to_profile(input_file: &File, import_args: &ImportArgs
     let file_meta = input_file.metadata().ok();
     let file_mod_time = file_meta.and_then(|metadata| metadata.modified().ok());
     let profile_creation_props = import_args.profile_creation_props();
+    let unstable_presymbolicate = profile_creation_props.unstable_presymbolicate;
     let mut binary_lookup_dirs = import_args.symbol_props().symbol_dir.clone();
     let mut aux_file_lookup_dirs = import_args.aux_file_dir.clone();
     if let Some(parent_dir) = path.parent() {
@@ -833,6 +834,13 @@ fn convert_perf_data_file_to_profile(input_file: &File, import_args: &ImportArgs
         }
     };
     save_profile_to_file(&profile, &import_args.output).expect("Couldn't write JSON");
+
+    if unstable_presymbolicate {
+        crate::shared::symbol_precog::presymbolicate(
+            &profile,
+            &import_args.output.with_extension("syms.json"),
+        );
+    }
 }
 
 #[cfg(test)]

--- a/samply/src/windows/import.rs
+++ b/samply/src/windows/import.rs
@@ -29,6 +29,8 @@ pub fn convert_etl_file_to_profile(
 
     eprintln!("Processing ETL trace...");
 
+    let unstable_presymbolicate = profile_creation_props.unstable_presymbolicate;
+
     let mut context =
         ProfileContext::new(profile, arch, included_processes, profile_creation_props);
 
@@ -36,6 +38,13 @@ pub fn convert_etl_file_to_profile(
 
     let profile = context.finish();
     save_profile_to_file(&profile, output_file).expect("Couldn't write JSON");
+
+    if unstable_presymbolicate {
+        crate::shared::symbol_precog::presymbolicate(
+            &profile,
+            &output_file.with_extension("syms.json"),
+        );
+    }
 }
 
 #[cfg(target_arch = "x86")]


### PR DESCRIPTION
`samply import` currently supports an `--unstable-presymbolicate` option but does not output the `.syms.json` file when this flag is enabled. This PR adds the missing code to generate the symbol JSON file, which is useful for running in CI.