### PR TITLE
Replace async-compression dependency with direct zlib-rs dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3201,7 +3201,6 @@ dependencies = [
 name = "wholesym"
 version = "0.8.1"
 dependencies = [
- "async-compression",
  "bytes",
  "core-foundation",
  "core-foundation-sys",
@@ -3225,6 +3224,7 @@ dependencies = [
  "uuid",
  "yoke",
  "yoke-derive",
+ "zlib-rs",
 ]
 
 [[package]]

--- a/wholesym/Cargo.toml
+++ b/wholesym/Cargo.toml
@@ -41,27 +41,16 @@ tokio = { version = "1.38", features = ["fs", "macros"] }
 futures-util = "0.3.30"
 fs4 = "0.13"
 thiserror = "2"
-async-compression = { version = "0.4", default-features = false, features = [
-    "tokio",
-    "futures-io",
-    "gzip"
-] }
 http = "1"
 scopeguard = { version = "1.2.0", default-features = false }
+zlib-rs = "0.6.3"
 
 # Needed for moria_mac_spotlight, to find dSYM files
 [target.'cfg(target_os = "macos")'.dependencies]
 core-foundation-sys = "0.8"
 core-foundation = "0.10"
 
-# Turn on the zlib-rs feature in flate2.
-# flate2 isn't used directly by wholesym; it's used via async-compression
-# So this is a (somewhat brittle) way to turn on the zlib-rs feature in
-# async-compression's use of flate2.
-[dependencies.flate2]
-version = "1.1.2"
-features = ["zlib-rs"]
-
 [dev-dependencies]
+flate2 = { version = "1.1.2", features = ["zlib-rs"] }
 futures = "0.3.5"
 tokio = { version = "1.38", features = ["macros", "rt", "rt-multi-thread"] } # Features for #[tokio::test]

--- a/wholesym/src/async_gzip_decoder.rs
+++ b/wholesym/src/async_gzip_decoder.rs
@@ -44,7 +44,6 @@ impl<R: AsyncRead + Unpin> AsyncGzipDecoder<R> {
     }
 
     /// Total number of compressed bytes consumed from the inner stream so far.
-    #[allow(unused)]
     pub fn total_in(&self) -> u64 {
         self.inflate.total_in()
     }

--- a/wholesym/src/async_gzip_decoder.rs
+++ b/wholesym/src/async_gzip_decoder.rs
@@ -1,0 +1,109 @@
+use std::pin::Pin;
+use std::task::Poll;
+
+use futures_util::AsyncRead;
+use zlib_rs::{Inflate, InflateFlush, Status};
+
+/// Streaming gzip decoder that wraps any `AsyncRead` source.
+pub struct AsyncGzipDecoder<R> {
+    inner: R,
+    inflate: Inflate,
+    /// Staging buffer for compressed bytes read from `inner`.
+    in_buf: Box<[u8]>,
+    in_start: usize,
+    in_end: usize,
+    done: bool,
+}
+
+fn make_gzip_inflate() -> Inflate {
+    // zlib-rs can decode both zlib and gzip wrappers, but the
+    // documentation currently only mentions zlib support.
+    // https://github.com/trifectatechfoundation/zlib-rs/issues/502
+    //
+    // To opt into gzip mode, we pass `zlib_header = true`` and
+    // `window_bits = 15 + 16``.
+    //
+    // 15 = max window bits for gzip (32KiB), +16 selects the gzip wrapper.
+    //
+    // Passing a window_bits outside of `8..=15` is, strictly speaking,
+    // an API contract violation. But maybe the comments will be adjusted
+    // to officially allow this use.
+    Inflate::new(true, 15 + 16)
+}
+
+impl<R: AsyncRead + Unpin> AsyncGzipDecoder<R> {
+    pub fn new(inner: R) -> Self {
+        Self {
+            inner,
+            inflate: make_gzip_inflate(),
+            in_buf: vec![0u8; 16 * 1024].into_boxed_slice(),
+            in_start: 0,
+            in_end: 0,
+            done: false,
+        }
+    }
+
+    /// Total number of compressed bytes consumed from the inner stream so far.
+    #[allow(unused)]
+    pub fn total_in(&self) -> u64 {
+        self.inflate.total_in()
+    }
+}
+
+impl<R: AsyncRead + Unpin> AsyncRead for AsyncGzipDecoder<R> {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &mut [u8],
+    ) -> Poll<std::io::Result<usize>> {
+        let me = self.get_mut();
+        if me.done || buf.is_empty() {
+            return Poll::Ready(Ok(0));
+        }
+        loop {
+            // Refill the staging buffer from the inner stream when exhausted.
+            if me.in_start >= me.in_end {
+                // Update in_start/in_end only after a successful read. If the
+                // inner reader returns Pending, leave them unchanged so the next
+                // poll sees the buffer as still exhausted and retries the refill.
+                let n = match Pin::new(&mut me.inner).poll_read(cx, &mut me.in_buf) {
+                    Poll::Pending => return Poll::Pending,
+                    Poll::Ready(Ok(n)) => n,
+                    Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
+                };
+                me.in_start = 0;
+                me.in_end = n;
+                if n == 0 {
+                    return Poll::Ready(Err(std::io::Error::new(
+                        std::io::ErrorKind::UnexpectedEof,
+                        "truncated gzip stream",
+                    )));
+                }
+            }
+
+            let input = &me.in_buf[me.in_start..me.in_end];
+            let prior_in = me.inflate.total_in();
+            let prior_out = me.inflate.total_out();
+            let status = match me.inflate.decompress(input, buf, InflateFlush::NoFlush) {
+                Ok(s) => s,
+                Err(e) => {
+                    return Poll::Ready(Err(std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        e.as_str(),
+                    )));
+                }
+            };
+            let consumed = (me.inflate.total_in() - prior_in) as usize;
+            let produced = (me.inflate.total_out() - prior_out) as usize;
+            me.in_start += consumed;
+
+            if status == Status::StreamEnd {
+                me.done = true;
+                return Poll::Ready(Ok(produced));
+            }
+            if produced > 0 {
+                return Poll::Ready(Ok(produced));
+            }
+        }
+    }
+}

