### PR TITLE
Some more breakpad sym file symbolication improvements

### DIFF
--- a/samply-api/src/symbolicate/looked_up_addresses.rs
+++ b/samply-api/src/symbolicate/looked_up_addresses.rs
@@ -19,65 +19,25 @@ pub struct AddressResult {
     pub inline_frames: Option<Vec<FrameDebugInfo>>,
 }
 
-pub type AddressResults = BTreeMap<u32, Option<AddressResult>>;
-
-pub struct LookedUpAddresses {
-    pub address_results: AddressResults,
-    pub symbol_count: u32,
-}
-
-impl LookedUpAddresses {
-    pub fn for_addresses(addresses: &[u32]) -> Self {
-        LookedUpAddresses {
-            address_results: addresses.iter().map(|&addr| (addr, None)).collect(),
-            symbol_count: 0,
-        }
-    }
-
-    pub fn add_address_symbol(
-        &mut self,
-        address: u32,
-        symbol_address: u32,
-        symbol_name: String,
-        function_size: Option<u32>,
-    ) {
-        *self.address_results.get_mut(&address).unwrap() = Some(AddressResult {
+impl AddressResult {
+    pub fn new(symbol_address: u32, symbol_name: String, function_size: Option<u32>) -> Self {
+        Self {
             symbol_address,
             symbol_name,
             function_size,
             inline_frames: None,
-        });
-    }
-
-    pub fn add_address_debug_info(&mut self, address: u32, frames: Vec<FrameDebugInfo>) {
-        let outer_function_name = frames.last().and_then(|f| f.function.as_deref());
-        let entry = self.address_results.get_mut(&address).unwrap();
-
-        match entry {
-            Some(address_result) => {
-                // Overwrite the symbol name with the function name from the debug info.
-                if let Some(name) = outer_function_name {
-                    address_result.symbol_name = name.to_string();
-                }
-                // Add the inline frame info.``
-                address_result.inline_frames = Some(frames);
-            }
-            None => {
-                // add_address_symbol has not been called for this address.
-                // This happens when we only have debug info but no symbol for this address.
-                // This is a rare case.
-                *entry = Some(AddressResult {
-                    symbol_address: address, // TODO: Would be nice to get the actual function start address from addr2line
-                    symbol_name: outer_function_name
-                        .map_or_else(|| format!("0x{address:x}"), str::to_string),
-                    function_size: None,
-                    inline_frames: Some(frames),
-                });
-            }
         }
     }
 
-    pub fn set_total_symbol_count(&mut self, total_symbol_count: u32) {
-        self.symbol_count = total_symbol_count;
+    pub fn set_debug_info(&mut self, frames: Vec<FrameDebugInfo>) {
+        let outer_function_name = frames.last().and_then(|f| f.function.as_deref());
+        // Overwrite the symbol name with the function name from the debug info.
+        if let Some(name) = outer_function_name {
+            self.symbol_name = name.to_string();
+        }
+        // Add the inline frame info.
+        self.inline_frames = Some(frames);
     }
 }
+
+pub type AddressResults = BTreeMap<u32, Option<AddressResult>>;

--- a/samply-api/src/symbolicate/looked_up_addresses.rs
+++ b/samply-api/src/symbolicate/looked_up_addresses.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use samply_symbols::{FrameDebugInfo, SourceFilePath, SourceFilePathHandle};
+use samply_symbols::{FrameDebugInfo, SourceFilePath, SourceFilePathHandle, SymbolInfo};
 
 pub trait PathResolver {
     fn resolve_source_file_path(&self, handle: SourceFilePathHandle) -> SourceFilePath<'_>;
@@ -13,27 +13,23 @@ impl PathResolver for () {
 }
 
 pub struct AddressResult {
-    pub symbol_address: u32,
-    pub symbol_name: String,
-    pub function_size: Option<u32>,
+    pub symbol: SymbolInfo,
     pub inline_frames: Option<Vec<FrameDebugInfo>>,
 }
 
 impl AddressResult {
-    pub fn new(symbol_address: u32, symbol_name: String, function_size: Option<u32>) -> Self {
+    pub fn new(symbol: SymbolInfo) -> Self {
         Self {
-            symbol_address,
-            symbol_name,
-            function_size,
+            symbol,
             inline_frames: None,
         }
     }
 
     pub fn set_debug_info(&mut self, frames: Vec<FrameDebugInfo>) {
-        let outer_function_name = frames.last().and_then(|f| f.function.as_deref());
+        let outer_function_name = frames.last().and_then(|f| f.function.as_ref());
         // Overwrite the symbol name with the function name from the debug info.
         if let Some(name) = outer_function_name {
-            self.symbol_name = name.to_string();
+            self.symbol.name = name.clone();
         }
         // Add the inline frame info.
         self.inline_frames = Some(frames);

--- a/samply-api/src/symbolicate/mod.rs
+++ b/samply-api/src/symbolicate/mod.rs
@@ -2,8 +2,8 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use samply_symbols::{
-    FileAndPathHelper, FramesLookupResult, LibraryInfo, LookupAddress, SourceFilePath,
-    SourceFilePathHandle, SymbolManager, SymbolMap,
+    AccessPatternHint, FileAndPathHelper, FramesLookupResult, LibraryInfo, LookupAddress,
+    SourceFilePath, SourceFilePathHandle, SymbolManager, SymbolMap,
 };
 
 use crate::error::Error;
@@ -94,6 +94,7 @@ impl<'a, H: FileAndPathHelper + 'static> SymbolicateApi<'a, H> {
             ..Default::default()
         };
         let symbol_map = self.symbol_manager.load_symbol_map(&info).await?;
+        symbol_map.set_access_pattern_hint(AccessPatternHint::SequentialLookup);
         let mut symbolication_result = LookedUpAddresses::for_addresses(&addresses);
 
         symbolication_result.set_total_symbol_count(symbol_map.symbol_count() as u32);

--- a/samply-api/src/symbolicate/mod.rs
+++ b/samply-api/src/symbolicate/mod.rs
@@ -95,21 +95,19 @@ impl<'a, H: FileAndPathHelper + 'static> SymbolicateApi<'a, H> {
         let mut external_addresses = Vec::new();
 
         for (&address, address_result) in &mut address_results {
-            if let Some(address_info) = symbol_map.lookup_sync(LookupAddress::Relative(address)) {
-                *address_result = Some(AddressResult::new(
-                    address_info.symbol.address,
-                    address_info.symbol.name,
-                    address_info.symbol.size,
-                ));
-                match address_info.frames {
-                    Some(FramesLookupResult::Available(frames)) => {
-                        address_result.as_mut().unwrap().set_debug_info(frames)
-                    }
-                    Some(FramesLookupResult::External(ext_address)) => {
-                        external_addresses.push((address, ext_address));
-                    }
-                    None => {}
+            let Some(address_info) = symbol_map.lookup_sync(LookupAddress::Relative(address))
+            else {
+                continue;
+            };
+            *address_result = Some(AddressResult::new(address_info.symbol));
+            match address_info.frames {
+                Some(FramesLookupResult::Available(frames)) => {
+                    address_result.as_mut().unwrap().set_debug_info(frames)
                 }
+                Some(FramesLookupResult::External(ext_address)) => {
+                    external_addresses.push((address, ext_address));
+                }
+                None => {}
             }
         }
 

--- a/samply-api/src/symbolicate/response_json.rs
+++ b/samply-api/src/symbolicate/response_json.rs
@@ -212,12 +212,12 @@ impl<'a> serde::Serialize for ResponseFrame<'a> {
             let address_result = symbol_map.address_results.get(&frame.address).unwrap();
             // But the result might still be None.
             if let Some(address_result) = address_result {
-                map.serialize_entry("function", &address_result.symbol_name)?;
+                map.serialize_entry("function", &address_result.symbol.name)?;
                 map.serialize_entry(
                     "function_offset",
-                    &SerializeAsHexStr(frame.address - address_result.symbol_address),
+                    &SerializeAsHexStr(frame.address - address_result.symbol.address),
                 )?;
-                if let Some(function_size) = address_result.function_size {
+                if let Some(function_size) = address_result.symbol.size {
                     map.serialize_entry("function_size", &SerializeAsHexStr(function_size))?;
                 }
 

--- a/samply-api/src/symbolicate/response_json.rs
+++ b/samply-api/src/symbolicate/response_json.rs
@@ -5,14 +5,13 @@ use std::sync::Arc;
 use samply_symbols::{FileAndPathHelper, FrameDebugInfo, SymbolMap};
 use serde::ser::{SerializeMap, SerializeSeq};
 
-use super::looked_up_addresses::LookedUpAddresses;
 use super::request_json::{Job, Lib, RequestFrame, RequestStack};
 use crate::api_file_path::to_api_file_path;
 use crate::symbolicate::looked_up_addresses::{AddressResults, PathResolver};
 use crate::symbolicate::request_json::Request;
 
 pub struct PerLibResult<H: FileAndPathHelper> {
-    pub address_results: LookedUpAddresses,
+    pub address_results: AddressResults,
     pub symbol_map: Arc<SymbolMap<H>>,
 }
 
@@ -59,7 +58,7 @@ impl<H: FileAndPathHelper> serde::Serialize for Response<H> {
 }
 
 pub struct PerLibResultRef<'a> {
-    pub address_results: std::result::Result<&'a LookedUpAddresses, &'a samply_symbols::Error>,
+    pub address_results: std::result::Result<&'a AddressResults, &'a samply_symbols::Error>,
     pub path_resolver: &'a dyn PathResolver,
 }
 
@@ -106,9 +105,9 @@ impl<'a> serde::Serialize for Result<'a> {
             if let Some(per_lib_result) = self.per_lib_results.get(lib) {
                 let module_key = format!("{}/{}", lib.debug_name, lib.breakpad_id);
                 match per_lib_result.address_results {
-                    Ok(symbols) => {
+                    Ok(address_results) => {
                         let module_results = PerModuleResultsRef {
-                            address_results: &symbols.address_results,
+                            address_results,
                             path_resolver: per_lib_result.path_resolver,
                         };
                         symbols_by_module_index.insert(module_index as u32, module_results);

--- a/samply-symbols/src/breakpad/index.rs
+++ b/samply-symbols/src/breakpad/index.rs
@@ -789,7 +789,7 @@ pub enum BreakpadParseError {
     NoModuleInfoInSymFile,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct BreakpadPublicSymbolInfo<'a> {
     pub name: &'a str,
 }

--- a/samply-symbols/src/breakpad/mod.rs
+++ b/samply-symbols/src/breakpad/mod.rs
@@ -3,6 +3,7 @@ mod symbol_map;
 
 pub use index::{
     BreakpadIndex, BreakpadIndexCreator, BreakpadParseError, BreakpadSymindexParseError,
+    OwnedBreakpadIndex,
 };
 pub use symbol_map::get_symbol_map_for_breakpad_sym;
 

--- a/samply-symbols/src/lib.rs
+++ b/samply-symbols/src/lib.rs
@@ -260,7 +260,7 @@ pub use crate::shared::{
     MultiArchDisambiguator, OptionallySendFuture, PeCodeId, SymbolInfo, SyncAddressInfo,
 };
 pub use crate::source_file_path::{SourceFilePath, SourceFilePathHandle, SourceFilePathIndex};
-pub use crate::symbol_map::{SymbolMap, SymbolMapTrait};
+pub use crate::symbol_map::{AccessPatternHint, SymbolMap, SymbolMapTrait};
 
 pub struct SymbolManager<H: FileAndPathHelper> {
     helper: Arc<H>,

--- a/samply-symbols/src/lib.rs
+++ b/samply-symbols/src/lib.rs
@@ -240,6 +240,7 @@ mod windows;
 pub use crate::binary_image::{BinaryImage, CodeByteReadingError};
 pub use crate::breakpad::{
     BreakpadIndex, BreakpadIndexCreator, BreakpadParseError, BreakpadSymindexParseError,
+    OwnedBreakpadIndex,
 };
 pub use crate::cache::{FileByteSource, FileContentsWithChunkedCaching};
 pub use crate::compact_symbol_table::CompactSymbolTable;

--- a/samply-symbols/src/symbol_map.rs
+++ b/samply-symbols/src/symbol_map.rs
@@ -26,6 +26,20 @@ pub trait SymbolMapTrait {
     fn lookup_sync(&self, address: LookupAddress) -> Option<SyncAddressInfo>;
 
     fn resolve_source_file_path(&self, handle: SourceFilePathHandle) -> SourceFilePath<'_>;
+
+    fn set_access_pattern_hint(&self, _hint: AccessPatternHint) {}
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum AccessPatternHint {
+    Arbitrary,
+
+    /// Indicates that lookup calls will happen with addresses in ascending
+    /// order. This lets the symbol map to save memory because it can discard
+    /// cached information about functions other than the one that contains
+    /// the current address, because those earlier functions cover lower
+    /// addresses and their information will not be needed by higher addresses.
+    SequentialLookup,
 }
 
 pub trait SymbolMapTraitWithExternalFileSupport<FC>: SymbolMapTrait {
@@ -219,5 +233,9 @@ impl<H: FileAndPathHelper> SymbolMap<H> {
 
     pub fn resolve_source_file_path(&self, handle: SourceFilePathHandle) -> SourceFilePath<'_> {
         self.inner().resolve_source_file_path(handle)
+    }
+
+    pub fn set_access_pattern_hint(&self, hint: AccessPatternHint) {
+        self.inner().set_access_pattern_hint(hint);
     }
 }

--- a/wholesym/src/breakpad.rs
+++ b/wholesym/src/breakpad.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use samply_symbols::{BreakpadIndex, BreakpadIndexCreator, BreakpadParseError};
+use samply_symbols::{BreakpadIndex, BreakpadIndexCreator, BreakpadParseError, OwnedBreakpadIndex};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 use crate::downloader::{ChunkConsumer, Downloader, DownloaderObserver, FileDownloadOutcome};
@@ -189,7 +189,7 @@ impl BreakpadSymbolDownloaderInner {
     async fn write_symindex(
         &self,
         symindex_path: &Path,
-        index_bytes: Vec<u8>,
+        index: OwnedBreakpadIndex,
     ) -> Result<(), SymindexGenerationError> {
         if let Some(parent_dir) = symindex_path.parent() {
             tokio::fs::create_dir_all(parent_dir).await.map_err(|e| {
@@ -202,17 +202,15 @@ impl BreakpadSymbolDownloaderInner {
         let index_size_result: Result<u64, CleanFileCreationError<SymindexGenerationError>> =
             create_file_cleanly(
                 symindex_path,
-                |index_file| async move {
-                    let mut index_file = tokio::fs::File::from_std(index_file);
-                    index_file
-                        .write_all(&index_bytes)
-                        .await
-                        .map_err(SymindexGenerationError::FileWriting)?;
-                    index_file
-                        .flush()
-                        .await
-                        .map_err(SymindexGenerationError::FileWriting)?;
-                    Ok(index_bytes.len() as u64)
+                |mut index_file| async move {
+                    tokio::task::spawn_blocking(move || -> std::io::Result<u64> {
+                        index.index().to_writer(&mut index_file)?;
+                        let metadata = index_file.metadata()?;
+                        Ok(metadata.len())
+                    })
+                    .await
+                    .unwrap()
+                    .map_err(SymindexGenerationError::FileWriting)
                 },
                 || async {
                     let size = std::fs::metadata(symindex_path)
@@ -267,15 +265,25 @@ impl BreakpadSymbolDownloaderInner {
             let _ = tokio::fs::remove_file(&symindex_path).await;
         }
 
-        let index_bytes = self.parse_sym_file_into_index(sym_path).await?;
-        self.write_symindex(&symindex_path, index_bytes).await?;
+        self.create_symindex_for_sym_file(sym_path, &symindex_path)
+            .await?;
         Ok(symindex_path)
+    }
+
+    async fn create_symindex_for_sym_file(
+        &self,
+        sym_path: &Path,
+        symindex_path: &Path,
+    ) -> Result<(), SymindexGenerationError> {
+        let index_bytes = self.parse_sym_file_into_index(sym_path).await?;
+        self.write_symindex(symindex_path, index_bytes).await?;
+        Ok(())
     }
 
     async fn parse_sym_file_into_index(
         &self,
         sym_path: &Path,
-    ) -> Result<Vec<u8>, SymindexGenerationError> {
+    ) -> Result<OwnedBreakpadIndex, SymindexGenerationError> {
         let mut sym_file = tokio::fs::File::open(sym_path)
             .await
             .map_err(SymindexGenerationError::SymReading)?;
@@ -307,7 +315,7 @@ async fn validate_symindex_magic_and_version(file: &mut tokio::fs::File) -> bool
 struct BreakpadIndexCreatorChunkConsumer(BreakpadIndexCreator);
 
 impl ChunkConsumer for BreakpadIndexCreatorChunkConsumer {
-    type Output = Result<Vec<u8>, BreakpadParseError>;
+    type Output = Result<OwnedBreakpadIndex, BreakpadParseError>;
 
     fn consume_chunk(&mut self, chunk_data: &[u8]) {
         self.0.consume(chunk_data);


### PR DESCRIPTION
This should reduce memory usage when symbols come from breakpad sym files.