### PR TITLE
Don't enable coreclr by default, because it was also enabling --unlink-aux-files.

### DIFF
--- a/samply/src/cli.rs
+++ b/samply/src/cli.rs
@@ -336,8 +336,8 @@ pub struct ProfileCreationArgs {
     #[arg(long)]
     pub unknown_event_markers: bool,
 
-    /// Enable CoreCLR event conversion.
-    #[clap(long, require_equals = true, value_name = "FLAG", value_enum, value_delimiter = ',', num_args = 0.., default_values_t = vec![CoreClrArgs::Enabled])]
+    /// Enable CoreCLR event conversion. Implies --unlink-aux-files if set.
+    #[clap(long, require_equals = true, value_name = "FLAG", value_enum, value_delimiter = ',', num_args = 0.., default_values_t = Vec::<CoreClrArgs>::new(), default_missing_value = "enabled")]
     pub coreclr: Vec<CoreClrArgs>,
 }
 


### PR DESCRIPTION
On macOS with jitdump debug info you wouldn't get source information in the generated profiles because the jitdump files ended up being deleted before debug-level symbolication looked at them. And we were deleting them because we didn't want to litter directories with extra jitdump files that we'd cause by setting `DOTNET_PerfMapEnabled` environment variables.

Let's not set `DOTNET_PerfMapEnabled` by default.