--- a/wholesym/src/download.rs
+++ b/wholesym/src/download.rs
@@ -2,9 +2,9 @@ use std::pin::Pin;
 use std::sync::Mutex;
 use std::task::Poll;
 
-use async_compression::futures::bufread::GzipDecoder;
 use futures_util::io::BufReader;
 use futures_util::{AsyncRead, TryStreamExt};
+use crate::async_gzip_decoder::AsyncGzipDecoder;
 use reqwest::header::{AsHeaderName, HeaderMap, CONTENT_ENCODING, CONTENT_LENGTH};
 
 fn get_header<K: AsHeaderName>(headers: &HeaderMap, name: K) -> Option<String> {
@@ -81,20 +81,20 @@ where
     match (response_encoding.as_deref(), total_size) {
         (Some("gzip"), Some(TotalSize::Uncompressed(len))) => {
             let async_buf_read = BufReader::new(async_read);
-            let decoder = GzipDecoder::new(async_buf_read);
+            let decoder = AsyncGzipDecoder::new(async_buf_read);
             let decoder_with_progress = decoder.with_progress(progress, Some(len));
             Ok(Box::pin(decoder_with_progress))
         }
         (Some("gzip"), Some(TotalSize::Compressed(len))) => {
             let async_read_with_progress = async_read.with_progress(progress, Some(len));
             let async_buf_read = BufReader::new(async_read_with_progress);
-            let decoder = GzipDecoder::new(async_buf_read);
+            let decoder = AsyncGzipDecoder::new(async_buf_read);
             Ok(Box::pin(decoder))
         }
         (Some("gzip"), None) => {
             let async_read_with_progress = async_read.with_progress(progress, None);
             let async_buf_read = BufReader::new(async_read_with_progress);
-            let decoder = GzipDecoder::new(async_buf_read);
+            let decoder = AsyncGzipDecoder::new(async_buf_read);
             Ok(Box::pin(decoder))
         }
         (Some(other_encoding), _) => {

--- a/wholesym/src/download.rs
+++ b/wholesym/src/download.rs
@@ -1,9 +1,7 @@
 use std::pin::Pin;
-use std::sync::Mutex;
-use std::task::Poll;
 
-use futures_util::io::BufReader;
 use futures_util::{AsyncRead, TryStreamExt};
+
 use crate::async_gzip_decoder::AsyncGzipDecoder;
 use reqwest::header::{AsHeaderName, HeaderMap, CONTENT_ENCODING, CONTENT_LENGTH};
 
@@ -64,10 +62,73 @@ pub enum Error {
     UnexpectedContentEncoding(String),
 }
 
+pub struct UncompressedStream {
+    inner: UncompressedStreamInner,
+    total_compressed_size: Option<u64>,
+    total_uncompressed_size: Option<u64>,
+    consumed_compressed_bytes: u64,
+    produced_uncompressed_bytes: u64,
+    progress_callback: Box<dyn FnMut(u64, Option<u64>) + Send + Sync + 'static>,
+}
+
+#[allow(clippy::large_enum_variant)]
+enum UncompressedStreamInner {
+    Decoder(AsyncGzipDecoder<Pin<Box<dyn AsyncRead + Send + Sync>>>),
+    Stream(Pin<Box<dyn AsyncRead + Send + Sync>>),
+}
+
+impl UncompressedStream {
+    fn new(
+        inner: UncompressedStreamInner,
+        total_size: Option<TotalSize>,
+        progress_callback: Box<dyn FnMut(u64, Option<u64>) + Send + Sync + 'static>,
+    ) -> Self {
+        let (total_compressed_size, total_uncompressed_size) = match total_size {
+            Some(TotalSize::Compressed(s)) => (Some(s), None),
+            Some(TotalSize::Uncompressed(s)) => (None, Some(s)),
+            None => (None, None),
+        };
+        Self {
+            inner,
+            total_compressed_size,
+            total_uncompressed_size,
+            consumed_compressed_bytes: 0,
+            produced_uncompressed_bytes: 0,
+            progress_callback,
+        }
+    }
+
+    pub async fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        use futures_util::AsyncReadExt;
+        let (consumed_delta, produced) = match &mut self.inner {
+            UncompressedStreamInner::Decoder(decoder) => {
+                let prior_in = decoder.total_in();
+                let produced = decoder.read(buf).await?;
+                (decoder.total_in() - prior_in, produced)
+            }
+            UncompressedStreamInner::Stream(stream) => {
+                let produced = stream.read(buf).await?;
+                (produced as u64, produced)
+            }
+        };
+        self.consumed_compressed_bytes += consumed_delta;
+        self.produced_uncompressed_bytes += produced as u64;
+        if self.total_compressed_size.is_some() || self.total_uncompressed_size.is_none() {
+            (*self.progress_callback)(self.consumed_compressed_bytes, self.total_compressed_size);
+        } else {
+            (*self.progress_callback)(
+                self.produced_uncompressed_bytes,
+                self.total_uncompressed_size,
+            );
+        }
+        Ok(produced)
+    }
+}
+
 pub fn response_to_uncompressed_stream_with_progress<F>(
     response: reqwest::Response,
     progress: F,
-) -> Result<Pin<Box<dyn AsyncRead + Send + Sync>>, Error>
+) -> Result<UncompressedStream, Error>
 where
     F: FnMut(u64, Option<u64>) + Send + Sync + 'static,
 {
@@ -77,118 +138,19 @@ where
 
     let stream = response.bytes_stream();
     let async_read = stream.map_err(std::io::Error::other).into_async_read();
+    let async_read: Pin<Box<dyn AsyncRead + Send + Sync>> = Box::pin(async_read);
 
-    match (response_encoding.as_deref(), total_size) {
-        (Some("gzip"), Some(TotalSize::Uncompressed(len))) => {
-            let async_buf_read = BufReader::new(async_read);
-            let decoder = AsyncGzipDecoder::new(async_buf_read);
-            let decoder_with_progress = decoder.with_progress(progress, Some(len));
-            Ok(Box::pin(decoder_with_progress))
+    let inner = match response_encoding.as_deref() {
+        Some("gzip") => UncompressedStreamInner::Decoder(AsyncGzipDecoder::new(async_read)),
+        Some(other_encoding) => {
+            // Did we send a wrong Accept-Encoding header in the request? We only support gzip.
+            return Err(Error::UnexpectedContentEncoding(other_encoding.to_string()));
         }
-        (Some("gzip"), Some(TotalSize::Compressed(len))) => {
-            let async_read_with_progress = async_read.with_progress(progress, Some(len));
-            let async_buf_read = BufReader::new(async_read_with_progress);
-            let decoder = AsyncGzipDecoder::new(async_buf_read);
-            Ok(Box::pin(decoder))
-        }
-        (Some("gzip"), None) => {
-            let async_read_with_progress = async_read.with_progress(progress, None);
-            let async_buf_read = BufReader::new(async_read_with_progress);
-            let decoder = AsyncGzipDecoder::new(async_buf_read);
-            Ok(Box::pin(decoder))
-        }
-        (Some(other_encoding), _) => {
-            // TODO: Add support for brotli and deflate
-            Err(Error::UnexpectedContentEncoding(other_encoding.to_string()))
-        }
-        (None, Some(TotalSize::Uncompressed(len))) => {
-            Ok(Box::pin(async_read.with_progress(progress, Some(len))))
-        }
-        (None, _) => Ok(Box::pin(async_read.with_progress(progress, None))),
-    }
-}
-
-trait AsyncReadObserver {
-    fn did_read(&self, len: u64);
-}
-
-struct ProgressNotifierData<F: FnMut(u64, Option<u64>)> {
-    progress_fun: F,
-    total_size: Option<u64>,
-    accumulated_size: u64,
-}
-
-struct ProgressNotifier<F: FnMut(u64, Option<u64>)>(Mutex<ProgressNotifierData<F>>);
-
-impl<F: FnMut(u64, Option<u64>)> AsyncReadObserver for ProgressNotifier<F> {
-    fn did_read(&self, len: u64) {
-        let mut data = self.0.lock().unwrap();
-        data.accumulated_size += len;
-        let accum = data.accumulated_size;
-        let total_size = data.total_size;
-        match total_size {
-            Some(total_size) if accum <= total_size => (data.progress_fun)(accum, Some(total_size)),
-            _ => (data.progress_fun)(accum, None),
-        }
-    }
-}
-
-impl<F: FnMut(u64, Option<u64>)> ProgressNotifier<F> {
-    pub fn new(progress_fun: F, total_size: Option<u64>) -> Self {
-        Self(Mutex::new(ProgressNotifierData {
-            progress_fun,
-            total_size,
-            accumulated_size: 0,
-        }))
-    }
-}
-
-struct AsyncReadWrapper<I: AsyncRead> {
-    inner: Pin<Box<I>>,
-    observer: Pin<Box<dyn AsyncReadObserver + Send + Sync>>,
-}
-
-impl<I: AsyncRead> AsyncReadWrapper<I> {
-    pub fn new<O: AsyncReadObserver + Send + Sync + 'static>(inner: I, observer: O) -> Self {
-        Self {
-            inner: Box::pin(inner),
-            observer: Box::pin(observer),
-        }
-    }
-}
-
-impl<I: AsyncRead> AsyncRead for AsyncReadWrapper<I> {
-    fn poll_read(
-        mut self: std::pin::Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-        buf: &mut [u8],
-    ) -> Poll<std::io::Result<usize>> {
-        let res = Pin::new(&mut self.inner).poll_read(cx, buf);
-        match res {
-            Poll::Ready(Ok(len)) => {
-                self.observer.did_read(len as u64);
-                Poll::Ready(Ok(len))
-            }
-            Poll::Ready(Err(e)) => Poll::Ready(Err(e)),
-            Poll::Pending => Poll::Pending,
-        }
-    }
-}
-
-trait WithProgress: AsyncRead + Sized {
-    fn with_progress<F: FnMut(u64, Option<u64>) + Send + Sync + 'static>(
-        self,
-        progress_fun: F,
-        total_size: Option<u64>,
-    ) -> AsyncReadWrapper<Self>;
-}
-
-impl<AR: AsyncRead + Sized> WithProgress for AR {
-    fn with_progress<F: FnMut(u64, Option<u64>) + Send + Sync + 'static>(
-        self,
-        progress_fun: F,
-        total_size: Option<u64>,
-    ) -> AsyncReadWrapper<Self> {
-        AsyncReadWrapper::new(self, ProgressNotifier::new(progress_fun, total_size))
-    }
+        None => UncompressedStreamInner::Stream(async_read),
+    };
+    Ok(UncompressedStream::new(
+        inner,
+        total_size,
+        Box::new(progress),
+    ))
 }

