### PR TITLE
Add arm64e variant to samply-mac-preload dylib universal binary

### DIFF
--- a/samply-mac-preload/README.md
+++ b/samply-mac-preload/README.md
@@ -3,6 +3,7 @@
 ```
 rustup target add x86_64-apple-darwin
 rustup target add aarch64-apple-darwin
+rustup component add rust-src --toolchain stable-aarch64-apple-darwin
 ```
 
 Run `build.sh` from inside this directory to update the files inside `binaries/` and to copy the updated dylib into `../samply/resources/`.

--- a/samply-mac-preload/build.sh
+++ b/samply-mac-preload/build.sh
@@ -3,5 +3,7 @@ MACOSX_DEPLOYMENT_TARGET=10.7 cargo build --release --target=x86_64-apple-darwin
 mv target/x86_64-apple-darwin/release/libsamply_mac_preload.dylib binaries/libsamply_mac_preload_x86_64.dylib
 MACOSX_DEPLOYMENT_TARGET=11.0 cargo build --release --target=aarch64-apple-darwin
 mv target/aarch64-apple-darwin/release/libsamply_mac_preload.dylib binaries/libsamply_mac_preload_arm64.dylib
+MACOSX_DEPLOYMENT_TARGET=11.0 RUSTC_BOOTSTRAP=1 cargo build --release --target=arm64e-apple-darwin -Zbuild-std
+mv target/arm64e-apple-darwin/release/libsamply_mac_preload.dylib binaries/libsamply_mac_preload_arm64e.dylib
 lipo binaries/libsamply_mac_preload_* -create -output binaries/libsamply_mac_preload.dylib
 gzip -cvf binaries/libsamply_mac_preload.dylib > ../samply/resources/libsamply_mac_preload.dylib.gz


### PR DESCRIPTION
On macOS, there are three slices for binaries: x86_64, arm64, and arm64e. The third one is introduced[1] and it is using ARMv8.3's PAC etc.

Because macOS samply injects dylib for the profiled process, if the profiled process is built with arm64e, dylib needs arm64e slice as well. Previously dylib only had x86_64 and arm64 slices.

This patch adds an instruction to add arm64e slice to this dylib as well. This allows running samply with the process using arm64e. While the generated code itself is not using PAC, this is fine since arm64 is subset of arm64e as whole code is just calling and exposing C interface.

This patch does not add a built binary intentionally to allow the upstream developers to build and add that.

[1]: https://developer.apple.com/documentation/security/preparing-your-app-to-work-with-pointer-authentication