### PR TITLE
feat: add `--share` flag to upload profiles to profiler.firefox.com

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -383,6 +383,16 @@ checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
 
 [[package]]
 name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -575,6 +585,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "enum-as-inner"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -688,6 +707,21 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -1060,6 +1094,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1077,9 +1127,11 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -1468,6 +1520,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1503,6 +1561,23 @@ checksum = "fbeff6bd154a309b2ada5639b2661ca6ae4599b34e8487dc276d2cd637da2d76"
 dependencies = [
  "bitflags",
  "itoa",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -1628,6 +1703,50 @@ dependencies = [
  "bstr",
  "normpath",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "openssl"
+version = "0.10.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfe4646e360ec77dff7dde40ed3d6c5fee52d156ef4a62f53973d38294dad87f"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.113"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad2f2c0eba47118757e4c6d2bff2838f3e0523380021356e7875e858372ce644"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -2102,17 +2221,22 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
+ "encoding_rs",
  "futures-channel",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
  "hyper-rustls",
+ "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
+ "mime",
+ "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -2123,6 +2247,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
  "tower",
@@ -2293,6 +2418,7 @@ dependencies = [
 name = "samply"
 version = "0.13.1"
 dependencies = [
+ "base64",
  "bitflags",
  "byteorder",
  "cfg-if",
@@ -2334,6 +2460,7 @@ dependencies = [
  "plist",
  "rand 0.10.1",
  "rangemap",
+ "reqwest",
  "runas",
  "rustc-hash",
  "samply-debugid",
@@ -2454,6 +2581,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a4416eddc0eaf31e04aa4039bd3db4288ea1ba613955d86cf9c310049c5d1e2"
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "schnellru"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2475,6 +2611,19 @@ name = "scroll"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ab8598aa408498679922eff7fa985c25d58a90771bd6be794434c5277eab1a6"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
 
 [[package]]
 name = "security-framework-sys"
@@ -2673,6 +2822,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2822,6 +2992,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]
@@ -3029,11 +3209,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -3042,7 +3222,7 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -3203,7 +3383,7 @@ version = "0.8.1"
 dependencies = [
  "async-compression",
  "bytes",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "debugid",
  "flate2",
@@ -3307,8 +3487,8 @@ dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-link 0.1.3",
- "windows-result",
- "windows-strings",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]
@@ -3367,6 +3547,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3376,12 +3567,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "windows-strings"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -3641,6 +3850,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"

--- a/samply/Cargo.toml
+++ b/samply/Cargo.toml
@@ -56,6 +56,8 @@ samply-debugid = { version = "0.1.0", path = "../samply-debugid" }
 samply-quota-manager = { version = "0.1.0", path = "../samply-quota-manager" }
 samply-object = { version = "0.1.0", path = "../samply-object" }
 indexmap = "2.9.0"
+reqwest = { version = "0.12", features = ["blocking"] }
+base64 = "0.22"
 
 [target.'cfg(any(target_os = "android", target_os = "macos", target_os = "linux"))'.dependencies]
 

--- a/samply/src/cli.rs
+++ b/samply/src/cli.rs
@@ -73,6 +73,10 @@ pub struct LoadArgs {
     /// Path to the file that should be loaded.
     pub file: PathBuf,
 
+    /// Upload the profile to profiler.firefox.com and print a shareable URL.
+    #[arg(long)]
+    pub share: bool,
+
     #[command(flatten)]
     pub server_args: ServerArgs,
 
@@ -94,6 +98,10 @@ pub struct ImportArgs {
     /// Do not run a local server after recording.
     #[arg(short, long)]
     pub save_only: bool,
+
+    /// Upload the profile to profiler.firefox.com and print a shareable URL.
+    #[arg(long)]
+    pub share: bool,
 
     /// Output filename.
     #[arg(short, long, default_value = "profile.json.gz")]
@@ -151,6 +159,10 @@ pub struct RecordArgs {
     /// Do not run a local server after recording.
     #[arg(short, long)]
     pub save_only: bool,
+
+    /// Upload the profile to profiler.firefox.com and print a shareable URL.
+    #[arg(long)]
+    pub share: bool,
 
     /// Output filename.
     #[arg(short, long, default_value = "profile.json.gz")]

--- a/samply/src/main.rs
+++ b/samply/src/main.rs
@@ -37,6 +37,7 @@ use profile_json_preparse::parse_libinfo_map_from_profile_file;
 use server::{start_server, RunningServerInfo, ServerProps};
 use shared::prop_types::{ImportProps, SymbolProps};
 use shared::save_profile::save_profile_to_file;
+use shared::share::upload_profile;
 use symbols::create_symbol_manager_and_quota_manager;
 
 fn main() {
@@ -67,6 +68,23 @@ fn main() {
 }
 
 fn do_load_action(load_args: cli::LoadArgs) {
+    if load_args.share {
+        match upload_profile(&load_args.file) {
+            Ok(url) => {
+                eprintln!("Profile shared successfully!");
+                eprintln!("View it at: {url}");
+                if !load_args.server_args.no_open {
+                    let _ = opener::open_browser(&url);
+                }
+                return;
+            }
+            Err(err) => {
+                eprintln!("Failed to share profile: {err}");
+                std::process::exit(1);
+            }
+        }
+    }
+
     run_server_serving_profile(
         &load_args.file,
         load_args.server_props(),
@@ -102,6 +120,23 @@ fn do_import_action(import_args: cli::ImportArgs) {
 
     // Drop the profile so that it doesn't take up memory while the server is running.
     drop(profile);
+
+    if import_args.share {
+        match upload_profile(&import_args.output) {
+            Ok(url) => {
+                eprintln!("Profile shared successfully!");
+                eprintln!("View it at: {url}");
+                if !import_args.server_args.no_open {
+                    let _ = opener::open_browser(&url);
+                }
+                return;
+            }
+            Err(err) => {
+                eprintln!("Failed to share profile: {err}");
+                std::process::exit(1);
+            }
+        }
+    }
 
     if let Some(server_props) = import_args.server_props() {
         run_server_serving_profile(
@@ -147,6 +182,23 @@ fn do_record_action(record_args: cli::RecordArgs) {
 
     // Drop the profile so that it doesn't take up memory while the server is running.
     drop(profile);
+
+    if record_args.share {
+        match upload_profile(&record_args.output) {
+            Ok(url) => {
+                eprintln!("Profile shared successfully!");
+                eprintln!("View it at: {url}");
+                if !record_args.server_args.no_open {
+                    let _ = opener::open_browser(&url);
+                }
+                std::process::exit(exit_status.code().unwrap_or(0));
+            }
+            Err(err) => {
+                eprintln!("Failed to share profile: {err}");
+                std::process::exit(1);
+            }
+        }
+    }
 
     // then fire up the server for the profiler front end, if not save-only
     if let Some(server_props) = record_args.server_props() {

--- a/samply/src/shared/mod.rs
+++ b/samply/src/shared/mod.rs
@@ -15,6 +15,7 @@ pub mod process_sample_data;
 pub mod prop_types;
 pub mod recycling;
 pub mod save_profile;
+pub mod share;
 pub mod stack_converter;
 pub mod stack_depth_limiting_frame_iter;
 pub mod symbol_manager_observer;

--- a/samply/src/shared/share.rs
+++ b/samply/src/shared/share.rs
@@ -1,0 +1,109 @@
+use std::io::Write;
+use std::path::Path;
+
+use base64::prelude::*;
+use flate2::write::GzEncoder;
+use flate2::Compression;
+
+const PROFILER_API_URL: &str = "https://api.profiler.firefox.com/compressed-store";
+const PROFILER_VIEW_URL: &str = "https://profiler.firefox.com/public/";
+
+/// Uploads a profile to profiler.firefox.com and returns a shareable URL.
+///
+/// See https://github.com/firefox-devtools/profiler/blob/main/docs-developer/loading-in-profiles.md
+pub fn upload_profile(profile_path: &Path) -> Result<String, ShareError> {
+    let file_data = std::fs::read(profile_path).map_err(ShareError::ReadFile)?;
+
+    let compressed_data = if is_gzipped(&file_data) {
+        file_data
+    } else {
+        gzip_compress(&file_data)?
+    };
+
+    eprintln!("Uploading profile...");
+
+    let client = reqwest::blocking::Client::new();
+    let response = client
+        .post(PROFILER_API_URL)
+        .header(
+            "Accept",
+            "application/vnd.firefox-profiler+json;version=1.0",
+        )
+        .body(compressed_data)
+        .send()
+        .map_err(ShareError::Upload)?;
+
+    if !response.status().is_success() {
+        return Err(ShareError::UploadFailed(response.status().to_string()));
+    }
+
+    let jwt = response.text().map_err(ShareError::ReadResponse)?;
+    let token = decode_jwt_payload(&jwt)?;
+    let url = format!("{}{}", PROFILER_VIEW_URL, token);
+
+    Ok(url)
+}
+
+/// Returns `true` if the payload starts with gzip magic bytes 0x1f8b.
+fn is_gzipped(data: &[u8]) -> bool {
+    data.len() >= 2 && data[0] == 0x1f && data[1] == 0x8b
+}
+
+/// Compresses a payload with gzip.
+fn gzip_compress(data: &[u8]) -> Result<Vec<u8>, ShareError> {
+    let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+    encoder.write_all(data).map_err(ShareError::Compress)?;
+    encoder.finish().map_err(ShareError::Compress)
+}
+
+/// Decodes JWT payload returned from upload the profile to [`PROFILER_API_URL`].
+///
+/// Returns the profile token that can be used to view the profile with [`PROFILER_VIEW_URL`].
+fn decode_jwt_payload(jwt: &str) -> Result<String, ShareError> {
+    let parts: Vec<&str> = jwt.trim().split('.').collect();
+    if parts.len() != 3 {
+        return Err(ShareError::InvalidJwt("expected 3 parts".to_string()));
+    }
+
+    let payload = parts[1];
+    let decoded = BASE64_URL_SAFE_NO_PAD
+        .decode(payload)
+        .or_else(|_| BASE64_STANDARD.decode(payload))
+        .map_err(|e| ShareError::InvalidJwt(format!("base64 decode failed: {e}")))?;
+
+    let payload_str =
+        String::from_utf8(decoded).map_err(|e| ShareError::InvalidJwt(format!("utf8: {e}")))?;
+
+    let json: serde_json::Value = serde_json::from_str(&payload_str)
+        .map_err(|e| ShareError::InvalidJwt(format!("json parse: {e}")))?;
+
+    json.get("profileToken")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+        .ok_or_else(|| ShareError::InvalidJwt("missing profileToken field".to_string()))
+}
+
+#[derive(Debug)]
+pub enum ShareError {
+    ReadFile(std::io::Error),
+    Compress(std::io::Error),
+    Upload(reqwest::Error),
+    UploadFailed(String),
+    ReadResponse(reqwest::Error),
+    InvalidJwt(String),
+}
+
+impl std::fmt::Display for ShareError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ShareError::ReadFile(e) => write!(f, "failed to read profile file: {e}"),
+            ShareError::Compress(e) => write!(f, "failed to compress profile: {e}"),
+            ShareError::Upload(e) => write!(f, "failed to upload profile: {e}"),
+            ShareError::UploadFailed(status) => {
+                write!(f, "profile upload failed with status: {status}")
+            }
+            ShareError::ReadResponse(e) => write!(f, "failed to read upload response: {e}"),
+            ShareError::InvalidJwt(msg) => write!(f, "invalid JWT response: {msg}"),
+        }
+    }
+}


### PR DESCRIPTION
## Description

Upload gzipped profile to Firefox Profiler API and return shareable URL. Opens browser automatically unless `--no-open` is passed.

Note that only runs with `--presymbolicate` will include symbols in the uploaded profile. @mstange I wonder if we should only allow to run with `--share` when `--presymbolicate` is provided, or just log a warning when it's not?

Instructions for uploading profiles: https://github.com/firefox-devtools/profiler/blob/main/docs-developer/loading-in-profiles.md

## Example

<img width="627" height="334" alt="image" src="https://github.com/user-attachments/assets/743fb79b-a6dc-4f8d-9f92-a031ad010d0e" />


Profile from the screenshot: https://share.firefox.dev/4aaiOFM