### PR TITLE
Fix panic when looking up missing symbol files.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1583,6 +1583,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "path-clean"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17359afc20d7ab31fdb42bb844c8b3bb1dabd7dcf7e68428492da7f16966fcef"
+
+[[package]]
 name = "pdb-addr2line"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2248,6 +2254,7 @@ version = "0.1.0"
 dependencies = [
  "bytesize",
  "log",
+ "path-clean",
  "rusqlite",
  "rusqlite_migration",
  "tokio",

--- a/samply-quota-manager/Cargo.toml
+++ b/samply-quota-manager/Cargo.toml
@@ -12,6 +12,7 @@ readme = "README.md"
 [dependencies]
 bytesize = "2"
 log = "0.4.21"
+path-clean = "1"
 tokio = { version = "1.39", features = [
   "fs",
   "rt",

--- a/samply-quota-manager/src/file_inventory.rs
+++ b/samply-quota-manager/src/file_inventory.rs
@@ -158,7 +158,8 @@ impl FileInventory {
     }
 
     fn to_absolute_path(&self, relative_path: &Path) -> PathBuf {
-        let abs_path = self.root_path.join(relative_path).canonicalize().unwrap();
+        let abs_path = self.root_path.join(relative_path);
+        let abs_path = path_clean::clean(abs_path);
         assert!(abs_path.starts_with(&self.root_path));
         abs_path
     }


### PR DESCRIPTION
This code was trying to turn the combination of an absolute path and a relative path into an absolute path without ./ and ../, but canonicalize() only works on files that actually exist.

Switch to path-clean instead.