### PR TITLE
Fix runaway memory usage when importing simpleperf profiles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1340,9 +1340,9 @@ checksum = "bfae20f6b19ad527b550c223fddc3077a547fc70cda94b9b566575423fd303ee"
 
 [[package]]
 name = "linux-perf-data"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fab2acdab7737b0c69f86496747f251231321db9141827b53d964f25b150807d"
+checksum = "79544deaf2626fe2d10e5f87af7b7fca93c0d0062fc6ec84fc24e463039c6750"
 dependencies = [
  "byteorder",
  "linear-map",

--- a/samply-symbols/Cargo.toml
+++ b/samply-symbols/Cargo.toml
@@ -57,7 +57,7 @@ yoke-derive = "0.8"
 nom = "7.1.1"
 zerocopy = "0.8"
 zerocopy-derive = "0.8"
-linux-perf-data = "0.12"
+linux-perf-data = { version = "0.13", default-features = false }
 crc32fast = "1.4.2"
 
 [dev-dependencies]

--- a/samply/Cargo.toml
+++ b/samply/Cargo.toml
@@ -14,8 +14,8 @@ readme = "README.md"
 fxprof-processed-profile = { version = "0.8", path = "../fxprof-processed-profile" }
 # framehop = { path = "../../framehop" }
 framehop = "0.16"
-# linux-perf-data = { path = "../../linux-perf-data" }
-linux-perf-data = "0.12"
+# linux-perf-data = { path = "../../linux-perf-data", default-features = false }
+linux-perf-data = { version = "0.13", default-features = false }
 
 tokio = { version = "1.39", features = ["rt", "rt-multi-thread", "macros"] }
 tokio-util = "0.7.11"

--- a/samply/src/import/perf.rs
+++ b/samply/src/import/perf.rs
@@ -7,7 +7,7 @@ use std::time::SystemTime;
 use framehop::{Module, Unwinder};
 use fxprof_processed_profile::{Profile, ReferenceTimestamp};
 use linux_perf_data::{linux_perf_event_reader, DsoInfo, DsoKey, PerfFileReader, PerfFileRecord};
-use linux_perf_event_reader::EventRecord;
+use linux_perf_event_reader::{EventRecord, RecordType};
 
 use crate::linux_shared::{
     ConvertRegs, ConvertRegsAarch64, ConvertRegsX86_64, Converter, EventInterpretation, KnownEvent,
@@ -198,12 +198,18 @@ where
             PerfFileRecord::UserRecord(_) => continue,
         };
         if let Some(timestamp) = record.timestamp() {
-            if timestamp < last_timestamp {
-                eprintln!(
-                    "bad timestamp ordering; {timestamp} is earlier but arrived after {last_timestamp}"
-                );
+            if !matches!(record.record_type, RecordType::MMAP | RecordType::MMAP2) {
+                if timestamp < last_timestamp {
+                    eprintln!(
+                        "Bad timestamp ordering for record of type {:?}:",
+                        record.record_type
+                    );
+                    eprintln!("  Record with timestamp {timestamp} arrived after record with timestamp {last_timestamp}.");
+                    eprintln!("Ignoring record.");
+                    continue;
+                }
+                last_timestamp = timestamp;
             }
-            last_timestamp = timestamp;
         }
 
         match parsed_record {


### PR DESCRIPTION
This updates to linux-perf-data 0.13.0 which contains the following commit: https://github.com/mstange/linux-perf-data/commit/eacf70230c8d817e4acfeafa1e2179df123329b3

See that commit for details.

I'm also making a change to ignore out-of-order records because they can mess up samply's on/off-CPU tracking.