### PR TITLE
profiler: check paranoia level after trying SwCpuClock

### DIFF
--- a/samply/src/linux/profiler.rs
+++ b/samply/src/linux/profiler.rs
@@ -402,7 +402,8 @@ fn init_profiler(
 
             // Another reason for the error could be the type of perf event:
             // The "Hardware CPU cycles" event is not supported in some contexts, for example in VMs.
-            // Try a different event type.
+// The "Hardware CPU cycles" event is not supported in some contexts, for example in VMs.
+// Try a different event type.
             let perf = PerfGroup::open(
                 pid,
                 frequency,


### PR DESCRIPTION
In some setups, like running in an EKS cluster, currently there's a false negative where the profiler exits before trying SwCpuClock because it sees that the `perf_event_paranoid` level is set to 2. However, if the binary has been given correct capability (CAP_PERFMON), the paranoia level doesn't really matter.

This patch fixes it to only check the paranoia level and error if we fail to run with both Hardware and Software CPU Clock events.