--- a/wholesym/src/downloader.rs
+++ b/wholesym/src/downloader.rs
@@ -1,13 +1,10 @@
 use std::io::Write;
 use std::path::Path;
-use std::pin::Pin;
 use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use futures_util::{AsyncRead, AsyncReadExt as _};
-
-use crate::download::response_to_uncompressed_stream_with_progress;
+use crate::download::{response_to_uncompressed_stream_with_progress, UncompressedStream};
 use crate::file_creation::{create_file_cleanly, CleanFileCreationError};
 use crate::{async_double_buffer, DownloadError};
 
@@ -294,7 +291,7 @@ impl Downloader {
 
 pub struct PendingDownload {
     reporter: DownloadStatusReporter,
-    stream: Pin<Box<dyn AsyncRead + Send + Sync>>,
+    stream: UncompressedStream,
     observer: Option<Arc<dyn DownloaderObserver>>,
     ts_after_status: Instant,
 }
@@ -450,7 +447,7 @@ impl PendingDownload {
 }
 
 async fn consume_stream_and_write_to_file<C, O>(
-    mut stream: Pin<Box<dyn AsyncRead + Send + Sync>>,
+    mut stream: UncompressedStream,
     mut chunk_consumer: C,
     mut dest_file: std::fs::File,
 ) -> Result<(FileDownloadOutcome<O>, u64), DownloadError>

--- a/wholesym/src/lib.rs
+++ b/wholesym/src/lib.rs
@@ -133,6 +133,7 @@
 pub use debugid;
 
 mod async_double_buffer;
+mod async_gzip_decoder;
 mod breakpad;
 mod config;
 mod debuginfod;


### PR DESCRIPTION
zlib-rs can do push-based decoding - it tracks a partially parsed header etc.
We don't need to have extra wrapper crates around it.