### PR TITLE
Store platform-specific timestamps in the profile.

### DIFF
--- a/fxprof-processed-profile/src/lib.rs
+++ b/fxprof-processed-profile/src/lib.rs
@@ -91,7 +91,7 @@ pub use profile::{
     FrameHandle, FrameSymbolInfo, Profile, SamplingInterval, SourceLocation, StackHandle,
     StringHandle, TimelineUnit,
 };
-pub use reference_timestamp::ReferenceTimestamp;
+pub use reference_timestamp::{PlatformSpecificReferenceTimestamp, ReferenceTimestamp};
 pub use sample_table::WeightType;
 pub use thread::ProcessHandle;
 pub use timestamp::Timestamp;

--- a/fxprof-processed-profile/src/reference_timestamp.rs
+++ b/fxprof-processed-profile/src/reference_timestamp.rs
@@ -42,3 +42,12 @@ impl Serialize for ReferenceTimestamp {
         self.ms_since_unix_epoch.serialize(serializer)
     }
 }
+
+/// An additional reference timestamp in a platform-specific unit.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum PlatformSpecificReferenceTimestamp {
+    ClockMonotonicNanosecondsSinceBoot(u64),
+    MachAbsoluteTimeNanoseconds(u64),
+    QueryPerformanceCounterValue(u64),
+}

--- a/samply/src/linux_shared/converter.rs
+++ b/samply/src/linux_shared/converter.rs
@@ -8,9 +8,9 @@ use debugid::DebugId;
 use framehop::{ExplicitModuleSectionInfo, FrameAddress, Module, Unwinder};
 use fxprof_processed_profile::{
     Category, CategoryColor, CategoryHandle, CpuDelta, FrameFlags, LibraryHandle, LibraryInfo,
-    MarkerFieldFlags, MarkerFieldFormat, MarkerTiming, Profile, ReferenceTimestamp,
-    SamplingInterval, StaticSchemaMarker, StaticSchemaMarkerField, StringHandle, SubcategoryHandle,
-    SymbolTable, ThreadHandle,
+    MarkerFieldFlags, MarkerFieldFormat, MarkerTiming, PlatformSpecificReferenceTimestamp, Profile,
+    ReferenceTimestamp, SamplingInterval, StaticSchemaMarker, StaticSchemaMarkerField,
+    StringHandle, SubcategoryHandle, SymbolTable, ThreadHandle,
 };
 use linux_perf_data::linux_perf_event_reader::TaskWasPreempted;
 use linux_perf_data::simpleperf_dso_type::{DSO_DEX_FILE, DSO_KERNEL, DSO_KERNEL_MODULE};
@@ -163,6 +163,12 @@ where
             reference_raw: first_sample_time,
             raw_to_ns_factor: 1,
         };
+
+        profile.set_platform_specific_reference_timestamp(
+            PlatformSpecificReferenceTimestamp::ClockMonotonicNanosecondsSinceBoot(
+                timestamp_converter.reference_raw,
+            ),
+        );
 
         let cpus = if profile_creation_props.create_per_cpu_threads {
             let start_timestamp = timestamp_converter.convert_time(first_sample_time);


### PR DESCRIPTION
This will make it easier to merge profiles from different sources that were collected at the same time with different collection mechanisms.