### PR TITLE
Update profile format to version 60.

### DIFF
--- a/fxprof-processed-profile/README.md
+++ b/fxprof-processed-profile/README.md
@@ -28,12 +28,12 @@ let thread = profile.add_thread(process, 54132000, Timestamp::from_millis_since_
 profile.set_thread_name(thread, "Main thread");
 
 let root_node_string = profile.handle_for_string("Root node");
-let root_frame = profile.handle_for_frame_with_label(thread, root_node_string, CategoryHandle::OTHER, FrameFlags::empty());
+let root_frame = profile.handle_for_frame_with_label(root_node_string, CategoryHandle::OTHER, FrameFlags::empty());
 let first_callee_string = profile.handle_for_string("First callee");
-let first_callee_frame = profile.handle_for_frame_with_label(thread, first_callee_string, CategoryHandle::OTHER, FrameFlags::empty());
+let first_callee_frame = profile.handle_for_frame_with_label(first_callee_string, CategoryHandle::OTHER, FrameFlags::empty());
 
-let root_stack_node = profile.handle_for_stack(thread, root_frame, None);
-let first_callee_node = profile.handle_for_stack(thread, first_callee_frame, Some(root_stack_node));
+let root_stack_node = profile.handle_for_stack(root_frame, None);
+let first_callee_node = profile.handle_for_stack(first_callee_frame, Some(root_stack_node));
 profile.add_sample(thread, Timestamp::from_millis_since_reference(0.0), Some(first_callee_node), CpuDelta::ZERO, 1);
 
 let writer = std::io::BufWriter::new(output_file);

--- a/fxprof-processed-profile/src/frame.rs
+++ b/fxprof-processed-profile/src/frame.rs
@@ -1,6 +1,6 @@
 use bitflags::bitflags;
 
-use crate::global_lib_table::LibraryHandle;
+use crate::{global_lib_table::LibraryHandle, ProcessHandle};
 
 /// The address information of a stack frame.
 #[derive(Debug, Clone, PartialOrd, Ord, PartialEq, Eq)]
@@ -10,13 +10,13 @@ pub enum FrameAddress {
     /// This code address will be resolved to a library-relative address using
     /// the library mappings on the process which were specified using
     /// [`Profile::add_lib_mapping`](crate::Profile::add_lib_mapping).
-    InstructionPointer(u64),
+    InstructionPointer(ProcessHandle, u64),
     /// A code address taken from a return address
     ///
     /// This code address will be resolved to a library-relative address using
     /// the library mappings on the process which were specified using
     /// [`Profile::add_lib_mapping`](crate::Profile::add_lib_mapping).
-    ReturnAddress(u64),
+    ReturnAddress(ProcessHandle, u64),
     /// A code address taken from a return address, but adjusted so that it
     /// points into the previous instruction. Usually this is "return address
     /// minus one byte", but some unwinders subtract 2 or 4 bytes if they know
@@ -33,7 +33,12 @@ pub enum FrameAddress {
     /// This code address will be resolved to a library-relative address using
     /// the library mappings on the process which were specified using
     /// [`Profile::add_lib_mapping`](crate::Profile::add_lib_mapping).
-    AdjustedReturnAddress(u64),
+    AdjustedReturnAddress(ProcessHandle, u64),
+
+    KernelInstructionPointer(u64),
+    KernelReturnAddress(u64),
+    KernelAdjustedReturnAddress(u64),
+
     /// A relative address taken from the instruction pointer which
     /// has already been resolved to a `LibraryHandle`.
     RelativeAddressFromInstructionPointer(LibraryHandle, u32),

--- a/fxprof-processed-profile/src/frame_table.rs
+++ b/fxprof-processed-profile/src/frame_table.rs
@@ -8,8 +8,9 @@ use crate::global_lib_table::{GlobalLibIndex, UsedLibraryAddressesCollector};
 use crate::native_symbols::NativeSymbolIndex;
 use crate::resource_table::ResourceTable;
 use crate::serialization_helpers::SerializableSingleValueColumn;
+use crate::source_table::{SourceKey, SourceTable};
 use crate::string_table::StringHandle;
-use crate::SourceLocation;
+use crate::{FrameHandle, SourceLocation};
 
 #[derive(Debug, Clone, Default)]
 pub struct FrameInterner {
@@ -22,7 +23,7 @@ impl FrameInterner {
         Default::default()
     }
 
-    pub fn index_for_frame(&mut self, frame: InternalFrame) -> usize {
+    pub fn index_for_frame(&mut self, frame: InternalFrame) -> FrameHandle {
         let (frame_index, is_new) = self.frame_key_set.insert_full(frame);
 
         if is_new
@@ -32,7 +33,7 @@ impl FrameInterner {
         {
             self.contains_js_frame = true;
         }
-        frame_index
+        FrameHandle(frame_index)
     }
 
     pub fn gather_used_rvas(&self, collector: &mut UsedLibraryAddressesCollector) {
@@ -56,7 +57,7 @@ impl FrameInterner {
         self.contains_js_frame
     }
 
-    pub fn create_tables(&self) -> (FrameTable, FuncTable, ResourceTable) {
+    pub fn create_tables(&self) -> (FrameTable, FuncTable, SourceTable, ResourceTable) {
         let len = self.frame_key_set.len();
         let mut func_col = Vec::with_capacity(len);
         let mut category_col = Vec::with_capacity(len);
@@ -69,9 +70,10 @@ impl FrameInterner {
 
         let mut func_table = FuncTable::default();
         let mut resource_table = ResourceTable::default();
+        let mut source_table = SourceTable::default();
 
         for frame in &self.frame_key_set {
-            let func_key = frame.func_key();
+            let func_key = frame.func_key(&mut source_table);
             let func = func_table.index_for_func(func_key, &mut resource_table);
 
             func_col.push(func);
@@ -111,7 +113,7 @@ impl FrameInterner {
             inline_depth_col,
         };
 
-        (frame_table, func_table, resource_table)
+        (frame_table, func_table, source_table, resource_table)
     }
 }
 
@@ -186,7 +188,7 @@ pub enum InternalFrameVariant {
 }
 
 impl InternalFrame {
-    pub fn func_key(&self) -> FuncKey {
+    pub fn func_key(&self, source_table: &mut SourceTable) -> FuncKey {
         let InternalFrame {
             name,
             variant,
@@ -194,13 +196,22 @@ impl InternalFrame {
             ..
         } = *self;
         let file_path = self.source_location.file_path;
+        let source = file_path.map(|file_path| {
+            source_table.index_for_source(SourceKey {
+                id: None,
+                file_path,
+                start_line: 1,
+                start_column: 1,
+                source_map_url: None,
+            })
+        });
         let lib = match variant {
             InternalFrameVariant::Label => None,
             InternalFrameVariant::Native(NativeFrameData { lib, .. }) => Some(lib),
         };
         FuncKey {
             name,
-            file_path,
+            source,
             lib,
             flags,
         }

--- a/fxprof-processed-profile/src/func_table.rs
+++ b/fxprof-processed-profile/src/func_table.rs
@@ -5,14 +5,15 @@ use crate::frame::FrameFlags;
 use crate::global_lib_table::GlobalLibIndex;
 use crate::resource_table::{ResourceIndex, ResourceTable};
 use crate::serialization_helpers::SerializableSingleValueColumn;
+use crate::source_table::SourceIndex;
 use crate::string_table::StringHandle;
 
 #[derive(Debug, Clone, Default)]
 pub struct FuncTable {
-    names: Vec<StringHandle>,
-    files: Vec<Option<StringHandle>>,
-    resources: Vec<Option<ResourceIndex>>,
-    flags: Vec<FrameFlags>,
+    name_col: Vec<StringHandle>,
+    source_col: Vec<Option<SourceIndex>>,
+    resource_col: Vec<Option<ResourceIndex>>,
+    flags_col: Vec<FrameFlags>,
 
     func_key_set: FastIndexSet<FuncKey>,
 }
@@ -20,7 +21,7 @@ pub struct FuncTable {
 #[derive(Debug, Clone, Copy, PartialOrd, Ord, PartialEq, Eq, Hash)]
 pub struct FuncKey {
     pub name: StringHandle,
-    pub file_path: Option<StringHandle>,
+    pub source: Option<SourceIndex>,
     pub lib: Option<GlobalLibIndex>,
     pub flags: FrameFlags,
 }
@@ -40,17 +41,17 @@ impl FuncTable {
 
         let FuncKey {
             name,
-            file_path,
+            source,
             lib,
             flags,
         } = func_key;
 
         let resource = lib.map(|lib| resource_table.resource_for_lib(lib));
 
-        self.names.push(name);
-        self.files.push(file_path);
-        self.resources.push(resource);
-        self.flags.push(flags);
+        self.name_col.push(name);
+        self.source_col.push(source);
+        self.resource_col.push(resource);
+        self.flags_col.push(flags);
 
         func_index
     }
@@ -67,23 +68,23 @@ impl Serialize for FuncIndex {
 
 impl Serialize for FuncTable {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let len = self.names.len();
+        let len = self.name_col.len();
         let mut map = serializer.serialize_map(None)?;
         map.serialize_entry("length", &len)?;
-        map.serialize_entry("name", &self.names)?;
+        map.serialize_entry("name", &self.name_col)?;
         map.serialize_entry(
             "isJS",
-            &SerializableFlagColumn(&self.flags, FrameFlags::IS_JS),
+            &SerializableFlagColumn(&self.flags_col, FrameFlags::IS_JS),
         )?;
         map.serialize_entry(
             "relevantForJS",
-            &SerializableFlagColumn(&self.flags, FrameFlags::IS_RELEVANT_FOR_JS),
+            &SerializableFlagColumn(&self.flags_col, FrameFlags::IS_RELEVANT_FOR_JS),
         )?;
         map.serialize_entry(
             "resource",
-            &SerializableFuncTableResourceColumn(&self.resources),
+            &SerializableFuncTableResourceColumn(&self.resource_col),
         )?;
-        map.serialize_entry("fileName", &self.files)?;
+        map.serialize_entry("source", &self.source_col)?;
         map.serialize_entry("lineNumber", &SerializableSingleValueColumn((), len))?;
         map.serialize_entry("columnNumber", &SerializableSingleValueColumn((), len))?;
         map.end()

--- a/fxprof-processed-profile/src/lib.rs
+++ b/fxprof-processed-profile/src/lib.rs
@@ -27,12 +27,12 @@
 //! profile.set_thread_name(thread, "Main thread");
 //!
 //! let root_node_string = profile.handle_for_string("Root node");
-//! let root_frame = profile.handle_for_frame_with_label(thread, root_node_string, CategoryHandle::OTHER, FrameFlags::empty());
+//! let root_frame = profile.handle_for_frame_with_label(root_node_string, CategoryHandle::OTHER, FrameFlags::empty());
 //! let first_callee_string = profile.handle_for_string("First callee");
-//! let first_callee_frame = profile.handle_for_frame_with_label(thread, first_callee_string, CategoryHandle::OTHER, FrameFlags::empty());
+//! let first_callee_frame = profile.handle_for_frame_with_label(first_callee_string, CategoryHandle::OTHER, FrameFlags::empty());
 //!
-//! let root_stack_node = profile.handle_for_stack(thread, root_frame, None);
-//! let first_callee_node = profile.handle_for_stack(thread, first_callee_frame, Some(root_stack_node));
+//! let root_stack_node = profile.handle_for_stack(root_frame, None);
+//! let first_callee_node = profile.handle_for_stack(first_callee_frame, Some(root_stack_node));
 //! profile.add_sample(thread, Timestamp::from_millis_since_reference(0.0), Some(first_callee_node), CpuDelta::ZERO, 1);
 //!
 //! let writer = std::io::BufWriter::new(output_file);
@@ -59,11 +59,13 @@ mod markers;
 mod native_symbols;
 mod process;
 mod profile;
+mod profile_shared_data;
 mod profile_symbol_info;
 mod reference_timestamp;
 mod resource_table;
 mod sample_table;
 mod serialization_helpers;
+mod source_table;
 mod stack_table;
 mod string_table;
 mod symbolication;

--- a/fxprof-processed-profile/src/marker_table.rs
+++ b/fxprof-processed-profile/src/marker_table.rs
@@ -5,7 +5,7 @@ use crate::serialization_helpers::SerializableOptionalTimestampColumn;
 use crate::string_table::{ProfileStringTable, StringHandle};
 use crate::{
     CategoryHandle, DynamicSchemaMarker, DynamicSchemaMarkerFieldFormat, MarkerHandle,
-    MarkerStringFieldFormat, MarkerTiming, MarkerTypeHandle, Timestamp,
+    MarkerStringFieldFormat, MarkerTiming, MarkerTypeHandle, StackHandle, Timestamp,
 };
 
 #[derive(Debug, Clone, Default)]
@@ -16,7 +16,7 @@ pub struct MarkerTable {
     marker_ends: Vec<Option<Timestamp>>,
     marker_phases: Vec<Phase>,
     marker_type_handles: Vec<MarkerTypeHandle>,
-    marker_stacks: Vec<Option<usize>>,
+    marker_stacks: Vec<Option<StackHandle>>,
     /// The field values for any marker fields of [kind](`MarkerFieldFormat::kind`) [`MarkerFieldFormatKind::Number`].
     ///
     /// This Vec can contain zero or more values per marker, depending on the marker's
@@ -93,15 +93,18 @@ impl MarkerTable {
         MarkerHandle(self.marker_categories.len() - 1)
     }
 
-    pub fn set_marker_stack(&mut self, marker: MarkerHandle, stack_index: Option<usize>) {
+    pub fn set_marker_stack(&mut self, marker: MarkerHandle, stack_index: Option<StackHandle>) {
         self.marker_stacks[marker.0] = stack_index;
     }
 
-    pub fn with_remapped_stacks(mut self, old_stack_to_new_stack: &[Option<usize>]) -> Self {
+    pub fn with_remapped_stacks(mut self, old_stack_to_new_stack: &[Option<StackHandle>]) -> Self {
         self.marker_stacks = self
             .marker_stacks
             .into_iter()
-            .map(|stack| stack.and_then(|s| old_stack_to_new_stack[s]))
+            .map(|stack| match stack {
+                Some(s) => old_stack_to_new_stack[s.0],
+                None => None,
+            })
             .collect();
         self
     }
@@ -211,7 +214,7 @@ impl Serialize for SerializableMarkerTableDataColumn<'_> {
 
 struct SerializableMarkerDataElement<'a> {
     string_table: &'a ProfileStringTable,
-    stack_index: Option<usize>,
+    stack_index: Option<StackHandle>,
     schema: &'a InternalMarkerSchema,
     string_fields: &'a [StringHandle],
     number_fields: &'a [f64],
@@ -262,7 +265,7 @@ impl Serialize for SerializableMarkerDataElement<'_> {
     }
 }
 
-struct SerializableMarkerCause(usize);
+struct SerializableMarkerCause(StackHandle);
 impl Serialize for SerializableMarkerCause {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let mut map = serializer.serialize_map(Some(1))?;

--- a/fxprof-processed-profile/src/native_symbols.rs
+++ b/fxprof-processed-profile/src/native_symbols.rs
@@ -4,7 +4,6 @@ use crate::fast_hash_map::{FastHashMap, FastHashSet};
 use crate::global_lib_table::GlobalLibIndex;
 use crate::library_info::Symbol;
 use crate::string_table::{ProfileStringTable, StringHandle};
-use crate::ThreadHandle;
 
 /// Represents a symbol from the symbol table of a library. Obtained from [`Profile::handle_for_native_symbol`](crate::Profile::handle_for_native_symbol).
 ///
@@ -35,7 +34,7 @@ use crate::ThreadHandle;
 ///   and line numbers, if this information is known.
 /// - The frame for A has inline depth 0 and the frame for B has inline depth 1.
 #[derive(Debug, Clone, Copy, PartialOrd, Ord, PartialEq, Eq, Hash)]
-pub struct NativeSymbolHandle(pub(crate) ThreadHandle, pub(crate) NativeSymbolIndex);
+pub struct NativeSymbolHandle(pub(crate) NativeSymbolIndex);
 
 /// The native symbols that are used by frames in a thread's `FrameTable`.
 /// They can be from different libraries. Only used symbols are included.

--- a/fxprof-processed-profile/src/profile.rs
+++ b/fxprof-processed-profile/src/profile.rs
@@ -27,11 +27,11 @@ use crate::markers::{
 };
 use crate::native_symbols::NativeSymbolHandle;
 use crate::process::{Process, ThreadHandle};
+use crate::profile_shared_data::ProfileSharedData;
 use crate::profile_symbol_info::{LibSymbolInfo, ProfileSymbolInfo};
 use crate::reference_timestamp::ReferenceTimestamp;
 use crate::sample_table::WeightType;
 use crate::string_table::{ProfileStringTable, StringHandle};
-use crate::symbolication::StringTableAdapter;
 use crate::thread::{ProcessHandle, Thread};
 use crate::timestamp::Timestamp;
 use crate::{FrameFlags, PlatformSpecificReferenceTimestamp, Symbol};
@@ -89,11 +89,23 @@ impl From<Duration> for SamplingInterval {
 /// [`Profile::handle_for_frame_with_label`], [`Profile::handle_for_frame_with_address`],
 /// and so on.
 #[derive(Debug, Clone, Copy, PartialOrd, Ord, PartialEq, Eq, Hash)]
-pub struct FrameHandle(ThreadHandle, usize);
+pub struct FrameHandle(pub(crate) usize);
+
+impl Serialize for FrameHandle {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.0.serialize(serializer)
+    }
+}
 
 /// A handle to a stack, specific to a thread. Can be created with [`Profile::handle_for_stack`](crate::Profile::handle_for_stack).
 #[derive(Debug, Clone, Copy, PartialOrd, Ord, PartialEq, Eq, Hash)]
-pub struct StackHandle(ThreadHandle, usize);
+pub struct StackHandle(pub(crate) usize);
+
+impl Serialize for StackHandle {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.0.serialize(serializer)
+    }
+}
 
 /// Symbol information about a frame address.
 ///
@@ -152,12 +164,12 @@ pub enum TimelineUnit {
 /// profile.set_thread_name(thread, "Main thread");
 ///
 /// let root_node_string = profile.handle_for_string("Root node");
-/// let root_frame = profile.handle_for_frame_with_label(thread, root_node_string, CategoryHandle::OTHER, FrameFlags::empty());
+/// let root_frame = profile.handle_for_frame_with_label(root_node_string, CategoryHandle::OTHER, FrameFlags::empty());
 /// let first_callee_string = profile.handle_for_string("First callee");
-/// let first_callee_frame = profile.handle_for_frame_with_label(thread, first_callee_string, CategoryHandle::OTHER, FrameFlags::empty());
+/// let first_callee_frame = profile.handle_for_frame_with_label(first_callee_string, CategoryHandle::OTHER, FrameFlags::empty());
 ///
-/// let root_stack_node = profile.handle_for_stack(thread, root_frame, None);
-/// let first_callee_node = profile.handle_for_stack(thread, first_callee_frame, Some(root_stack_node));
+/// let root_stack_node = profile.handle_for_stack(root_frame, None);
+/// let first_callee_node = profile.handle_for_stack(first_callee_frame, Some(root_stack_node));
 /// profile.add_sample(thread, Timestamp::from_millis_since_reference(0.0), Some(first_callee_node), CpuDelta::ZERO, 1);
 ///
 /// let writer = std::io::BufWriter::new(output_file);
@@ -181,7 +193,7 @@ pub struct Profile {
     pub(crate) initial_selected_threads: Vec<ThreadHandle>,
     pub(crate) reference_timestamp: ReferenceTimestamp,
     pub(crate) platform_specific_reference_timestamp: Option<PlatformSpecificReferenceTimestamp>,
-    pub(crate) string_table: ProfileStringTable,
+    shared_data: ProfileSharedData,
     pub(crate) marker_schemas: Vec<InternalMarkerSchema>,
     static_schema_marker_types: FastHashMap<&'static str, MarkerTypeHandle>,
     pub(crate) symbolicated: bool,
@@ -216,7 +228,7 @@ impl Profile {
             reference_timestamp,
             platform_specific_reference_timestamp: None,
             processes: Vec::new(),
-            string_table: ProfileStringTable::new(),
+            shared_data: ProfileSharedData::new(),
             marker_schemas: Vec::new(),
             categories,
             static_schema_marker_types: FastHashMap::default(),
@@ -558,7 +570,7 @@ impl Profile {
 
     /// Get or create the [`StringHandle`] for a string.
     pub fn handle_for_string(&mut self, s: &str) -> StringHandle {
-        self.string_table.index_for_string(s)
+        self.shared_data.string_table.index_for_string(s)
     }
 
     /// Look up the string for a string handle. This is sometimes useful when writing tests.
@@ -566,57 +578,50 @@ impl Profile {
     /// Panics if the handle wasn't found, which can happen if you pass a handle
     /// from a different Profile instance.
     pub fn get_string(&self, handle: StringHandle) -> &str {
-        self.string_table.get_string(handle)
+        self.shared_data.string_table.get_string(handle)
     }
 
     /// Get the [`FrameHandle`] for a label frame.
-    ///
-    /// The returned handle can only be used with this thread.
     pub fn handle_for_frame_with_label<SC: IntoSubcategoryHandle>(
         &mut self,
-        thread: ThreadHandle,
         label: StringHandle,
         subcategory: SC,
         flags: FrameFlags,
     ) -> FrameHandle {
         let subcategory = subcategory.into_subcategory_handle(self);
-        self.handle_for_frame_with_label_internal(thread, label, None, subcategory, flags)
+        self.handle_for_frame_with_label_internal(label, None, subcategory, flags)
     }
 
     /// Get the [`FrameHandle`] for an address-based stack frame.
-    ///
-    /// The returned handle can only be used with this thread.
     pub fn handle_for_frame_with_address<SC: IntoSubcategoryHandle>(
         &mut self,
-        thread: ThreadHandle,
         frame_address: FrameAddress,
         subcategory: SC,
         flags: FrameFlags,
     ) -> FrameHandle {
         let subcategory = subcategory.into_subcategory_handle(self);
-        self.handle_for_frame_with_address_internal(thread, frame_address, subcategory, flags)
+        self.handle_for_frame_with_address_internal(frame_address, subcategory, flags)
     }
 
     fn handle_for_frame_with_address_internal(
         &mut self,
-        thread: ThreadHandle,
         frame_address: FrameAddress,
         subcategory: SubcategoryHandle,
         flags: FrameFlags,
     ) -> FrameHandle {
-        let thread_handle = thread;
-        let thread = &mut self.threads[thread_handle.0];
-        let process = &mut self.processes[thread.process().0];
         let address = Self::resolve_frame_address(
-            process,
             frame_address,
+            &mut self.processes,
             &mut self.global_libs,
             &mut self.kernel_libs,
-            &mut self.string_table,
+            &mut self.shared_data.string_table,
         );
         let (variant, name) = match address {
             InternalFrameAddress::Unknown(address) => {
-                let name = self.string_table.index_for_hex_address_string(address);
+                let name = self
+                    .shared_data
+                    .string_table
+                    .index_for_hex_address_string(address);
                 (InternalFrameVariant::Label, name)
             }
             InternalFrameAddress::InLib(address, lib_index) => {
@@ -624,16 +629,14 @@ impl Profile {
                 let symbol = lib_symbol_table.and_then(|symbol_table| symbol_table.lookup(address));
                 let (native_symbol, name) = match symbol {
                     Some(symbol) => {
-                        let (native_symbol, name) = thread
-                            .native_symbol_index_and_string_index_for_symbol(
-                                lib_index,
-                                symbol,
-                                &mut self.string_table,
-                            );
+                        let (native_symbol, name) = self
+                            .shared_data
+                            .native_symbol_index_and_string_index_for_symbol(lib_index, symbol);
                         (Some(native_symbol), name)
                     }
                     None => {
                         let name = self
+                            .shared_data
                             .string_table
                             .index_for_hex_address_string(address.into());
                         (None, name)
@@ -655,8 +658,7 @@ impl Profile {
             name,
             source_location: Default::default(),
         };
-        let frame_index = thread.frame_index_for_frame(internal_frame);
-        FrameHandle(thread_handle, frame_index)
+        self.shared_data.frame_index_for_frame(internal_frame)
     }
 
     /// Get the [`FrameHandle`] for a label frame with source location information.
@@ -664,32 +666,22 @@ impl Profile {
     /// The returned handle can only be used with this thread.
     pub fn handle_for_frame_with_label_and_source_location<SC: IntoSubcategoryHandle>(
         &mut self,
-        thread: ThreadHandle,
         label: StringHandle,
         source_location: SourceLocation,
         subcategory: SC,
         flags: FrameFlags,
     ) -> FrameHandle {
         let subcategory = subcategory.into_subcategory_handle(self);
-        self.handle_for_frame_with_label_internal(
-            thread,
-            label,
-            Some(source_location),
-            subcategory,
-            flags,
-        )
+        self.handle_for_frame_with_label_internal(label, Some(source_location), subcategory, flags)
     }
 
     fn handle_for_frame_with_label_internal(
         &mut self,
-        thread: ThreadHandle,
         label: StringHandle,
         source_location: Option<SourceLocation>,
         subcategory: SubcategoryHandle,
         flags: FrameFlags,
     ) -> FrameHandle {
-        let thread_handle = thread;
-        let thread = &mut self.threads[thread_handle.0];
         let name = label;
         let source_location = source_location.unwrap_or_default();
         let internal_frame = InternalFrame {
@@ -699,8 +691,7 @@ impl Profile {
             source_location,
             flags,
         };
-        let frame_index = thread.frame_index_for_frame(internal_frame);
-        FrameHandle(thread_handle, frame_index)
+        self.shared_data.frame_index_for_frame(internal_frame)
     }
 
     /// Get the [`FrameHandle`] for an address-based stack frame with symbol information.
@@ -708,7 +699,6 @@ impl Profile {
     /// The returned handle can only be used with this thread.
     pub fn handle_for_frame_with_address_and_symbol<SC: IntoSubcategoryHandle>(
         &mut self,
-        thread: ThreadHandle,
         frame_address: FrameAddress,
         frame_symbol_info: FrameSymbolInfo,
         inline_depth: u16,
@@ -717,7 +707,6 @@ impl Profile {
     ) -> FrameHandle {
         let subcategory = subcategory.into_subcategory_handle(self);
         self.handle_for_frame_with_address_and_symbol_internal(
-            thread,
             frame_address,
             frame_symbol_info,
             inline_depth,
@@ -728,43 +717,42 @@ impl Profile {
 
     fn handle_for_frame_with_address_and_symbol_internal(
         &mut self,
-        thread: ThreadHandle,
         frame_address: FrameAddress,
         frame_symbol_info: FrameSymbolInfo,
         inline_depth: u16,
         subcategory: SubcategoryHandle,
         flags: FrameFlags,
     ) -> FrameHandle {
-        let thread_handle = thread;
         let FrameSymbolInfo {
             name,
             source_location,
             native_symbol,
         } = frame_symbol_info;
-        assert_eq!(native_symbol.0, thread_handle, "NativeSymbolHandle from wrong thread passed to Profile::handle_for_frame_with_address_and_symbol");
-        let native_symbol_index = native_symbol.1;
-        let thread = &mut self.threads[thread_handle.0];
-        let process = &mut self.processes[thread.process().0];
+        let native_symbol_index = native_symbol.0;
         let address = Self::resolve_frame_address(
-            process,
             frame_address,
+            &mut self.processes,
             &mut self.global_libs,
             &mut self.kernel_libs,
-            &mut self.string_table,
+            &mut self.shared_data.string_table,
         );
         let (variant, name) = match address {
             InternalFrameAddress::Unknown(addr) => {
-                let name =
-                    name.unwrap_or_else(|| self.string_table.index_for_hex_address_string(addr));
+                let name = name.unwrap_or_else(|| {
+                    self.shared_data
+                        .string_table
+                        .index_for_hex_address_string(addr)
+                });
                 (InternalFrameVariant::Label, name)
             }
             InternalFrameAddress::InLib(relative_address, lib) => {
-                let name =
-                    name.unwrap_or_else(|| thread.get_native_symbol_name(native_symbol_index));
+                let name = name.unwrap_or_else(|| {
+                    self.shared_data.get_native_symbol_name(native_symbol_index)
+                });
                 (
                     InternalFrameVariant::Native(NativeFrameData {
                         lib,
-                        native_symbol: Some(native_symbol.1),
+                        native_symbol: Some(native_symbol.0),
                         relative_address,
                         inline_depth,
                     }),
@@ -779,8 +767,7 @@ impl Profile {
             source_location,
             flags,
         };
-        let frame_index = thread.frame_index_for_frame(internal_frame);
-        FrameHandle(thread_handle, frame_index)
+        self.shared_data.frame_index_for_frame(internal_frame)
     }
 
     /// Get the [`NativeSymbolHandle`] for a native symbol, for use in [`FrameSymbolInfo`].
@@ -788,21 +775,16 @@ impl Profile {
     /// The returned handle can only be used with this thread.
     pub fn handle_for_native_symbol(
         &mut self,
-        thread: ThreadHandle,
         lib: LibraryHandle,
         symbol: &Symbol,
     ) -> NativeSymbolHandle {
-        let thread_handle = thread;
-        let thread = &mut self.threads[thread_handle.0];
         let global_lib_index = self
             .global_libs
-            .index_for_used_lib(lib, &mut self.string_table);
-        let native_symbol_index = thread.native_symbol_index_for_native_symbol(
-            global_lib_index,
-            symbol,
-            &mut self.string_table,
-        );
-        NativeSymbolHandle(thread_handle, native_symbol_index)
+            .index_for_used_lib(lib, &mut self.shared_data.string_table);
+        let native_symbol_index = self
+            .shared_data
+            .native_symbol_index_for_native_symbol(global_lib_index, symbol);
+        NativeSymbolHandle(native_symbol_index)
     }
 
     /// Get the [`StackHandle`] for a stack with the given `frame` and `parent`,
@@ -816,29 +798,10 @@ impl Profile {
     /// is the caller of the returned stack node.
     pub fn handle_for_stack(
         &mut self,
-        thread: ThreadHandle,
         frame: FrameHandle,
         parent: Option<StackHandle>,
     ) -> StackHandle {
-        let thread_handle = thread;
-        let prefix = match parent {
-            Some(StackHandle(parent_thread_handle, prefix_stack_index)) => {
-                assert_eq!(
-                    parent_thread_handle, thread_handle,
-                    "StackHandle from different thread passed to Profile::handle_for_stack"
-                );
-                Some(prefix_stack_index)
-            }
-            None => None,
-        };
-        let FrameHandle(frame_thread_handle, frame_index) = frame;
-        assert_eq!(
-            frame_thread_handle, thread_handle,
-            "FrameHandle from different thread passed to Profile::handle_for_stack"
-        );
-        let thread = &mut self.threads[thread.0];
-        let stack_index = thread.stack_index_for_stack(prefix, frame_index);
-        StackHandle(thread_handle, stack_index)
+        self.shared_data.stack_index_for_stack(parent, frame)
     }
 
     /// Get the [`StackHandle`] for a stack whose frames are given by an iterator function.
@@ -848,26 +811,15 @@ impl Profile {
     /// reference to this profile object so that the callback can create new frames.
     ///
     /// Returns `None` if the stack has zero frames.
-    pub fn handle_for_stack_frames<F>(
-        &mut self,
-        thread: ThreadHandle,
-        mut frames_iter: F,
-    ) -> Option<StackHandle>
+    pub fn handle_for_stack_frames<F>(&mut self, mut frames_iter: F) -> Option<StackHandle>
     where
         F: FnMut(&mut Profile) -> Option<FrameHandle>,
     {
-        let thread_handle = thread;
         let mut prefix = None;
         while let Some(frame_handle) = frames_iter(self) {
-            assert_eq!(
-                frame_handle.0, thread_handle,
-                "FrameHandle from different thread passed to Profile::handle_for_stack_frames"
-            );
-            let thread = &mut self.threads[thread_handle.0];
-            prefix = Some(thread.stack_index_for_stack(prefix, frame_handle.1));
+            prefix = Some(self.shared_data.stack_index_for_stack(prefix, frame_handle));
         }
-        let stack_index = prefix?;
-        Some(StackHandle(thread_handle, stack_index))
+        prefix
     }
 
     /// Add a sample to the given thread.
@@ -901,17 +853,7 @@ impl Profile {
         cpu_delta: CpuDelta,
         weight: i32,
     ) {
-        let stack_index = match stack {
-            Some(StackHandle(stack_thread_handle, stack_index)) => {
-                assert_eq!(
-                    stack_thread_handle, thread,
-                    "StackHandle from different thread passed to Profile::add_sample"
-                );
-                Some(stack_index)
-            }
-            None => None,
-        };
-        self.threads[thread.0].add_sample(timestamp, stack_index, cpu_delta, weight);
+        self.threads[thread.0].add_sample(timestamp, stack, cpu_delta, weight);
     }
 
     /// Add a sample with a CPU delta of zero. Internally, multiple consecutive
@@ -984,19 +926,9 @@ impl Profile {
         let Some(allocation_thread) = process.thread_handle_for_allocations() else {
             panic!("Profile::add_allocation_sample called for a thread whose process does not have a main thread");
         };
-        let stack_index = match stack {
-            Some(StackHandle(stack_thread, stack_index)) => {
-                assert_eq!(
-                    stack_thread, allocation_thread,
-                    "StackHandle from different thread passed to Profile::add_allocation_sample"
-                );
-                Some(stack_index)
-            }
-            None => None,
-        };
         self.threads[allocation_thread.0].add_allocation_sample(
             timestamp,
-            stack_index,
+            stack,
             allocation_address,
             allocation_size,
         );
@@ -1097,7 +1029,7 @@ impl Profile {
         let schema = &self.marker_schemas[marker_type.0];
         let thread_obj = &mut self.threads[thread.0];
         thread_obj.add_marker(
-            &mut self.string_table,
+            &mut self.shared_data.string_table,
             name,
             marker_type,
             schema,
@@ -1120,17 +1052,7 @@ impl Profile {
         marker: MarkerHandle,
         stack: Option<StackHandle>,
     ) {
-        let stack_index = match stack {
-            Some(StackHandle(stack_thread_handle, stack_index)) => {
-                assert_eq!(
-                    stack_thread_handle, thread,
-                    "StackHandle from different thread passed to Profile::add_sample"
-                );
-                Some(stack_index)
-            }
-            None => None,
-        };
-        self.threads[thread.0].set_marker_stack(marker, stack_index);
+        self.threads[thread.0].set_marker_stack(marker, stack);
     }
 
     /// Add a data point to a counter. For a memory counter, `value_delta` is the number
@@ -1166,9 +1088,7 @@ impl Profile {
     /// with it.
     pub fn native_frame_addresses_per_library(&self) -> Vec<(LibraryHandle, BTreeSet<u32>)> {
         let mut collector = self.global_libs.address_collector();
-        for thread in &self.threads {
-            thread.gather_used_rvas(&mut collector);
-        }
+        self.shared_data.gather_used_rvas(&mut collector);
         collector.finish(&self.global_libs)
     }
 
@@ -1245,7 +1165,7 @@ impl Profile {
             initial_selected_threads,
             reference_timestamp,
             platform_specific_reference_timestamp,
-            mut string_table,
+            shared_data,
             marker_schemas,
             static_schema_marker_types,
             symbolicated,
@@ -1253,10 +1173,11 @@ impl Profile {
             used_tids,
         } = self;
 
-        let mut strings = StringTableAdapter::new(symbol_string_table, &mut string_table);
+        let (shared_data, old_stack_to_new_stack) =
+            shared_data.make_symbolicated_shared(&libs, &lib_symbols, symbol_string_table);
         let threads: Vec<Thread> = threads
             .into_iter()
-            .map(|thread| thread.make_symbolicated_thread(&libs, &lib_symbols, &mut strings))
+            .map(|thread| thread.make_symbolicated_thread(&old_stack_to_new_stack))
             .collect();
 
         // TODO: Remove unused hex address strings from the string table.
@@ -1276,7 +1197,7 @@ impl Profile {
             initial_selected_threads,
             reference_timestamp,
             platform_specific_reference_timestamp,
-            string_table,
+            shared_data,
             marker_schemas,
             static_schema_marker_types,
             symbolicated,
@@ -1285,26 +1206,60 @@ impl Profile {
         }
     }
 
+    fn convert_kernel_address(
+        global_libs: &mut GlobalLibTable,
+        kernel_libs: &mut LibMappings<LibraryHandle>,
+        string_table: &mut ProfileStringTable,
+        address: u64,
+    ) -> InternalFrameAddress {
+        match kernel_libs.convert_address(address) {
+            Some((relative_address, lib_handle)) => {
+                let global_lib_index = global_libs.index_for_used_lib(*lib_handle, string_table);
+                InternalFrameAddress::InLib(relative_address, global_lib_index)
+            }
+            None => InternalFrameAddress::Unknown(address),
+        }
+    }
+
     fn resolve_frame_address(
-        process: &mut Process,
         frame_address: FrameAddress,
+        processes: &mut [Process],
         global_libs: &mut GlobalLibTable,
         kernel_libs: &mut LibMappings<LibraryHandle>,
         string_table: &mut ProfileStringTable,
     ) -> InternalFrameAddress {
         match frame_address {
-            FrameAddress::InstructionPointer(ip) => {
+            FrameAddress::InstructionPointer(process_handle, ip) => {
+                let process = &mut processes[process_handle.0];
                 process.convert_address(global_libs, kernel_libs, string_table, ip)
             }
-            FrameAddress::ReturnAddress(ra) => process.convert_address(
+            FrameAddress::ReturnAddress(process_handle, ra) => {
+                let process = &mut processes[process_handle.0];
+                process.convert_address(
+                    global_libs,
+                    kernel_libs,
+                    string_table,
+                    ra.saturating_sub(1),
+                )
+            }
+            FrameAddress::AdjustedReturnAddress(process_handle, ara) => {
+                let process = &mut processes[process_handle.0];
+                process.convert_address(global_libs, kernel_libs, string_table, ara)
+            }
+
+            FrameAddress::KernelInstructionPointer(ip) => {
+                Self::convert_kernel_address(global_libs, kernel_libs, string_table, ip)
+            }
+            FrameAddress::KernelReturnAddress(ra) => Self::convert_kernel_address(
                 global_libs,
                 kernel_libs,
                 string_table,
                 ra.saturating_sub(1),
             ),
-            FrameAddress::AdjustedReturnAddress(ara) => {
-                process.convert_address(global_libs, kernel_libs, string_table, ara)
+            FrameAddress::KernelAdjustedReturnAddress(ara) => {
+                Self::convert_kernel_address(global_libs, kernel_libs, string_table, ara)
             }
+
             FrameAddress::RelativeAddressFromInstructionPointer(lib_handle, relative_address) => {
                 let global_lib_index = global_libs.index_for_used_lib(lib_handle, string_table);
                 InternalFrameAddress::InLib(relative_address, global_lib_index)
@@ -1411,7 +1366,7 @@ impl Profile {
             processes: &self.processes,
             sorted_threads,
             marker_schemas: &self.marker_schemas,
-            string_table: &self.string_table,
+            string_table: &self.shared_data.string_table,
         }
     }
 
@@ -1426,7 +1381,7 @@ impl Profile {
     }
 
     fn contains_js_frame(&self) -> bool {
-        self.threads.iter().any(|t| t.contains_js_frame())
+        self.shared_data.contains_js_frame()
     }
 }
 
@@ -1437,7 +1392,7 @@ impl Serialize for Profile {
         let mut map = serializer.serialize_map(None)?;
         map.serialize_entry("meta", &SerializableProfileMeta(self, &new_thread_indices))?;
         map.serialize_entry("libs", &self.global_libs)?;
-        map.serialize_entry("shared", &SerializableProfileShared(self))?;
+        map.serialize_entry("shared", &self.shared_data)?;
         map.serialize_entry("threads", &self.serializable_threads(&sorted_threads))?;
         map.serialize_entry("pages", &[] as &[()])?;
         map.serialize_entry("profilerOverhead", &[] as &[()])?;
@@ -1466,7 +1421,7 @@ impl Serialize for SerializableProfileMeta<'_> {
             }),
         )?;
         map.serialize_entry("interval", &(self.0.interval.as_secs_f64() * 1000.0))?;
-        map.serialize_entry("preprocessedProfileVersion", &57)?;
+        map.serialize_entry("preprocessedProfileVersion", &60)?;
         map.serialize_entry("processType", &0)?;
         map.serialize_entry("product", &self.0.product)?;
         if let Some(os_name) = &self.0.os_name {
@@ -1535,16 +1490,6 @@ impl Serialize for SerializableProfileMeta<'_> {
     }
 }
 
-struct SerializableProfileShared<'a>(&'a Profile);
-
-impl Serialize for SerializableProfileShared<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("stringArray", &self.0.string_table)?;
-        map.end()
-    }
-}
-
 struct SerializableProfileThreadsProperty<'a> {
     threads: &'a [Thread],
     processes: &'a [Process],
@@ -1596,7 +1541,7 @@ struct SerializableProfileThread<'a>(
     &'a Process,
     &'a Thread,
     &'a [InternalMarkerSchema],
-    &'a ProfileStringTable,
+    &'a ProfileStringTable, // for Url / FilePath / SanitizedString marker fields
 );
 
 impl Serialize for SerializableProfileThread<'_> {

--- a/fxprof-processed-profile/src/profile_shared_data.rs
+++ b/fxprof-processed-profile/src/profile_shared_data.rs
@@ -1,0 +1,129 @@
+use std::collections::BTreeMap;
+
+use serde::ser::{Serialize, SerializeMap, Serializer};
+
+use crate::fast_hash_map::FastHashSet;
+use crate::frame_table::{FrameInterner, InternalFrame};
+use crate::global_lib_table::{GlobalLibIndex, UsedLibraryAddressesCollector};
+use crate::native_symbols::{NativeSymbolIndex, NativeSymbols};
+use crate::profile_symbol_info::LibSymbolInfo;
+use crate::stack_table::StackTable;
+use crate::string_table::{ProfileStringTable, StringHandle};
+use crate::symbol_info::SymbolStringTable;
+use crate::symbolication::{apply_symbol_information, StringTableAdapter};
+use crate::{FrameHandle, StackHandle, Symbol};
+
+#[derive(Debug)]
+pub struct ProfileSharedData {
+    pub(crate) string_table: ProfileStringTable,
+    stack_table: StackTable,
+    frame_interner: FrameInterner,
+    native_symbols: NativeSymbols,
+}
+
+impl ProfileSharedData {
+    pub fn new() -> Self {
+        Self {
+            string_table: ProfileStringTable::new(),
+            stack_table: StackTable::new(),
+            frame_interner: FrameInterner::new(),
+            native_symbols: NativeSymbols::new(),
+        }
+    }
+
+    pub fn native_symbol_index_and_string_index_for_symbol(
+        &mut self,
+        lib_index: GlobalLibIndex,
+        symbol: &Symbol,
+    ) -> (NativeSymbolIndex, StringHandle) {
+        self.native_symbols
+            .symbol_index_and_string_index_for_symbol(lib_index, symbol, &mut self.string_table)
+    }
+
+    pub fn native_symbol_index_for_native_symbol(
+        &mut self,
+        lib_index: GlobalLibIndex,
+        symbol: &Symbol,
+    ) -> NativeSymbolIndex {
+        let (symbol_index, _) =
+            self.native_symbol_index_and_string_index_for_symbol(lib_index, symbol);
+        symbol_index
+    }
+
+    pub fn get_native_symbol_name(&self, native_symbol_index: NativeSymbolIndex) -> StringHandle {
+        self.native_symbols
+            .get_native_symbol_name(native_symbol_index)
+    }
+
+    pub fn frame_index_for_frame(&mut self, frame: InternalFrame) -> FrameHandle {
+        self.frame_interner.index_for_frame(frame)
+    }
+
+    pub fn stack_index_for_stack(
+        &mut self,
+        prefix: Option<StackHandle>,
+        frame: FrameHandle,
+    ) -> StackHandle {
+        self.stack_table.index_for_stack(prefix, frame)
+    }
+
+    pub fn contains_js_frame(&self) -> bool {
+        self.frame_interner.contains_js_frame()
+    }
+
+    pub fn gather_used_rvas(&self, collector: &mut UsedLibraryAddressesCollector) {
+        self.frame_interner.gather_used_rvas(collector);
+    }
+
+    pub fn make_symbolicated_shared(
+        self,
+        libs: &FastHashSet<GlobalLibIndex>,
+        lib_symbols: &BTreeMap<GlobalLibIndex, &LibSymbolInfo>,
+        symbol_string_table: &SymbolStringTable,
+    ) -> (ProfileSharedData, Vec<Option<StackHandle>>) {
+        let ProfileSharedData {
+            mut string_table,
+            stack_table,
+            frame_interner,
+            native_symbols,
+        } = self;
+
+        let mut strings = StringTableAdapter::new(symbol_string_table, &mut string_table);
+        let (frame_interner, native_symbols, stack_table, old_stack_to_new_stack) =
+            apply_symbol_information(
+                frame_interner,
+                native_symbols,
+                stack_table,
+                libs,
+                lib_symbols,
+                &mut strings,
+            );
+
+        (
+            ProfileSharedData {
+                string_table,
+                stack_table,
+                frame_interner,
+                native_symbols,
+            },
+            old_stack_to_new_stack,
+        )
+    }
+}
+
+impl Serialize for ProfileSharedData {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let (frame_table, func_table, source_table, resource_table) =
+            self.frame_interner.create_tables();
+
+        let mut map = serializer.serialize_map(None)?;
+        map.serialize_entry("stackTable", &self.stack_table)?;
+        map.serialize_entry("frameTable", &frame_table)?;
+        map.serialize_entry("funcTable", &func_table)?;
+        map.serialize_entry("nativeSymbols", &self.native_symbols)?;
+        map.serialize_entry("resourceTable", &resource_table)?;
+        map.serialize_entry("sources", &source_table)?;
+        map.serialize_entry("stringArray", &self.string_table)?;
+        map.end()
+    }
+}

--- a/fxprof-processed-profile/src/sample_table.rs
+++ b/fxprof-processed-profile/src/sample_table.rs
@@ -8,6 +8,7 @@ use crate::timestamp::{
     SerializableTimestampSliceAsDeltas, SerializableTimestampSliceAsDeltasWithPermutation,
     Timestamp,
 };
+use crate::StackHandle;
 
 /// The sample table contains stacks with timestamps and some extra information.
 ///
@@ -20,7 +21,7 @@ pub struct SampleTable {
     sample_weights: Vec<i32>,
     sample_timestamps: Vec<Timestamp>,
     /// An index into the thread's stack table for each sample. `None` means the empty stack.
-    sample_stack_indexes: Vec<Option<usize>>,
+    sample_stack_indexes: Vec<Option<StackHandle>>,
     /// CPU usage delta since the previous sample for this thread, for each sample.
     sample_cpu_deltas: Vec<CpuDelta>,
     is_sorted_by_time: bool,
@@ -87,7 +88,7 @@ impl SampleTable {
     pub fn add_sample(
         &mut self,
         timestamp: Timestamp,
-        stack_index: Option<usize>,
+        stack_index: Option<StackHandle>,
         cpu_delta: CpuDelta,
         weight: i32,
     ) {
@@ -110,11 +111,14 @@ impl SampleTable {
         *self.sample_timestamps.last_mut().unwrap() = timestamp;
     }
 
-    pub fn with_remapped_stacks(mut self, old_stack_to_new_stack: &[Option<usize>]) -> Self {
+    pub fn with_remapped_stacks(mut self, old_stack_to_new_stack: &[Option<StackHandle>]) -> Self {
         self.sample_stack_indexes = self
             .sample_stack_indexes
             .into_iter()
-            .map(|stack| stack.and_then(|s| old_stack_to_new_stack[s]))
+            .map(|stack| match stack {
+                Some(s) => old_stack_to_new_stack[s.0],
+                None => None,
+            })
             .collect();
         self
     }
@@ -196,7 +200,7 @@ pub struct NativeAllocationsTable {
     /// The timstamps for each sample
     time: Vec<Timestamp>,
     /// The stack index for each sample
-    stack: Vec<Option<usize>>,
+    stack: Vec<Option<StackHandle>>,
     /// The size in bytes (positive for allocations, negative for deallocations) for each sample
     allocation_size: Vec<i64>,
     /// The memory address of the allocation for each sample
@@ -208,7 +212,7 @@ impl NativeAllocationsTable {
     pub fn add_sample(
         &mut self,
         timestamp: Timestamp,
-        stack_index: Option<usize>,
+        stack_index: Option<StackHandle>,
         allocation_address: u64,
         allocation_size: i64,
     ) {
@@ -218,11 +222,14 @@ impl NativeAllocationsTable {
         self.allocation_size.push(allocation_size);
     }
 
-    pub fn with_remapped_stacks(mut self, old_stack_to_new_stack: &[Option<usize>]) -> Self {
+    pub fn with_remapped_stacks(mut self, old_stack_to_new_stack: &[Option<StackHandle>]) -> Self {
         self.stack = self
             .stack
             .into_iter()
-            .map(|stack| stack.and_then(|s| old_stack_to_new_stack[s]))
+            .map(|stack| match stack {
+                Some(s) => old_stack_to_new_stack[s.0],
+                None => None,
+            })
             .collect();
         self
     }

--- a/fxprof-processed-profile/src/source_table.rs
+++ b/fxprof-processed-profile/src/source_table.rs
@@ -1,0 +1,74 @@
+use serde::ser::{Serialize, SerializeMap, Serializer};
+
+use crate::fast_hash_map::FastIndexSet;
+use crate::string_table::StringHandle;
+
+#[derive(Debug, Clone, Default)]
+pub struct SourceTable {
+    id_col: Vec<Option<StringHandle>>,
+    file_path_col: Vec<StringHandle>,
+    start_line_col: Vec<u32>,
+    start_column_col: Vec<u32>,
+    source_map_url_col: Vec<Option<StringHandle>>,
+
+    source_key_set: FastIndexSet<SourceKey>,
+}
+
+#[derive(Debug, Clone, Copy, PartialOrd, Ord, PartialEq, Eq, Hash)]
+pub struct SourceKey {
+    pub id: Option<StringHandle>,
+    pub file_path: StringHandle,
+    pub start_line: u32,   // Use 1 if unsure
+    pub start_column: u32, // Use 1 if unsure
+    pub source_map_url: Option<StringHandle>,
+}
+
+impl SourceTable {
+    pub fn index_for_source(&mut self, source_key: SourceKey) -> SourceIndex {
+        let (index, is_new) = self.source_key_set.insert_full(source_key);
+
+        let source_index = SourceIndex(index.try_into().unwrap());
+        if !is_new {
+            return source_index;
+        }
+
+        let SourceKey {
+            id,
+            file_path,
+            start_line,
+            start_column,
+            source_map_url,
+        } = source_key;
+
+        self.id_col.push(id);
+        self.file_path_col.push(file_path);
+        self.start_line_col.push(start_line);
+        self.start_column_col.push(start_column);
+        self.source_map_url_col.push(source_map_url);
+
+        source_index
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialOrd, Ord, PartialEq, Eq, Hash)]
+pub struct SourceIndex(u32);
+
+impl Serialize for SourceIndex {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_u32(self.0)
+    }
+}
+
+impl Serialize for SourceTable {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let len = self.id_col.len();
+        let mut map = serializer.serialize_map(None)?;
+        map.serialize_entry("length", &len)?;
+        map.serialize_entry("uuid", &self.id_col)?;
+        map.serialize_entry("filename", &self.file_path_col)?;
+        // map.serialize_entry("startLine", &self.start_line_col)?;
+        // map.serialize_entry("startColumn", &self.start_column_col)?;
+        // map.serialize_entry("sourceMapURL", &self.source_map_url_col)?;
+        map.end()
+    }
+}

--- a/fxprof-processed-profile/src/stack_table.rs
+++ b/fxprof-processed-profile/src/stack_table.rs
@@ -1,6 +1,6 @@
 use serde::ser::{Serialize, SerializeMap, Serializer};
 
-use crate::fast_hash_map::FastIndexSet;
+use crate::{fast_hash_map::FastIndexSet, FrameHandle, StackHandle};
 
 /// The stack table stores the tree of stack nodes of a thread. The shape of the tree is encoded in
 /// the prefix column: Root stack nodes have null as their prefix, and every non-root stack has the
@@ -40,23 +40,26 @@ use crate::fast_hash_map::FastIndexSet;
 /// would be lost if it wasn't inherited into the nsAttrAndChildArray::InsertChildAt stack before
 /// transforms are applied.
 #[derive(Debug, Clone, Default)]
-pub struct StackTable(FastIndexSet<(Option<usize>, usize)>);
+pub struct StackTable(FastIndexSet<(Option<StackHandle>, FrameHandle)>);
 
 impl StackTable {
     pub fn new() -> Self {
         Default::default()
     }
 
-    pub fn index_for_stack(&mut self, prefix: Option<usize>, frame: usize) -> usize {
-        let (stack_index, _is_new) = self.0.insert_full((prefix, frame));
-        stack_index
+    pub fn index_for_stack(
+        &mut self,
+        prefix: Option<StackHandle>,
+        frame: FrameHandle,
+    ) -> StackHandle {
+        StackHandle(self.0.insert_full((prefix, frame)).0)
     }
 
     pub fn len(&self) -> usize {
         self.0.len()
     }
 
-    pub fn into_stacks(self) -> impl Iterator<Item = (Option<usize>, usize)> {
+    pub fn into_stacks(self) -> impl Iterator<Item = (Option<StackHandle>, FrameHandle)> {
         self.0.into_iter()
     }
 }

--- a/fxprof-processed-profile/src/symbolication.rs
+++ b/fxprof-processed-profile/src/symbolication.rs
@@ -9,7 +9,9 @@ use crate::profile_symbol_info::{
 };
 use crate::stack_table::StackTable;
 use crate::string_table::ProfileStringTable;
-use crate::{FrameFlags, SourceLocation, StringHandle, SubcategoryHandle};
+use crate::{
+    FrameFlags, FrameHandle, SourceLocation, StackHandle, StringHandle, SubcategoryHandle,
+};
 
 /// Describes a native frame which should be replaced with its symbolicated
 /// equivalent.
@@ -36,7 +38,7 @@ impl FrameKeyForSymbolication {
 /// stack node's frame.
 pub enum StackNodeConversionAction {
     /// Change the frame index to the new index.
-    RemapIndex(usize),
+    RemapIndex(FrameHandle),
     /// Replace this stack node with one or more stack nodes by looking up
     /// the symbolicated frames for this frame key.
     Symbolicate(FrameKeyForSymbolication),
@@ -153,7 +155,12 @@ pub fn apply_symbol_information(
     libs: &FastHashSet<GlobalLibIndex>,
     lib_symbols: &BTreeMap<GlobalLibIndex, &LibSymbolInfo>,
     strings: &mut StringTableAdapter,
-) -> (FrameInterner, NativeSymbols, StackTable, Vec<Option<usize>>) {
+) -> (
+    FrameInterner,
+    NativeSymbols,
+    StackTable,
+    Vec<Option<StackHandle>>,
+) {
     let (mut new_native_symbols, old_native_symbol_to_new_native_symbol) =
         native_symbols.new_table_with_symbols_from_libs_removed(libs);
 
@@ -389,7 +396,7 @@ fn create_symbolicated_frames_for_frame(
             source_location: SourceLocation::default(),
             flags: frame_flags,
         });
-        return CompactFrameSequence::single_frame(new_frame);
+        return CompactFrameSequence::single_frame(new_frame.0);
     };
 
     // We have symbol information for this address!
@@ -429,7 +436,7 @@ fn create_symbolicated_frames_for_frame(
             source_location: SourceLocation::default(),
             flags: frame_flags,
         });
-        return CompactFrameSequence::single_frame(new_frame);
+        return CompactFrameSequence::single_frame(new_frame.0);
     }
 
     // We have function name + file path + line info for this address, and it
@@ -450,22 +457,24 @@ fn create_symbolicated_frames_for_frame(
     // seen before - it didn't contain any frames at all from lib before
     // `create_symbolicated_frames` was called.
     CompactFrameSequence::from_iter(frame_iter.enumerate().map(|(inline_depth, frame)| {
-        new_frame_interner.index_for_frame(InternalFrame {
-            name: strings.convert_index(frame.function_name),
-            variant: InternalFrameVariant::Native(NativeFrameData {
-                lib,
-                native_symbol: Some(native_symbol_index),
-                relative_address: address,
-                inline_depth: inline_depth as u16,
-            }),
-            subcategory,
-            source_location: SourceLocation {
-                file_path: frame.file.map(|f| strings.convert_index(f)),
-                line: frame.line,
-                col: None,
-            },
-            flags: frame_flags,
-        })
+        new_frame_interner
+            .index_for_frame(InternalFrame {
+                name: strings.convert_index(frame.function_name),
+                variant: InternalFrameVariant::Native(NativeFrameData {
+                    lib,
+                    native_symbol: Some(native_symbol_index),
+                    relative_address: address,
+                    inline_depth: inline_depth as u16,
+                }),
+                subcategory,
+                source_location: SourceLocation {
+                    file_path: frame.file.map(|f| strings.convert_index(f)),
+                    line: frame.line,
+                    col: None,
+                },
+                flags: frame_flags,
+            })
+            .0
     }))
 }
 
@@ -489,13 +498,15 @@ fn create_symbolicated_stacks(
     conversion_action_for_stack_frame: Vec<StackNodeConversionAction>,
     stack_table: StackTable,
     symbolicated_frames_by_key: BTreeMap<FrameKeyForSymbolication, CompactFrameSequence>,
-) -> (StackTable, Vec<Option<usize>>) {
+) -> (StackTable, Vec<Option<StackHandle>>) {
     let mut new_stack_table = StackTable::new();
-    let mut old_stack_to_new_stack = Vec::with_capacity(stack_table.len());
+    let mut old_stack_to_new_stack: Vec<Option<StackHandle>> =
+        Vec::with_capacity(stack_table.len());
 
     for (old_prefix, old_frame) in stack_table.into_stacks() {
+        let old_prefix = old_prefix.map(|StackHandle(index)| index);
         let new_prefix = old_prefix.and_then(|old_prefix| old_stack_to_new_stack[old_prefix]);
-        let new_stack = match &conversion_action_for_stack_frame[old_frame] {
+        let new_stack: Option<StackHandle> = match &conversion_action_for_stack_frame[old_frame.0] {
             StackNodeConversionAction::RemapIndex(new_frame) => {
                 Some(new_stack_table.index_for_stack(new_prefix, *new_frame))
             }
@@ -504,8 +515,9 @@ fn create_symbolicated_stacks(
                 let expanded_frames = symbolicated_frames_by_key[frame_key_for_symbolication];
                 let mut current_stack = new_prefix;
                 for frame_index in expanded_frames.frame_index_iter() {
-                    current_stack =
-                        Some(new_stack_table.index_for_stack(current_stack, frame_index));
+                    current_stack = Some(
+                        new_stack_table.index_for_stack(current_stack, FrameHandle(frame_index)),
+                    );
                 }
                 current_stack
             }

--- a/fxprof-processed-profile/src/thread.rs
+++ b/fxprof-processed-profile/src/thread.rs
@@ -1,22 +1,16 @@
 use std::borrow::Cow;
 use std::cmp::Ordering;
-use std::collections::BTreeMap;
 
 use serde::ser::{SerializeMap, Serializer};
 
 use crate::cpu_delta::CpuDelta;
-use crate::fast_hash_map::FastHashSet;
-use crate::frame_table::{FrameInterner, InternalFrame};
-use crate::global_lib_table::{GlobalLibIndex, UsedLibraryAddressesCollector};
 use crate::marker_table::MarkerTable;
 use crate::markers::InternalMarkerSchema;
-use crate::native_symbols::{NativeSymbolIndex, NativeSymbols};
-use crate::profile_symbol_info::LibSymbolInfo;
 use crate::sample_table::{NativeAllocationsTable, SampleTable, WeightType};
-use crate::stack_table::StackTable;
 use crate::string_table::{ProfileStringTable, StringHandle};
-use crate::symbolication::{apply_symbol_information, StringTableAdapter};
-use crate::{DynamicSchemaMarker, MarkerHandle, MarkerTiming, MarkerTypeHandle, Symbol, Timestamp};
+use crate::{
+    DynamicSchemaMarker, MarkerHandle, MarkerTiming, MarkerTypeHandle, StackHandle, Timestamp,
+};
 
 /// A process. Can be created with [`Profile::add_process`](crate::Profile::add_process).
 #[derive(Debug, Clone, Copy, PartialOrd, Ord, PartialEq, Eq, Hash)]
@@ -30,13 +24,10 @@ pub struct Thread {
     start_time: Timestamp,
     end_time: Option<Timestamp>,
     is_main: bool,
-    stack_table: StackTable,
-    frame_interner: FrameInterner,
     samples: SampleTable,
     native_allocations: Option<NativeAllocationsTable>,
     markers: MarkerTable,
-    native_symbols: NativeSymbols,
-    last_sample_stack: Option<usize>,
+    last_sample_stack: Option<StackHandle>,
     last_sample_was_zero_cpu: bool,
     show_markers_in_timeline: bool,
 }
@@ -50,12 +41,9 @@ impl Thread {
             start_time,
             end_time: None,
             is_main,
-            stack_table: StackTable::new(),
-            frame_interner: FrameInterner::new(),
             samples: SampleTable::new(),
             native_allocations: None,
             markers: MarkerTable::new(),
-            native_symbols: NativeSymbols::new(),
             last_sample_stack: None,
             last_sample_was_zero_cpu: false,
             show_markers_in_timeline: false,
@@ -86,44 +74,10 @@ impl Thread {
         self.process
     }
 
-    pub fn native_symbol_index_and_string_index_for_symbol(
-        &mut self,
-        lib_index: GlobalLibIndex,
-        symbol: &Symbol,
-        string_table: &mut ProfileStringTable,
-    ) -> (NativeSymbolIndex, StringHandle) {
-        self.native_symbols
-            .symbol_index_and_string_index_for_symbol(lib_index, symbol, string_table)
-    }
-
-    pub fn native_symbol_index_for_native_symbol(
-        &mut self,
-        lib_index: GlobalLibIndex,
-        symbol: &Symbol,
-        string_table: &mut ProfileStringTable,
-    ) -> NativeSymbolIndex {
-        let (symbol_index, _) =
-            self.native_symbol_index_and_string_index_for_symbol(lib_index, symbol, string_table);
-        symbol_index
-    }
-
-    pub fn get_native_symbol_name(&self, native_symbol_index: NativeSymbolIndex) -> StringHandle {
-        self.native_symbols
-            .get_native_symbol_name(native_symbol_index)
-    }
-
-    pub fn frame_index_for_frame(&mut self, frame: InternalFrame) -> usize {
-        self.frame_interner.index_for_frame(frame)
-    }
-
-    pub fn stack_index_for_stack(&mut self, prefix: Option<usize>, frame: usize) -> usize {
-        self.stack_table.index_for_stack(prefix, frame)
-    }
-
     pub fn add_sample(
         &mut self,
         timestamp: Timestamp,
-        stack_index: Option<usize>,
+        stack_index: Option<StackHandle>,
         cpu_delta: CpuDelta,
         weight: i32,
     ) {
@@ -136,7 +90,7 @@ impl Thread {
     pub fn add_allocation_sample(
         &mut self,
         timestamp: Timestamp,
-        stack_index: Option<usize>,
+        stack_index: Option<StackHandle>,
         allocation_address: u64,
         allocation_size: i64,
     ) {
@@ -182,16 +136,8 @@ impl Thread {
         )
     }
 
-    pub fn set_marker_stack(&mut self, marker: MarkerHandle, stack_index: Option<usize>) {
+    pub fn set_marker_stack(&mut self, marker: MarkerHandle, stack_index: Option<StackHandle>) {
         self.markers.set_marker_stack(marker, stack_index);
-    }
-
-    pub fn contains_js_frame(&self) -> bool {
-        self.frame_interner.contains_js_frame()
-    }
-
-    pub fn gather_used_rvas(&self, collector: &mut UsedLibraryAddressesCollector) {
-        self.frame_interner.gather_used_rvas(collector);
     }
 
     pub fn cmp_for_json_order(&self, other: &Thread) -> Ordering {
@@ -213,9 +159,7 @@ impl Thread {
 
     pub fn make_symbolicated_thread(
         self,
-        libs: &FastHashSet<GlobalLibIndex>,
-        lib_symbols: &BTreeMap<GlobalLibIndex, &LibSymbolInfo>,
-        strings: &mut StringTableAdapter,
+        old_stack_to_new_stack: &[Option<StackHandle>],
     ) -> Thread {
         let Thread {
             process,
@@ -224,34 +168,21 @@ impl Thread {
             start_time,
             end_time,
             is_main,
-            stack_table,
-            frame_interner,
             samples,
             native_allocations,
             markers,
-            native_symbols,
             last_sample_stack,
             last_sample_was_zero_cpu,
             show_markers_in_timeline,
         } = self;
 
-        let (frame_interner, native_symbols, stack_table, old_stack_to_new_stack) =
-            apply_symbol_information(
-                frame_interner,
-                native_symbols,
-                stack_table,
-                libs,
-                lib_symbols,
-                strings,
-            );
-
-        let samples = samples.with_remapped_stacks(&old_stack_to_new_stack);
+        let samples = samples.with_remapped_stacks(old_stack_to_new_stack);
         let native_allocations = native_allocations.map(|native_allocations| {
-            native_allocations.with_remapped_stacks(&old_stack_to_new_stack)
+            native_allocations.with_remapped_stacks(old_stack_to_new_stack)
         });
-        let markers = markers.with_remapped_stacks(&old_stack_to_new_stack);
+        let markers = markers.with_remapped_stacks(old_stack_to_new_stack);
         let last_sample_stack = last_sample_stack
-            .and_then(|last_sample_stack| old_stack_to_new_stack[last_sample_stack]);
+            .and_then(|last_sample_stack| old_stack_to_new_stack[last_sample_stack.0]);
 
         Thread {
             process,
@@ -260,12 +191,9 @@ impl Thread {
             start_time,
             end_time,
             is_main,
-            stack_table,
-            frame_interner,
             samples,
             native_allocations,
             markers,
-            native_symbols,
             last_sample_stack,
             last_sample_was_zero_cpu,
             show_markers_in_timeline,
@@ -292,18 +220,9 @@ impl Thread {
         let thread_register_time = self.start_time;
         let thread_unregister_time = self.end_time;
 
-        let (frame_table, func_table, resource_table) = self.frame_interner.create_tables();
-
         let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("frameTable", &frame_table)?;
-        map.serialize_entry("funcTable", &func_table)?;
-        map.serialize_entry(
-            "markers",
-            &self.markers.as_serializable(marker_schemas, string_table),
-        )?;
         map.serialize_entry("name", &thread_name)?;
         map.serialize_entry("isMainThread", &self.is_main)?;
-        map.serialize_entry("nativeSymbols", &self.native_symbols)?;
         map.serialize_entry("pausedRanges", &[] as &[()])?;
         map.serialize_entry("pid", &pid)?;
         map.serialize_entry("processName", process_name)?;
@@ -311,15 +230,17 @@ impl Thread {
         map.serialize_entry("processStartupTime", &process_start_time)?;
         map.serialize_entry("processType", &"default")?;
         map.serialize_entry("registerTime", &thread_register_time)?;
-        map.serialize_entry("resourceTable", &resource_table)?;
+        map.serialize_entry("tid", &self.tid)?;
+        map.serialize_entry("unregisterTime", &thread_unregister_time)?;
+        map.serialize_entry("showMarkersInTimeline", &self.show_markers_in_timeline)?;
         map.serialize_entry("samples", &self.samples)?;
         if let Some(allocations) = &self.native_allocations {
             map.serialize_entry("nativeAllocations", &allocations)?;
         }
-        map.serialize_entry("stackTable", &self.stack_table)?;
-        map.serialize_entry("tid", &self.tid)?;
-        map.serialize_entry("unregisterTime", &thread_unregister_time)?;
-        map.serialize_entry("showMarkersInTimeline", &self.show_markers_in_timeline)?;
+        map.serialize_entry(
+            "markers",
+            &self.markers.as_serializable(marker_schemas, string_table),
+        )?;
         map.end()
     }
 }

--- a/fxprof-processed-profile/tests/integration_tests/main.rs
+++ b/fxprof-processed-profile/tests/integration_tests/main.rs
@@ -169,18 +169,13 @@ fn profile_without_js() {
     .rev()
     .map(|(i, addr)| {
         if i == 0 {
-            FrameAddress::InstructionPointer(addr)
+            FrameAddress::InstructionPointer(process, addr)
         } else {
-            FrameAddress::ReturnAddress(addr)
+            FrameAddress::ReturnAddress(process, addr)
         }
     });
-    let s1 = profile.handle_for_stack_frames(thread, |p| {
-        Some(p.handle_for_frame_with_address(
-            thread,
-            frames1_iter.next()?,
-            category,
-            FrameFlags::empty(),
-        ))
+    let s1 = profile.handle_for_stack_frames(|p| {
+        Some(p.handle_for_frame_with_address(frames1_iter.next()?, category, FrameFlags::empty()))
     });
     profile.add_sample(
         thread,
@@ -203,18 +198,13 @@ fn profile_without_js() {
     .rev()
     .map(|(i, addr)| {
         if i == 0 {
-            FrameAddress::InstructionPointer(*addr)
+            FrameAddress::InstructionPointer(process, *addr)
         } else {
-            FrameAddress::ReturnAddress(*addr)
+            FrameAddress::ReturnAddress(process, *addr)
         }
     });
-    let s2 = profile.handle_for_stack_frames(thread, |p| {
-        Some(p.handle_for_frame_with_address(
-            thread,
-            frames2_iter.next()?,
-            category,
-            FrameFlags::empty(),
-        ))
+    let s2 = profile.handle_for_stack_frames(|p| {
+        Some(p.handle_for_frame_with_address(frames2_iter.next()?, category, FrameFlags::empty()))
     });
     profile.add_sample(
         thread,
@@ -237,18 +227,13 @@ fn profile_without_js() {
     .rev()
     .map(|(i, addr)| {
         if i == 0 {
-            FrameAddress::InstructionPointer(*addr)
+            FrameAddress::InstructionPointer(process, *addr)
         } else {
-            FrameAddress::ReturnAddress(*addr)
+            FrameAddress::ReturnAddress(process, *addr)
         }
     });
-    let s3 = profile.handle_for_stack_frames(thread, |p| {
-        Some(p.handle_for_frame_with_address(
-            thread,
-            frames3_iter.next()?,
-            category,
-            FrameFlags::empty(),
-        ))
+    let s3 = profile.handle_for_stack_frames(|p| {
+        Some(p.handle_for_frame_with_address(frames3_iter.next()?, category, FrameFlags::empty()))
     });
     profile.add_sample(
         thread,
@@ -334,7 +319,7 @@ fn profile_without_js() {
                 "name": []
               },
               "interval": 1.0,
-              "preprocessedProfileVersion": 57,
+              "preprocessedProfileVersion": 60,
               "processType": 0,
               "product": "test",
               "oscpu": "macOS 14.4",
@@ -427,6 +412,386 @@ fn profile_without_js() {
               }
             ],
             "shared": {
+              "stackTable": {
+                "length": 16,
+                "prefix": [
+                  null,
+                  0,
+                  1,
+                  2,
+                  3,
+                  4,
+                  5,
+                  1,
+                  7,
+                  8,
+                  9,
+                  10,
+                  7,
+                  12,
+                  13,
+                  14
+                ],
+                "frame": [
+                  0,
+                  1,
+                  2,
+                  3,
+                  4,
+                  5,
+                  6,
+                  7,
+                  8,
+                  9,
+                  10,
+                  11,
+                  12,
+                  13,
+                  14,
+                  15
+                ]
+              },
+              "frameTable": {
+                "length": 16,
+                "address": [
+                  -1,
+                  796420,
+                  911223,
+                  1332248,
+                  2354017,
+                  2452862,
+                  1700071,
+                  172156,
+                  1075602,
+                  905942,
+                  979918,
+                  2437518,
+                  1405368,
+                  737506,
+                  2586868,
+                  674246
+                ],
+                "inlineDepth": [
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0
+                ],
+                "category": [
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1,
+                  1
+                ],
+                "subcategory": [
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0
+                ],
+                "func": [
+                  0,
+                  1,
+                  2,
+                  3,
+                  4,
+                  5,
+                  6,
+                  7,
+                  8,
+                  9,
+                  10,
+                  11,
+                  12,
+                  13,
+                  14,
+                  15
+                ],
+                "nativeSymbol": [
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                  0,
+                  1,
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                  2
+                ],
+                "innerWindowID": [
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0
+                ],
+                "line": [
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                  null
+                ],
+                "column": [
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                  null
+                ]
+              },
+              "funcTable": {
+                "length": 16,
+                "name": [
+                  0,
+                  2,
+                  3,
+                  4,
+                  5,
+                  6,
+                  8,
+                  9,
+                  10,
+                  11,
+                  12,
+                  13,
+                  14,
+                  15,
+                  16,
+                  17
+                ],
+                "isJS": [
+                  false,
+                  false,
+                  false,
+                  false,
+                  false,
+                  false,
+                  false,
+                  false,
+                  false,
+                  false,
+                  false,
+                  false,
+                  false,
+                  false,
+                  false,
+                  false
+                ],
+                "relevantForJS": [
+                  false,
+                  false,
+                  false,
+                  false,
+                  false,
+                  false,
+                  false,
+                  false,
+                  false,
+                  false,
+                  false,
+                  false,
+                  false,
+                  false,
+                  false,
+                  false
+                ],
+                "resource": [
+                  -1,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  1,
+                  1,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  1
+                ],
+                "source": [
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                  null
+                ],
+                "lineNumber": [
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                  null
+                ],
+                "columnNumber": [
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                  null
+                ]
+              },
+              "sources": {
+                "length": 0,
+                "uuid": [],
+                "filename": [],
+              },
+              "nativeSymbols": {
+                "length": 3,
+                "address": [
+                  1700001,
+                  172156,
+                  674226
+                ],
+                "functionSize": [
+                  180,
+                  20,
+                  44
+                ],
+                "libIndex": [
+                  1,
+                  1,
+                  1
+                ],
+                "name": [
+                  8,
+                  9,
+                  17
+                ]
+              },
+              "resourceTable": {
+                "length": 2,
+                "lib": [
+                  0,
+                  1
+                ],
+                "name": [
+                  1,
+                  7
+                ],
+                "host": [
+                  null,
+                  null
+                ],
+                "type": [
+                  1,
+                  1
+                ]
+              },
               "stringArray": [
                 "0x7ffdb4824837",
                 "dump_syms",
@@ -455,300 +820,6 @@ fn profile_without_js() {
             },
             "threads": [
               {
-                "frameTable": {
-                  "length": 16,
-                  "address": [
-                    -1,
-                    796420,
-                    911223,
-                    1332248,
-                    2354017,
-                    2452862,
-                    1700071,
-                    172156,
-                    1075602,
-                    905942,
-                    979918,
-                    2437518,
-                    1405368,
-                    737506,
-                    2586868,
-                    674246
-                  ],
-                  "inlineDepth": [
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0
-                  ],
-                  "category": [
-                    1,
-                    1,
-                    1,
-                    1,
-                    1,
-                    1,
-                    1,
-                    1,
-                    1,
-                    1,
-                    1,
-                    1,
-                    1,
-                    1,
-                    1,
-                    1
-                  ],
-                  "subcategory": [
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0
-                  ],
-                  "func": [
-                    0,
-                    1,
-                    2,
-                    3,
-                    4,
-                    5,
-                    6,
-                    7,
-                    8,
-                    9,
-                    10,
-                    11,
-                    12,
-                    13,
-                    14,
-                    15
-                  ],
-                  "nativeSymbol": [
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    0,
-                    1,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    2
-                  ],
-                  "innerWindowID": [
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0
-                  ],
-                  "line": [
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null
-                  ],
-                  "column": [
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null
-                  ]
-                },
-                "funcTable": {
-                  "length": 16,
-                  "name": [
-                    0,
-                    2,
-                    3,
-                    4,
-                    5,
-                    6,
-                    8,
-                    9,
-                    10,
-                    11,
-                    12,
-                    13,
-                    14,
-                    15,
-                    16,
-                    17
-                  ],
-                  "isJS": [
-                    false,
-                    false,
-                    false,
-                    false,
-                    false,
-                    false,
-                    false,
-                    false,
-                    false,
-                    false,
-                    false,
-                    false,
-                    false,
-                    false,
-                    false,
-                    false
-                  ],
-                  "relevantForJS": [
-                    false,
-                    false,
-                    false,
-                    false,
-                    false,
-                    false,
-                    false,
-                    false,
-                    false,
-                    false,
-                    false,
-                    false,
-                    false,
-                    false,
-                    false,
-                    false
-                  ],
-                  "resource": [
-                    -1,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    1,
-                    1,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    1
-                  ],
-                  "fileName": [
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null
-                  ],
-                  "lineNumber": [
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null
-                  ],
-                  "columnNumber": [
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null
-                  ]
-                },
                 "markers": {
                   "length": 2,
                   "category": [
@@ -787,29 +858,6 @@ fn profile_without_js() {
                 },
                 "name": "test",
                 "isMainThread": true,
-                "nativeSymbols": {
-                  "length": 3,
-                  "address": [
-                    1700001,
-                    172156,
-                    674226
-                  ],
-                  "functionSize": [
-                    180,
-                    20,
-                    44
-                  ],
-                  "libIndex": [
-                    1,
-                    1,
-                    1
-                  ],
-                  "name": [
-                    8,
-                    9,
-                    17
-                  ]
-                },
                 "pausedRanges": [],
                 "pid": "123",
                 "processName": "test",
@@ -817,25 +865,6 @@ fn profile_without_js() {
                 "processStartupTime": 0.0,
                 "processType": "default",
                 "registerTime": 0.0,
-                "resourceTable": {
-                  "length": 2,
-                  "lib": [
-                    0,
-                    1
-                  ],
-                  "name": [
-                    1,
-                    7
-                  ],
-                  "host": [
-                    null,
-                    null
-                  ],
-                  "type": [
-                    1,
-                    1
-                  ]
-                },
                 "samples": {
                   "length": 4,
                   "weightType": "samples",
@@ -862,45 +891,6 @@ fn profile_without_js() {
                     0,
                     0,
                     0
-                  ]
-                },
-                "stackTable": {
-                  "length": 16,
-                  "prefix": [
-                    null,
-                    0,
-                    1,
-                    2,
-                    3,
-                    4,
-                    5,
-                    1,
-                    7,
-                    8,
-                    9,
-                    10,
-                    7,
-                    12,
-                    13,
-                    14
-                  ],
-                  "frame": [
-                    0,
-                    1,
-                    2,
-                    3,
-                    4,
-                    5,
-                    6,
-                    7,
-                    8,
-                    9,
-                    10,
-                    11,
-                    12,
-                    13,
-                    14,
-                    15
                   ]
                 },
                 "tid": "12345",
@@ -962,16 +952,15 @@ fn profile_with_js() {
     let category = profile.handle_for_category(Category("Cycle Collection", CategoryColor::Orange));
     let subcategory = profile.handle_for_subcategory(category, "Graph Reduction");
     let frames = vec![
-        profile.handle_for_frame_with_label(thread, some_label_string, category, FrameFlags::IS_JS),
+        profile.handle_for_frame_with_label(some_label_string, category, FrameFlags::IS_JS),
         profile.handle_for_frame_with_address(
-            thread,
-            FrameAddress::ReturnAddress(0x7f76b7ffc0e7),
+            FrameAddress::ReturnAddress(process, 0x7f76b7ffc0e7),
             subcategory,
             FrameFlags::empty(),
         ),
     ];
     let mut iter = frames.into_iter();
-    let s1 = profile.handle_for_stack_frames(thread, |_| iter.next());
+    let s1 = profile.handle_for_stack_frames(|_| iter.next());
     profile.add_sample(
         thread,
         Timestamp::from_millis_since_reference(1.0),
@@ -1011,7 +1000,7 @@ fn profile_with_js() {
                 "name": []
               },
               "interval": 1.0,
-              "preprocessedProfileVersion": 57,
+              "preprocessedProfileVersion": 60,
               "processType": 0,
               "product": "test with js",
               "sampleUnits": {
@@ -1029,6 +1018,106 @@ fn profile_with_js() {
             },
             "libs": [],
             "shared": {
+              "stackTable": {
+                "length": 2,
+                "prefix": [
+                  null,
+                  0
+                ],
+                "frame": [
+                  0,
+                  1
+                ]
+              },
+              "frameTable": {
+                "length": 2,
+                "address": [
+                  -1,
+                  -1
+                ],
+                "inlineDepth": [
+                  0,
+                  0
+                ],
+                "category": [
+                  1,
+                  1
+                ],
+                "subcategory": [
+                  0,
+                  1
+                ],
+                "func": [
+                  0,
+                  1
+                ],
+                "nativeSymbol": [
+                  null,
+                  null
+                ],
+                "innerWindowID": [
+                  0,
+                  0
+                ],
+                "line": [
+                  null,
+                  null
+                ],
+                "column": [
+                  null,
+                  null
+                ]
+              },
+              "funcTable": {
+                "length": 2,
+                "name": [
+                  0,
+                  1
+                ],
+                "isJS": [
+                  true,
+                  false
+                ],
+                "relevantForJS": [
+                  false,
+                  false
+                ],
+                "resource": [
+                  -1,
+                  -1
+                ],
+                "source": [
+                  null,
+                  null
+                ],
+                "lineNumber": [
+                  null,
+                  null
+                ],
+                "columnNumber": [
+                  null,
+                  null
+                ]
+              },
+              "resourceTable": {
+                "length": 0,
+                "lib": [],
+                "name": [],
+                "host": [],
+                "type": []
+              },
+              "sources": {
+                "length": 0,
+                "uuid": [],
+                "filename": [],
+              },
+              "nativeSymbols": {
+                "length": 0,
+                "address": [],
+                "functionSize": [],
+                "libIndex": [],
+                "name": []
+              },
               "stringArray": [
                 "Some label string",
                 "0x7f76b7ffc0e6"
@@ -1036,76 +1125,6 @@ fn profile_with_js() {
             },
             "threads": [
               {
-                "frameTable": {
-                  "length": 2,
-                  "address": [
-                    -1,
-                    -1
-                  ],
-                  "inlineDepth": [
-                    0,
-                    0
-                  ],
-                  "category": [
-                    1,
-                    1
-                  ],
-                  "subcategory": [
-                    0,
-                    1
-                  ],
-                  "func": [
-                    0,
-                    1
-                  ],
-                  "nativeSymbol": [
-                    null,
-                    null
-                  ],
-                  "innerWindowID": [
-                    0,
-                    0
-                  ],
-                  "line": [
-                    null,
-                    null
-                  ],
-                  "column": [
-                    null,
-                    null
-                  ]
-                },
-                "funcTable": {
-                  "length": 2,
-                  "name": [
-                    0,
-                    1
-                  ],
-                  "isJS": [
-                    true,
-                    false
-                  ],
-                  "relevantForJS": [
-                    false,
-                    false
-                  ],
-                  "resource": [
-                    -1,
-                    -1
-                  ],
-                  "fileName": [
-                    null,
-                    null
-                  ],
-                  "lineNumber": [
-                    null,
-                    null
-                  ],
-                  "columnNumber": [
-                    null,
-                    null
-                  ]
-                },
                 "markers": {
                   "length": 0,
                   "category": [],
@@ -1117,13 +1136,6 @@ fn profile_with_js() {
                 },
                 "name": "test2",
                 "isMainThread": true,
-                "nativeSymbols": {
-                  "length": 0,
-                  "address": [],
-                  "functionSize": [],
-                  "libIndex": [],
-                  "name": []
-                },
                 "pausedRanges": [],
                 "pid": "123",
                 "processName": "test2",
@@ -1131,13 +1143,6 @@ fn profile_with_js() {
                 "processStartupTime": 0.0,
                 "processType": "default",
                 "registerTime": 0.0,
-                "resourceTable": {
-                  "length": 0,
-                  "lib": [],
-                  "name": [],
-                  "host": [],
-                  "type": []
-                },
                 "samples": {
                   "length": 1,
                   "stack": [
@@ -1155,17 +1160,6 @@ fn profile_with_js() {
                   ]
                 },
                 "showMarkersInTimeline": false,
-                "stackTable": {
-                  "length": 2,
-                  "prefix": [
-                    null,
-                    0
-                  ],
-                  "frame": [
-                    0,
-                    1
-                  ]
-                },
                 "tid": "12346",
                 "unregisterTime": null
               }
@@ -1268,7 +1262,7 @@ fn profile_counters_with_sorted_processes() {
               "initialSelectedThreads": [0],
               "initialVisibleThreads": [0],
               "interval": 1.0,
-              "preprocessedProfileVersion": 57,
+              "preprocessedProfileVersion": 60,
               "processType": 0,
               "product": "test",
               "sampleUnits": {
@@ -1286,32 +1280,56 @@ fn profile_counters_with_sorted_processes() {
             },
             "libs": [],
             "shared": {
+              "stackTable": {
+                "length": 0,
+                "prefix": [],
+                "frame": []
+              },
+              "frameTable": {
+                "length": 0,
+                "address": [],
+                "inlineDepth": [],
+                "category": [],
+                "subcategory": [],
+                "func": [],
+                "nativeSymbol": [],
+                "innerWindowID": [],
+                "line": [],
+                "column": []
+              },
+              "funcTable": {
+                "length": 0,
+                "name": [],
+                "isJS": [],
+                "relevantForJS": [],
+                "resource": [],
+                "source": [],
+                "lineNumber": [],
+                "columnNumber": []
+              },
+              "sources": {
+                "length": 0,
+                "uuid": [],
+                "filename": [],
+              },
+              "nativeSymbols": {
+                "length": 0,
+                "address": [],
+                "functionSize": [],
+                "libIndex": [],
+                "name": []
+              },
+              "resourceTable": {
+                "length": 0,
+                "lib": [],
+                "name": [],
+                "host": [],
+                "type": []
+              },
               "stringArray": [],
             },
             "threads": [
               {
-                "frameTable": {
-                  "length": 0,
-                  "address": [],
-                  "inlineDepth": [],
-                  "category": [],
-                  "subcategory": [],
-                  "func": [],
-                  "nativeSymbol": [],
-                  "innerWindowID": [],
-                  "line": [],
-                  "column": []
-                },
-                "funcTable": {
-                  "length": 0,
-                  "name": [],
-                  "isJS": [],
-                  "relevantForJS": [],
-                  "resource": [],
-                  "fileName": [],
-                  "lineNumber": [],
-                  "columnNumber": []
-                },
                 "markers": {
                   "length": 0,
                   "category": [],
@@ -1323,13 +1341,6 @@ fn profile_counters_with_sorted_processes() {
                 },
                 "name": "test 2",
                 "isMainThread": true,
-                "nativeSymbols": {
-                  "length": 0,
-                  "address": [],
-                  "functionSize": [],
-                  "libIndex": [],
-                  "name": []
-                },
                 "pausedRanges": [],
                 "pid": "123.1",
                 "processName": "test 2",
@@ -1337,13 +1348,6 @@ fn profile_counters_with_sorted_processes() {
                 "processStartupTime": 0.0,
                 "processType": "default",
                 "registerTime": 1.0,
-                "resourceTable": {
-                  "length": 0,
-                  "lib": [],
-                  "name": [],
-                  "host": [],
-                  "type": []
-                },
                 "samples": {
                   "length": 1,
                   "stack": [
@@ -1361,37 +1365,10 @@ fn profile_counters_with_sorted_processes() {
                   ]
                 },
                 "showMarkersInTimeline": false,
-                "stackTable": {
-                  "length": 0,
-                  "prefix": [],
-                  "frame": []
-                },
                 "tid": "54321",
                 "unregisterTime": null
               },
               {
-                "frameTable": {
-                  "length": 0,
-                  "address": [],
-                  "inlineDepth": [],
-                  "category": [],
-                  "subcategory": [],
-                  "func": [],
-                  "nativeSymbol": [],
-                  "innerWindowID": [],
-                  "line": [],
-                  "column": []
-                },
-                "funcTable": {
-                  "length": 0,
-                  "name": [],
-                  "isJS": [],
-                  "relevantForJS": [],
-                  "resource": [],
-                  "fileName": [],
-                  "lineNumber": [],
-                  "columnNumber": []
-                },
                 "markers": {
                   "length": 0,
                   "category": [],
@@ -1403,13 +1380,6 @@ fn profile_counters_with_sorted_processes() {
                 },
                 "name": "test 1",
                 "isMainThread": true,
-                "nativeSymbols": {
-                  "length": 0,
-                  "address": [],
-                  "functionSize": [],
-                  "libIndex": [],
-                  "name": []
-                },
                 "pausedRanges": [],
                 "pid": "123",
                 "processName": "test 1",
@@ -1417,13 +1387,6 @@ fn profile_counters_with_sorted_processes() {
                 "processStartupTime": 1.0,
                 "processType": "default",
                 "registerTime": 0.0,
-                "resourceTable": {
-                  "length": 0,
-                  "lib": [],
-                  "name": [],
-                  "host": [],
-                  "type": []
-                },
                 "samples": {
                   "length": 1,
                   "stack": [
@@ -1441,11 +1404,6 @@ fn profile_counters_with_sorted_processes() {
                   ]
                 },
                 "showMarkersInTimeline": true,
-                "stackTable": {
-                  "length": 0,
-                  "prefix": [],
-                  "frame": []
-                },
                 "tid": "12345",
                 "unregisterTime": null
               }
@@ -1581,7 +1539,7 @@ fn test_flow_marker_fields() {
                 "name": []
               },
               "interval": 1.0,
-              "preprocessedProfileVersion": 57,
+              "preprocessedProfileVersion": 60,
               "processType": 0,
               "product": "test",
               "sampleUnits": {
@@ -1621,6 +1579,52 @@ fn test_flow_marker_fields() {
             },
             "libs": [],
             "shared": {
+              "stackTable": {
+                "length": 0,
+                "prefix": [],
+                "frame": []
+              },
+              "frameTable": {
+                "length": 0,
+                "func": [],
+                "category": [],
+                "subcategory": [],
+                "line": [],
+                "column": [],
+                "address": [],
+                "nativeSymbol": [],
+                "inlineDepth": [],
+                "innerWindowID": []
+              },
+              "funcTable": {
+                "length": 0,
+                "name": [],
+                "isJS": [],
+                "relevantForJS": [],
+                "resource": [],
+                "source": [],
+                "lineNumber": [],
+                "columnNumber": []
+              },
+              "sources": {
+                "length": 0,
+                "uuid": [],
+                "filename": [],
+              },
+              "nativeSymbols": {
+                "length": 0,
+                "address": [],
+                "functionSize": [],
+                "libIndex": [],
+                "name": []
+              },
+              "resourceTable": {
+                "length": 0,
+                "lib": [],
+                "name": [],
+                "host": [],
+                "type": []
+              },
               "stringArray": [
                 "Flow Start",
                 "ab54a98ceb1f0ad2",
@@ -1629,28 +1633,6 @@ fn test_flow_marker_fields() {
             },
             "threads": [
               {
-                "frameTable": {
-                  "length": 0,
-                  "func": [],
-                  "category": [],
-                  "subcategory": [],
-                  "line": [],
-                  "column": [],
-                  "address": [],
-                  "nativeSymbol": [],
-                  "inlineDepth": [],
-                  "innerWindowID": []
-                },
-                "funcTable": {
-                  "length": 0,
-                  "name": [],
-                  "isJS": [],
-                  "relevantForJS": [],
-                  "resource": [],
-                  "fileName": [],
-                  "lineNumber": [],
-                  "columnNumber": []
-                },
                 "markers": {
                   "length": 1,
                   "category": [
@@ -1678,13 +1660,6 @@ fn test_flow_marker_fields() {
                 },
                 "name": "test",
                 "isMainThread": true,
-                "nativeSymbols": {
-                  "length": 0,
-                  "address": [],
-                  "functionSize": [],
-                  "libIndex": [],
-                  "name": []
-                },
                 "pausedRanges": [],
                 "pid": "123",
                 "processName": "test",
@@ -1692,13 +1667,6 @@ fn test_flow_marker_fields() {
                 "processStartupTime": 0.0,
                 "processType": "default",
                 "registerTime": 0.0,
-                "resourceTable": {
-                  "length": 0,
-                  "lib": [],
-                  "name": [],
-                  "host": [],
-                  "type": []
-                },
                 "samples": {
                   "length": 0,
                   "weightType": "samples",
@@ -1706,11 +1674,6 @@ fn test_flow_marker_fields() {
                   "timeDeltas": [],
                   "weight": [],
                   "threadCPUDelta": []
-                },
-                "stackTable": {
-                  "length": 0,
-                  "prefix": [],
-                  "frame": []
                 },
                 "tid": "12345",
                 "unregisterTime": null,

--- a/samply/src/linux_shared/converter.rs
+++ b/samply/src/linux_shared/converter.rs
@@ -353,7 +353,6 @@ where
             };
 
             let label_frame = self.profile.handle_for_frame_with_label(
-                thread_handle,
                 thread.thread_label,
                 CategoryHandle::OTHER,
                 FrameFlags::empty(),
@@ -369,7 +368,6 @@ where
             );
 
             let label_frame = self.profile.handle_for_frame_with_label(
-                cpus.combined_thread_handle(),
                 thread.thread_label,
                 CategoryHandle::OTHER,
                 FrameFlags::empty(),

--- a/samply/src/linux_shared/process.rs
+++ b/samply/src/linux_shared/process.rs
@@ -234,6 +234,7 @@ where
         }
 
         let process_sample_data = ProcessSampleData::new(
+            self.profile_process,
             std::mem::take(&mut self.unresolved_samples),
             std::mem::take(&mut self.lib_mapping_ops),
             jitdump_ops,

--- a/samply/src/mac/task_profiler.rs
+++ b/samply/src/mac/task_profiler.rs
@@ -668,6 +668,7 @@ impl TaskProfiler {
             }
         }
         let process_sample_data = ProcessSampleData::new(
+            self.profile_process,
             self.unresolved_samples,
             self.lib_mapping_ops,
             jitdump_lib_ops,

--- a/samply/src/shared/per_cpu.rs
+++ b/samply/src/shared/per_cpu.rs
@@ -8,7 +8,7 @@ use crate::shared::timestamp_converter::TimestampConverter;
 
 pub struct Cpus {
     start_time: Timestamp,
-    process_handle: ProcessHandle,
+    pub process_handle: ProcessHandle,
     combined_thread_handle: ThreadHandle,
     cpus: Vec<Cpu>,
 }
@@ -133,7 +133,6 @@ impl Cpus {
             profile.set_thread_name(thread, &name);
             let idle_string = profile.handle_for_string("<Idle>");
             let idle_frame = profile.handle_for_frame_with_label(
-                thread,
                 idle_string,
                 CategoryHandle::OTHER,
                 FrameFlags::empty(),

--- a/samply/src/shared/process_sample_data.rs
+++ b/samply/src/shared/process_sample_data.rs
@@ -1,5 +1,5 @@
 use fxprof_processed_profile::{
-    LibMappings, Marker, MarkerField, MarkerTiming, Profile, Schema, StringHandle,
+    LibMappings, Marker, MarkerField, MarkerTiming, ProcessHandle, Profile, Schema, StringHandle,
     SubcategoryHandle, ThreadHandle, Timestamp,
 };
 
@@ -29,6 +29,7 @@ pub enum RssStatMember {
 
 #[derive(Debug, Clone)]
 pub struct ProcessSampleData {
+    process_handle: ProcessHandle,
     unresolved_samples: UnresolvedSamples,
     regular_lib_mapping_op_queue: LibMappingOpQueue,
     jitdump_lib_mapping_op_queues: Vec<LibMappingOpQueue>,
@@ -38,6 +39,7 @@ pub struct ProcessSampleData {
 
 impl ProcessSampleData {
     pub fn new(
+        process_handle: ProcessHandle,
         unresolved_samples: UnresolvedSamples,
         regular_lib_mapping_op_queue: LibMappingOpQueue,
         jitdump_lib_mapping_op_queues: Vec<LibMappingOpQueue>,
@@ -45,6 +47,7 @@ impl ProcessSampleData {
         marker_spans: Vec<MarkerSpanOnThread>,
     ) -> Self {
         Self {
+            process_handle,
             unresolved_samples,
             regular_lib_mapping_op_queue,
             jitdump_lib_mapping_op_queues,
@@ -67,6 +70,7 @@ impl ProcessSampleData {
         stacks: &UnresolvedStacks,
     ) {
         let ProcessSampleData {
+            process_handle,
             unresolved_samples,
             regular_lib_mapping_op_queue,
             jitdump_lib_mapping_op_queues,
@@ -96,15 +100,13 @@ impl ProcessSampleData {
             stack_frame_scratch_buf.clear();
             stacks.convert_back(stack, stack_frame_scratch_buf);
             let frames = stack_converter.convert_stack(
-                thread_handle,
+                process_handle,
                 stack_frame_scratch_buf,
                 &lib_mappings_hierarchy,
                 extra_label_frame,
             );
-            let mut frames =
-                StackDepthLimitingFrameIter::new(profile, frames, thread_handle, user_category);
-            let stack_handle =
-                profile.handle_for_stack_frames(thread_handle, move |p| frames.next(p));
+            let mut frames = StackDepthLimitingFrameIter::new(profile, frames, user_category);
+            let stack_handle = profile.handle_for_stack_frames(move |p| frames.next(p));
             match sample_or_marker {
                 SampleOrMarker::Sample(SampleData { cpu_delta, weight }) => {
                     profile.add_sample(thread_handle, timestamp, stack_handle, cpu_delta, weight);

--- a/samply/src/shared/stack_converter.rs
+++ b/samply/src/shared/stack_converter.rs
@@ -2,7 +2,7 @@ use std::collections::VecDeque;
 use std::iter::{Cloned, Rev};
 
 use fxprof_processed_profile::{
-    FrameAddress, FrameFlags, FrameHandle, Profile, SubcategoryHandle, ThreadHandle,
+    FrameAddress, FrameFlags, FrameHandle, ProcessHandle, Profile, SubcategoryHandle,
 };
 
 use super::jit_category_manager::{JsFrame, JsName};
@@ -34,6 +34,7 @@ struct FirstPassIter<I: Iterator<Item = StackFrame>>(I);
 
 struct SecondPassIter<'a, I: Iterator<Item = FirstPassFrameInfo>> {
     inner: I,
+    process_handle: ProcessHandle,
     lib_mappings: &'a LibMappingsHierarchy,
     user_category: SubcategoryHandle,
     kernel_category: SubcategoryHandle,
@@ -47,7 +48,6 @@ struct LibartFilteringIter<'c, I: Iterator<Item = SecondPassFrameInfo>> {
 
 struct ConvertedStackIterD<I: Iterator<Item = SecondPassFrameInfo>> {
     inner: I,
-    thread: ThreadHandle,
     pending_frame_handle: Option<FrameHandle>,
     js_name_for_baseline_interpreter: Option<JsName>,
 }
@@ -123,17 +123,18 @@ impl<I: Iterator<Item = FirstPassFrameInfo>> Iterator for SecondPassIter<'_, I> 
                     )
                 }
                 None => {
+                    let p = self.process_handle;
                     let location = match from_ip {
-                        true => FrameAddress::InstructionPointer(lookup_address),
-                        false => FrameAddress::AdjustedReturnAddress(lookup_address),
+                        true => FrameAddress::InstructionPointer(p, lookup_address),
+                        false => FrameAddress::AdjustedReturnAddress(p, lookup_address),
                     };
                     (location, self.user_category, None, None)
                 }
             },
             StackMode::Kernel => {
                 let location = match from_ip {
-                    true => FrameAddress::InstructionPointer(lookup_address),
-                    false => FrameAddress::AdjustedReturnAddress(lookup_address),
+                    true => FrameAddress::KernelInstructionPointer(lookup_address),
+                    false => FrameAddress::KernelAdjustedReturnAddress(lookup_address),
                 };
                 (location, self.kernel_category, None, None)
             }
@@ -245,16 +246,12 @@ impl<I: Iterator<Item = SecondPassFrameInfo>> ConvertedStackIterD<I> {
         };
 
         let mut frame_handle =
-            profile.handle_for_frame_with_address(self.thread, location, category, frame_flags);
+            profile.handle_for_frame_with_address(location, category, frame_flags);
         if let Some(JsName::NonSelfHosted(js_name)) = extra_js_name {
             // Prepend a JS frame.
             // We don't treat Spidermonkey "self-hosted" functions as JS (e.g. filter/map/push).
-            let prepended_js_frame = profile.handle_for_frame_with_label(
-                self.thread,
-                js_name,
-                category,
-                FrameFlags::IS_JS,
-            );
+            let prepended_js_frame =
+                profile.handle_for_frame_with_label(js_name, category, FrameFlags::IS_JS);
             let buffered_frame = std::mem::replace(&mut frame_handle, prepended_js_frame);
             self.pending_frame_handle = Some(buffered_frame);
         };
@@ -287,7 +284,7 @@ impl StackConverter {
     /// Returns an iterator going from root caller to callee.
     pub fn convert_stack<'a>(
         &'a mut self,
-        thread: ThreadHandle,
+        process: ProcessHandle,
         stack: &'a [StackFrame],
         lib_mappings: &'a LibMappingsHierarchy,
         extra_first_frame: Option<FrameHandle>,
@@ -295,6 +292,7 @@ impl StackConverter {
         let pass1 = FirstPassIter(stack.iter().cloned().rev());
         let pass2 = SecondPassIter {
             inner: pass1,
+            process_handle: process,
             lib_mappings,
             user_category: self.user_category,
             kernel_category: self.kernel_category,
@@ -307,7 +305,6 @@ impl StackConverter {
         };
         let pass4 = ConvertedStackIterD {
             inner: pass3,
-            thread,
             pending_frame_handle: extra_first_frame,
             js_name_for_baseline_interpreter: None,
         };

--- a/samply/src/shared/stack_depth_limiting_frame_iter.rs
+++ b/samply/src/shared/stack_depth_limiting_frame_iter.rs
@@ -1,4 +1,4 @@
-use fxprof_processed_profile::{FrameFlags, FrameHandle, Profile, SubcategoryHandle, ThreadHandle};
+use fxprof_processed_profile::{FrameFlags, FrameHandle, Profile, SubcategoryHandle};
 
 use super::stack_converter::ConvertedStackIter;
 
@@ -59,7 +59,6 @@ impl<'a> StackDepthLimitingFrameIter<'a> {
     pub fn new(
         profile: &mut Profile,
         iter: ConvertedStackIter<'a>,
-        thread: ThreadHandle,
         category: SubcategoryHandle,
     ) -> Self {
         // Check if part of the stack should be elided, to limit the stack depth.
@@ -75,7 +74,6 @@ impl<'a> StackDepthLimitingFrameIter<'a> {
             let elision_frame_string =
                 profile.handle_for_string(&format!("({elided_count} frames elided)"));
             let elision_frame_handle = profile.handle_for_frame_with_label(
-                thread,
                 elision_frame_string,
                 category,
                 FrameFlags::empty(),

--- a/samply/src/windows/profile_context.rs
+++ b/samply/src/windows/profile_context.rs
@@ -210,6 +210,7 @@ impl Processes {
                 };
 
                 ProcessSampleData::new(
+                    process.handle,
                     process.unresolved_samples,
                     process.regular_lib_mapping_ops,
                     jitdump_lib_mapping_op_queues,
@@ -1331,7 +1332,6 @@ impl ProfileContext {
 
         if let Some((cpu_thread_handle, cpu_delta)) = per_cpu_stuff {
             let thread_label_frame = self.profile.handle_for_frame_with_label(
-                cpu_thread_handle,
                 thread_label,
                 CategoryHandle::OTHER,
                 FrameFlags::empty(),
@@ -1648,9 +1648,7 @@ impl ProfileContext {
                     let begin_timestamp = self
                         .timestamp_converter
                         .convert_time(idle_cpu_sample.begin_timestamp);
-                    let stack =
-                        self.profile
-                            .handle_for_stack(cpu.thread_handle, cpu.idle_frame, None);
+                    let stack = self.profile.handle_for_stack(cpu.idle_frame, None);
                     self.profile.add_sample(
                         cpu.thread_handle,
                         begin_timestamp,


### PR DESCRIPTION
See https://github.com/firefox-devtools/profiler/blob/main/docs-developer/CHANGELOG-formats.md .

Version 60 moves a lot of per-thread things to be profile-global.

This lets us simplify some APIs because we no longer need to pass a thread when creating frame or stack handles.