### PR TITLE
Fix --all-features build

### DIFF
--- a/samply-symbols/src/shared.rs
+++ b/samply-symbols/src/shared.rs
@@ -1,5 +1,3 @@
-#[cfg(feature = "partial_read_stats")]
-use std::cell::RefCell;
 use std::fmt::{Debug, Display};
 use std::future::Future;
 use std::marker::PhantomData;
@@ -624,7 +622,7 @@ impl FileReadStats {
             }
             self.read_call_count += 1;
         }
-        chunkbits.set_all(true);
+        chunkbits.fill(true);
     }
 
     pub fn unique_bytes_read(&self) -> u64 {
@@ -744,7 +742,7 @@ impl<T: FileContents> FileContentsWrapper<T> {
 #[cfg(feature = "partial_read_stats")]
 impl<T: FileContents> Drop for FileContentsWrapper<T> {
     fn drop(&mut self) {
-        eprintln!("{}", self.partial_read_stats.lock());
+        eprintln!("{}", *self.partial_read_stats.lock().unwrap());
     }
 }
 

--- a/tools/dump_table/src/lib.rs
+++ b/tools/dump_table/src/lib.rs
@@ -120,7 +120,7 @@ type FileContentsType = samply_symbols::FileContentsWithChunkedCaching<MmapFileC
 
 #[cfg(feature = "chunked_caching")]
 fn mmap_to_file_contents(mmap: memmap2::Mmap) -> FileContentsType {
-    samply_symbols::FileContentsWithChunkedCaching::new(mmap.len() as u64, MmapFileContents(mmap))
+    samply_symbols::FileContentsWithChunkedCaching::new(mmap.len(), MmapFileContents(mmap))
 }
 
 #[cfg(not(feature = "chunked_caching"))]


### PR DESCRIPTION
I have rust-analyzer set up to use `--all-features` by default, and so do a lot of my Cargo command aliases.

Fix the build for `--all-features`.