### PR TITLE
Compute profiling time range from samples and markers

### DIFF
--- a/fxprof-processed-profile/src/marker_table.rs
+++ b/fxprof-processed-profile/src/marker_table.rs
@@ -106,6 +106,14 @@ impl MarkerTable {
         self
     }
 
+    pub fn start_times(&self) -> impl Iterator<Item = Timestamp> + use<'_> {
+        self.marker_starts.iter().copied().flatten()
+    }
+
+    pub fn end_times(&self) -> impl Iterator<Item = Timestamp> + use<'_> {
+        self.marker_ends.iter().copied().flatten()
+    }
+
     pub fn as_serializable<'a>(
         &'a self,
         schemas: &'a [InternalMarkerSchema],

--- a/fxprof-processed-profile/src/profile.rs
+++ b/fxprof-processed-profile/src/profile.rs
@@ -1425,6 +1425,22 @@ impl Profile {
         }
     }
 
+    fn compute_profiling_time_range(&self) -> Option<(Timestamp, Timestamp)> {
+        self.threads
+            .iter()
+            .flat_map(|thread| {
+                thread
+                    .sample_timestamps()
+                    .chain(thread.marker_start_times())
+                    .chain(thread.marker_end_times())
+            })
+            .fold(None, |acc, timestamp| {
+                acc.map_or(Some((timestamp, timestamp)), |(min, max)| {
+                    Some((min.min(timestamp), max.max(timestamp)))
+                })
+            })
+    }
+
     fn contains_js_frame(&self) -> bool {
         self.threads.iter().any(|t| t.contains_js_frame())
     }
@@ -1497,6 +1513,12 @@ impl Serialize for SerializableProfileMeta<'_> {
             }
             None => {}
         }
+
+        if let Some((start, end)) = self.0.compute_profiling_time_range() {
+            map.serialize_entry("profilingStartTime", &start)?;
+            map.serialize_entry("profilingEndTime", &end)?;
+        }
+
         map.serialize_entry("symbolicated", &self.0.symbolicated)?;
         map.serialize_entry("pausedRanges", &[] as &[()])?;
         map.serialize_entry("version", &24)?; // this version is ignored, only "preprocessedProfileVersion" is used

--- a/fxprof-processed-profile/src/sample_table.rs
+++ b/fxprof-processed-profile/src/sample_table.rs
@@ -105,6 +105,10 @@ impl SampleTable {
         self.sample_weight_type = t;
     }
 
+    pub fn timestamps(&self) -> impl Iterator<Item = Timestamp> + use<'_> {
+        self.sample_timestamps.iter().copied()
+    }
+
     pub fn modify_last_sample(&mut self, timestamp: Timestamp, weight: i32) {
         *self.sample_weights.last_mut().unwrap() += weight;
         *self.sample_timestamps.last_mut().unwrap() = timestamp;

--- a/fxprof-processed-profile/src/thread.rs
+++ b/fxprof-processed-profile/src/thread.rs
@@ -194,6 +194,18 @@ impl Thread {
         self.frame_interner.gather_used_rvas(collector);
     }
 
+    pub fn sample_timestamps(&self) -> impl Iterator<Item = Timestamp> + use<'_> {
+        self.samples.timestamps()
+    }
+
+    pub fn marker_start_times(&self) -> impl Iterator<Item = Timestamp> + use<'_> {
+        self.markers.start_times()
+    }
+
+    pub fn marker_end_times(&self) -> impl Iterator<Item = Timestamp> + use<'_> {
+        self.markers.end_times()
+    }
+
     pub fn cmp_for_json_order(&self, other: &Thread) -> Ordering {
         let ordering = (!self.is_main).cmp(&(!other.is_main));
         if ordering != Ordering::Equal {

--- a/fxprof-processed-profile/tests/integration_tests/main.rs
+++ b/fxprof-processed-profile/tests/integration_tests/main.rs
@@ -344,6 +344,8 @@ fn profile_without_js() {
                 "time": "ms"
               },
               "startTime": 1636162232627.0,
+              "profilingStartTime": 0.0,
+              "profilingEndTime": 3.0,
               "symbolicated": false,
               "pausedRanges": [],
               "version": 24,
@@ -1020,6 +1022,8 @@ fn profile_with_js() {
                 "time": "ms"
               },
               "startTime": 1636162232627.0,
+              "profilingStartTime": 1.0,
+              "profilingEndTime": 1.0,
               "symbolicated": false,
               "pausedRanges": [],
               "version": 24,
@@ -1277,6 +1281,8 @@ fn profile_counters_with_sorted_processes() {
                 "time": "ms"
               },
               "startTime": 1636162232627.0,
+              "profilingStartTime": 0.0,
+              "profilingEndTime": 1.0,
               "symbolicated": true,
               "pausedRanges": [],
               "version": 24,
@@ -1590,6 +1596,8 @@ fn test_flow_marker_fields() {
                 "time": "ms"
               },
               "startTime": 1636162232627.0,
+              "profilingStartTime": 10.0,
+              "profilingEndTime": 10.0,
               "symbolicated": false,
               "pausedRanges": [],
               "version": 24,


### PR DESCRIPTION
## Overview

This PR adds `profilingStartTime` and `profilingEndTime` fields to the profile metadata, computed from all sample timestamps and marker start/end times across all threads.

## Tests

I've updated all of the existing tests to check these values, but it doesn't have full coverage of the edge cases I've encountered, where marker times may be before/after sample times, or the converse, on multiple threads, etc.

I did manually verify that it fixes the issues I was seeing in #710 related to the profiling time range.

**Example Before: https://share.firefox.dev/4oSRnGW**

> Notice that much of the right-most `Fib(14)` is truncated.

<img width="1663" height="1375" alt="image" src="https://github.com/user-attachments/assets/202b8d68-9e6a-4c34-b75f-c26e7044b906" />

<br>

<br>

**Example After: https://share.firefox.dev/4p5vUux**

> Notice that every Fibonacci call is wholly present.
> The profile ends _exactly_ at the end of the markers.

<img width="1663" height="1375" alt="image" src="https://github.com/user-attachments/assets/2d675d1b-7099-4fd5-8800-2d462137748f" />

<br>

<br>

However, I'm not entirely sure if the current behavior is correct for every scenario.

For example, I'm not sure if the following start and end time of `10.0`, which is the computed result for one of the current test cases, makes sense:

```json
"startTime": 1636162232627.0,
"profilingStartTime": 10.0,
"profilingEndTime": 10.0,
"symbolicated": false,
"symbolicated": false,
"pausedRanges": [],
"pausedRanges": [],
"version": 24,
"version": 24,
```

I didn't add any additional test cases because I'm still very much a novice when it comes to the internals of the profiles. I bet an LLM could generate more test cases pretty well, given the context, but I wouldn't be able to accurately review whether it represents a realistic profile.

I'm not sure how extensive you want the test coverage, since these cases are pretty long, but I'm happy to try to add more cases if desired.

## Additional Thoughts

I considered utilizing [rayon](https://crates.io/crates/rayon) for the `compute_profiling_time_range()` function, because it seems like a natural use case, and probably would drastically reduce the time to process large profiles. However, I didn't want to introduce a new dependency to this crate without asking. 

## Related Work

This PR was implemented as an alternative to https://github.com/firefox-devtools/profiler/pull/5682.
