### PR TITLE
Use a Docker image with an old glibc when building Linux releases.

### DIFF
--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -19,3 +19,10 @@ install-updater = false
 precise-builds = true
 # Path that installers should place binaries in
 install-path = "CARGO_HOME"
+
+# Use a container with an older glibc for maximum Linux version compat,
+# as described on https://github.com/astral-sh/cargo-dist/blob/main/book/src/ci/customizing.md
+[dist.github-custom-runners.x86_64-unknown-linux-gnu]
+container = { image = "quay.io/pypa/manylinux_2_28_x86_64", host = "x86_64-unknown-linux-musl" }
+[dist.github-custom-runners.aarch64-unknown-linux-gnu]
+container = { image = "quay.io/pypa/manylinux_2_28_x86_64", host = "x86_64-unknown-linux-musl" }


### PR DESCRIPTION
The current Linux release of samply was compiled on the Ubuntu 20.04 runner which is now deprecated. Compiling on the newer runner would drop compatibility with some glibc versions, so use a Docker image with an old glibc to avoid dropping compatibility.