### PR TITLE
Improve symbolication API validation and tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -466,6 +466,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
 name = "debugid"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3213,9 +3231,11 @@ dependencies = [
  "scopeguard",
  "serde",
  "symsrv",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "uuid",
+ "wiremock",
  "yoke",
  "yoke-derive",
  "zlib-rs",
@@ -3625,6 +3645,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e0e7162b9e282fd75a0a832cce93994bdb21208d848a418cd05a5fdd9b9ab33"
 dependencies = [
  "windows 0.48.0",
+]
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64",
+ "deadpool",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,6 +141,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -169,7 +180,7 @@ dependencies = [
  "flate2",
  "futures",
  "query-api",
- "reqwest",
+ "reqwest 0.13.2",
  "tar",
  "tempfile",
 ]
@@ -1737,6 +1748,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2114,7 +2131,6 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
- "futures-channel",
  "futures-core",
  "futures-util",
  "http",
@@ -2143,9 +2159,86 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.4.2",
  "web-sys",
  "webpki-roots",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams 0.5.0",
+ "web-sys",
+]
+
+[[package]]
+name = "reqwest-middleware"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "199dda04a536b532d0cc04d7979e39b1c763ea749bf91507017069c00b96056f"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "http",
+ "reqwest 0.13.2",
+ "thiserror 2.0.18",
+ "tower-service",
+]
+
+[[package]]
+name = "reqwest-retry"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe2412db2af7d2268e7a5406be0431f37d9eb67ff390f35b395716f5f06c2eaa"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "futures",
+ "getrandom 0.2.17",
+ "http",
+ "hyper",
+ "reqwest 0.13.2",
+ "reqwest-middleware",
+ "retry-policies",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "wasmtimer",
+]
+
+[[package]]
+name = "retry-policies"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a4bd6027df676bcb752d3724db0ea3c0c5fc1dd0376fec51ac7dcaf9cc69be"
+dependencies = [
+ "rand 0.9.4",
 ]
 
 [[package]]
@@ -2633,7 +2726,7 @@ dependencies = [
  "fs4",
  "futures-util",
  "http",
- "reqwest",
+ "reqwest 0.12.28",
  "scopeguard",
  "thiserror 2.0.18",
  "tokio",
@@ -2916,7 +3009,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3148,6 +3253,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3157,6 +3275,20 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "wasmtimer"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c598d6b99ea013e35844697fc4670d08339d5cda15588f193c6beedd12f644b"
+dependencies = [
+ "futures",
+ "js-sys",
+ "parking_lot",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3224,7 +3356,9 @@ dependencies = [
  "http",
  "libc",
  "memmap2",
- "reqwest",
+ "reqwest 0.13.2",
+ "reqwest-middleware",
+ "reqwest-retry",
  "samply-api",
  "samply-debugid",
  "samply-symbols",

--- a/samply-api/src/error.rs
+++ b/samply-api/src/error.rs
@@ -51,6 +51,9 @@ impl Serialize for Error {
     where
         S: serde::Serializer,
     {
-        self.to_string().serialize(serializer)
+        use serde::ser::SerializeMap;
+        let mut map = serializer.serialize_map(Some(1))?;
+        map.serialize_entry("title", &self.to_string())?;
+        map.end()
     }
 }

--- a/samply-api/src/error.rs
+++ b/samply-api/src/error.rs
@@ -34,6 +34,18 @@ pub enum Error {
     ),
 }
 
+impl Error {
+    /// Returns the HTTP status code that best describes this error.
+    pub fn http_status(&self) -> u16 {
+        match self {
+            Error::ParseRequestErrorSerde(_) => 400,
+            Error::ParseRequestErrorContents(_) => 400,
+            Error::UnrecognizedUrl(_) => 404,
+            Error::Symbols(_) | Error::Source(_) | Error::Asm(_) => 500,
+        }
+    }
+}
+
 impl Serialize for Error {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where

--- a/samply-api/src/lib.rs
+++ b/samply-api/src/lib.rs
@@ -202,6 +202,16 @@ impl<H: FileAndPathHelper> From<Error> for QueryApiJsonResult<H> {
     }
 }
 
+impl<H: FileAndPathHelper> QueryApiJsonResult<H> {
+    /// Returns the HTTP status code that best describes this result.
+    pub fn http_status(&self) -> u16 {
+        match self {
+            QueryApiJsonResult::Err(e) => e.http_status(),
+            _ => 200,
+        }
+    }
+}
+
 impl<H: FileAndPathHelper> Serialize for QueryApiJsonResult<H> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where

--- a/samply-api/src/lib.rs
+++ b/samply-api/src/lib.rs
@@ -161,6 +161,48 @@ mod symbolicate;
 
 pub use error::Error;
 
+/// The outcome of loading symbols for one module during a `/symbolicate/v5` request.
+#[derive(Debug, Clone)]
+pub enum ModuleLoadOutcome {
+    /// Symbols were loaded successfully.
+    Loaded,
+    /// Symbol loading failed.
+    ///
+    /// `error_name` is a stable identifier for the error kind (the enum variant name),
+    /// suitable for use as a metric tag or log field.
+    Failed { error_name: &'static str },
+}
+
+/// Per-module observability data collected during a `/symbolicate/v5` request.
+///
+/// The `load_duration` covers the full cost of making the module's symbols
+/// available: cache lookup, download (if needed), and parsing.  Download timing
+/// is also reported independently via [`wholesym::DownloaderObserver`] callbacks,
+/// which fire for every download regardless of which request triggered it.
+#[derive(Debug, Clone)]
+pub struct ModuleStat {
+    pub debug_name: String,
+    pub breakpad_id: String,
+    pub outcome: ModuleLoadOutcome,
+}
+
+/// Observability data for a `/symbolicate/v5` request.
+///
+/// Returned alongside the symbolication result so that callers can emit
+/// per-request metrics and structured log entries without having to parse the
+/// JSON response.  It is **not** included in the serialized JSON output.
+#[derive(Debug, Clone)]
+pub struct SymbolicateStats {
+    /// Number of jobs in the request.
+    pub jobs_count: usize,
+    /// Total number of stacks across all jobs.
+    pub stacks_count: usize,
+    /// Total number of frames across all jobs.
+    pub frames_count: usize,
+    /// One entry per unique (debug_name, breakpad_id) pair that was looked up.
+    pub module_stats: Vec<ModuleStat>,
+}
+
 pub(crate) fn to_debug_id(breakpad_id: &str) -> Result<DebugId, samply_symbols::Error> {
     // Only accept breakpad IDs with the right syntax, and which aren't all-zeros.
     match DebugId::from_breakpad(breakpad_id) {
@@ -208,6 +250,16 @@ impl<H: FileAndPathHelper> QueryApiJsonResult<H> {
         match self {
             QueryApiJsonResult::Err(e) => e.http_status(),
             _ => 200,
+        }
+    }
+
+    /// Returns observability statistics for `/symbolicate/v5` requests.
+    ///
+    /// Returns `None` for `/asm/v1`, `/source/v1`, and error responses.
+    pub fn symbolicate_stats(&self) -> Option<&SymbolicateStats> {
+        match self {
+            QueryApiJsonResult::SymbolicateResponse(r) => Some(&r.stats),
+            _ => None,
         }
     }
 }

--- a/samply-api/src/symbolicate/mod.rs
+++ b/samply-api/src/symbolicate/mod.rs
@@ -9,7 +9,7 @@ use samply_symbols::{
 use crate::error::Error;
 use crate::symbolicate::looked_up_addresses::{AddressResult, AddressResults};
 use crate::symbolicate::response_json::{LibSymbols, Response};
-use crate::to_debug_id;
+use crate::{to_debug_id, ModuleLoadOutcome, ModuleStat, SymbolicateStats};
 
 pub mod looked_up_addresses;
 pub mod request_json;
@@ -40,27 +40,56 @@ impl<'a, H: FileAndPathHelper + 'static> SymbolicateApi<'a, H> {
         request: request_json::Request,
     ) -> Result<response_json::Response<H>, Error> {
         let requested_addresses = gather_requested_addresses(&request)?;
-        let symbols_per_lib = self
+
+        let jobs_count = request.jobs().count();
+        let stacks_count = request.jobs().map(|j| j.stacks.len()).sum();
+        let frames_count = request
+            .jobs()
+            .map(|j| j.stacks.iter().map(|s| s.0.len()).sum::<usize>())
+            .sum();
+
+        let (symbols_per_lib, module_stats) = self
             .symbolicate_requested_addresses(requested_addresses)
             .await;
         Ok(Response {
             request,
             symbols_per_lib,
+            stats: SymbolicateStats {
+                jobs_count,
+                stacks_count,
+                frames_count,
+                module_stats,
+            },
         })
     }
 
     async fn symbolicate_requested_addresses(
         &self,
         requested_addresses: HashMap<Lib, Vec<u32>>,
-    ) -> HashMap<Lib, Result<LibSymbols<H>, samply_symbols::Error>> {
+    ) -> (
+        HashMap<Lib, Result<LibSymbols<H>, samply_symbols::Error>>,
+        Vec<ModuleStat>,
+    ) {
         let mut symbolicated_addresses = HashMap::new();
+        let mut module_stats = Vec::with_capacity(requested_addresses.len());
         for (lib, addresses) in requested_addresses.into_iter() {
             let address_results = self
                 .symbolicate_requested_addresses_for_lib(&lib, &addresses)
                 .await;
+            let outcome = match &address_results {
+                Ok(_) => ModuleLoadOutcome::Loaded,
+                Err(e) => ModuleLoadOutcome::Failed {
+                    error_name: e.enum_as_string(),
+                },
+            };
+            module_stats.push(ModuleStat {
+                debug_name: lib.debug_name.to_string(),
+                breakpad_id: lib.breakpad_id.to_string(),
+                outcome,
+            });
             symbolicated_addresses.insert(lib, address_results);
         }
-        symbolicated_addresses
+        (symbolicated_addresses, module_stats)
     }
 
     async fn symbolicate_requested_addresses_for_lib(

--- a/samply-api/src/symbolicate/mod.rs
+++ b/samply-api/src/symbolicate/mod.rs
@@ -68,7 +68,7 @@ impl<'a, H: FileAndPathHelper + 'static> SymbolicateApi<'a, H> {
         lib: &Lib,
         addresses: &[u32],
     ) -> Result<LibSymbols<H>, samply_symbols::Error> {
-        let debug_id = to_debug_id(&lib.breakpad_id)?;
+        let debug_id = to_debug_id(lib.breakpad_id.as_str())?;
 
         let info = LibraryInfo {
             debug_name: Some(lib.debug_name.to_string()),

--- a/samply-api/src/symbolicate/request_json.rs
+++ b/samply-api/src/symbolicate/request_json.rs
@@ -1,6 +1,9 @@
-use serde_derive::Deserialize;
+use std::fmt;
 
-#[derive(Deserialize, Debug)]
+use serde::de::{self, Deserializer};
+use serde::Deserialize;
+
+#[derive(serde_derive::Deserialize, Debug)]
 #[serde(untagged)]
 pub enum Request {
     WithJobsList { jobs: Vec<Job> },
@@ -16,23 +19,117 @@ impl Request {
     }
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(serde_derive::Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct Job {
     pub memory_map: Vec<Lib>,
     pub stacks: Vec<RequestStack>,
 }
 
-#[derive(Deserialize, Debug, PartialEq, Eq, Hash, Clone)]
-pub struct Lib {
-    pub debug_name: String,
-    pub breakpad_id: String,
+/// A debug filename whose characters have gone through some validation.
+///
+/// Allowed characters: alphanumeric and `_.+{}[]:@<> ~-`.
+///
+/// This check is based on eliot's `VALID_DEBUG_FILENAME` regex:
+/// `^([A-Za-z0-9_.+{}@<> ~-]*)$`, extended with `[]:` for kallsyms /
+/// kernel module names.
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+pub struct ValidDebugName(String);
+
+impl ValidDebugName {
+    pub fn new(s: String) -> Result<Self, String> {
+        if !is_valid_debug_filename(&s) {
+            return Err(format!("invalid debug_filename {s:?}"));
+        }
+        Ok(Self(s))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
 }
 
-#[derive(Deserialize, Debug)]
+impl fmt::Display for ValidDebugName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl<'de> Deserialize<'de> for ValidDebugName {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        Self::new(s).map_err(de::Error::custom)
+    }
+}
+
+impl serde::Serialize for ValidDebugName {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.0.serialize(serializer)
+    }
+}
+
+fn is_valid_debug_filename(s: &str) -> bool {
+    s.bytes().all(|b| {
+        matches!(b, b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9'
+            | b'_' | b'.' | b'+' | b'{' | b'}' | b'[' | b']' | b':' | b'@' | b'<' | b'>' | b' ' | b'~' | b'-')
+    })
+}
+
+/// A string whose characters have been validated to be hex digits.
+///
+/// Used for breakpad IDs in symbolication requests.
+/// The string is *not* required to / be a fully parseable [`debugid::DebugId`]
+/// — strict parsing happens later, per-lib, so that a single malformed ID
+/// fails just that lib's symbolication rather than the whole request.
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+pub struct HexString(String);
+
+impl HexString {
+    pub fn new(s: String) -> Result<Self, String> {
+        if !is_hex_string(&s) {
+            return Err(format!("invalid debug_id {s:?}"));
+        }
+        Ok(Self(s))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for HexString {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl<'de> Deserialize<'de> for HexString {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        Self::new(s).map_err(de::Error::custom)
+    }
+}
+
+impl serde::Serialize for HexString {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.0.serialize(serializer)
+    }
+}
+
+fn is_hex_string(s: &str) -> bool {
+    s.bytes().all(|b| b.is_ascii_hexdigit())
+}
+
+#[derive(serde_derive::Deserialize, Debug, PartialEq, Eq, Hash, Clone)]
+pub struct Lib {
+    pub debug_name: ValidDebugName,
+    pub breakpad_id: HexString,
+}
+
+#[derive(serde_derive::Deserialize, Debug)]
 pub struct RequestStack(pub Vec<RequestFrame>);
 
-#[derive(Deserialize, Debug)]
+#[derive(serde_derive::Deserialize, Debug)]
 pub struct RequestFrame {
     /// index into memory_map
     pub module_index: u32,
@@ -60,7 +157,48 @@ impl<'a> Iterator for JobIterator<'a> {
 mod test {
     use serde_json::Result;
 
-    use super::super::request_json::Request;
+    use super::super::request_json::{Lib, Request};
+
+    #[test]
+    fn valid_debug_filename_chars() {
+        // All allowed characters
+        let lib: Lib = serde_json::from_str(r#"["xul.pdb", "44E4EC8C"]"#).unwrap();
+        assert_eq!(lib.debug_name.as_str(), "xul.pdb");
+
+        // Spaces, tildes, braces, brackets, etc.
+        let lib: Lib =
+            serde_json::from_str(r#"["lib foo+bar{v2}@<arch> ~test-1", "AABB"]"#).unwrap();
+        assert_eq!(lib.debug_name.as_str(), "lib foo+bar{v2}@<arch> ~test-1");
+
+        // Square brackets — used for kallsyms / kernel module debug names
+        let lib: Lib = serde_json::from_str(r#"["[kernel.kallsyms]", ""]"#).unwrap();
+        assert_eq!(lib.debug_name.as_str(), "[kernel.kallsyms]");
+
+        // Empty string is allowed
+        let lib: Lib = serde_json::from_str(r#"["", ""]"#).unwrap();
+        assert_eq!(lib.debug_name.as_str(), "");
+    }
+
+    #[test]
+    fn invalid_debug_filename_rejected() {
+        // Slash is not allowed
+        assert!(serde_json::from_str::<Lib>(r#"["xul/pdb", "44E4EC8C"]"#).is_err());
+        // Backslash is not allowed
+        assert!(serde_json::from_str::<Lib>(r#"["xul\\pdb", "44E4EC8C"]"#).is_err());
+        // Exclamation mark is not allowed
+        assert!(serde_json::from_str::<Lib>(r#"["xul!pdb", "44E4EC8C"]"#).is_err());
+    }
+
+    #[test]
+    fn invalid_debug_id_rejected() {
+        // Non-hex character
+        assert!(
+            serde_json::from_str::<Lib>(r#"["xul.pdb", "44E4EC8C2F41492B9369D6B9A059577G"]"#)
+                .is_err()
+        );
+        // Hyphen not allowed in debug_id (only in debug_filename)
+        assert!(serde_json::from_str::<Lib>(r#"["xul.pdb", "44E4EC8C-2F41"]"#).is_err());
+    }
 
     #[test]
     fn parse_job() -> Result<()> {

--- a/samply-api/src/symbolicate/response_json.rs
+++ b/samply-api/src/symbolicate/response_json.rs
@@ -30,6 +30,8 @@ pub struct LibSymbols<H: FileAndPathHelper> {
 pub struct Response<H: FileAndPathHelper> {
     pub request: Request,
     pub symbols_per_lib: HashMap<Lib, Result<LibSymbols<H>, samply_symbols::Error>>,
+    /// Observability data; not included in the serialized JSON output.
+    pub stats: crate::SymbolicateStats,
 }
 
 impl<H: FileAndPathHelper> serde::Serialize for Response<H> {

--- a/tools/benchmarks/Cargo.toml
+++ b/tools/benchmarks/Cargo.toml
@@ -9,8 +9,7 @@ publish = false
 [dependencies]
 dump-table = { path = "../dump_table" }
 query-api = { path = "../query_api" }
-reqwest = { version = "0.12", default-features = false, features = [
-  "rustls-tls",
+reqwest = { version = "0.13", default-features = false, features = [
   "gzip",
   "blocking"
 ] }

--- a/wholesym/Cargo.toml
+++ b/wholesym/Cargo.toml
@@ -53,4 +53,6 @@ core-foundation = "0.10"
 [dev-dependencies]
 flate2 = { version = "1.1.2", features = ["zlib-rs"] }
 futures = "0.3.5"
+tempfile = "3"
 tokio = { version = "1.38", features = ["macros", "rt", "rt-multi-thread"] } # Features for #[tokio::test]
+wiremock = "0.6"

--- a/wholesym/Cargo.toml
+++ b/wholesym/Cargo.toml
@@ -28,8 +28,9 @@ yoke = "0.8"
 yoke-derive = "0.8"
 libc = "0.2"
 uuid = "1"
-reqwest = { version = "0.12", default-features = false, features = [
-    "rustls-tls",
+reqwest-middleware = "0.5"
+reqwest-retry = "0.9"
+reqwest = { version = "0.13", default-features = false, features = [
     "stream",
     "gzip",
     "brotli",

--- a/wholesym/src/breakpad.rs
+++ b/wholesym/src/breakpad.rs
@@ -70,7 +70,14 @@ impl BreakpadSymbolDownloader {
         Arc::get_mut(&mut self.inner).unwrap().observer = observer;
     }
 
-    pub async fn get_file(&self, rel_path: &str) -> Option<PathBuf> {
+    /// Download (if needed) and return the local path to the breakpad symbol file at `rel_path`.
+    ///
+    /// Returns:
+    /// - `Ok(Some(path))` — file found locally or successfully downloaded
+    /// - `Ok(None)` — all servers returned 404; the file definitively does not exist
+    /// - `Err(e)` — at least one server returned a transient error (5xx, 429, network
+    ///   failure, etc.); the file may exist but was unreachable
+    pub async fn get_file(&self, rel_path: &str) -> Result<Option<PathBuf>, DownloadError> {
         self.inner.get_file(rel_path).await
     }
 
@@ -122,20 +129,27 @@ impl BreakpadSymbolDownloaderInner {
         None
     }
 
-    pub async fn get_file(&self, rel_path: &str) -> Option<PathBuf> {
+    pub async fn get_file(&self, rel_path: &str) -> Result<Option<PathBuf>, DownloadError> {
         if let Some(path) = self.get_file_no_download(rel_path).await {
-            return Some(path);
+            return Ok(Some(path));
         }
 
+        let mut transient_error: Option<DownloadError> = None;
         for (server_base_url, cache_dir) in &self.breakpad_servers {
-            if let Ok(path) = self
+            match self
                 .get_bp_sym_file_from_server(rel_path, server_base_url, cache_dir)
                 .await
             {
-                return Some(path);
+                Ok(path) => return Ok(Some(path)),
+                Err(DownloadError::StatusError(404)) => {}
+                Err(e) => transient_error = Some(e),
             }
         }
-        None
+
+        match transient_error {
+            Some(e) => Err(e),
+            None => Ok(None),
+        }
     }
 
     /// Return whether a file is found at `path`, and notify the observer if not.
@@ -426,8 +440,8 @@ mod tests {
             Some(Arc::new(Downloader::new_with_max_retries(0))),
         );
         let result = downloader.get_file(REL_PATH).await;
-        assert!(result.is_some());
-        assert!(result.unwrap().exists());
+        assert!(result.as_ref().unwrap().is_some());
+        assert!(result.unwrap().unwrap().exists());
     }
 
     #[tokio::test]
@@ -457,8 +471,8 @@ mod tests {
             None,
         );
         let result = downloader.get_file(REL_PATH).await;
-        assert!(result.is_some());
-        assert!(result.unwrap().exists());
+        assert!(result.as_ref().unwrap().is_some());
+        assert!(result.unwrap().unwrap().exists());
     }
 
     #[tokio::test]
@@ -488,6 +502,56 @@ mod tests {
             None,
         );
         let result = downloader.get_file(REL_PATH).await;
-        assert!(result.is_none());
+        assert!(matches!(result, Ok(None)));
+    }
+
+    #[tokio::test]
+    async fn get_file_returns_err_on_transient_server_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(format!("/{REL_PATH}")))
+            .respond_with(ResponseTemplate::new(503))
+            .mount(&server)
+            .await;
+
+        let cache_dir = tempfile::tempdir().unwrap();
+        let downloader = BreakpadSymbolDownloader::new(
+            vec![],
+            vec![(server.uri(), cache_dir.path().to_path_buf())],
+            None,
+            Some(Arc::new(Downloader::new_with_max_retries(0))),
+        );
+        let result = downloader.get_file(REL_PATH).await;
+        assert!(matches!(result, Err(DownloadError::StatusError(503))));
+    }
+
+    #[tokio::test]
+    async fn get_file_returns_err_when_first_server_transient_second_server_404() {
+        let server1 = MockServer::start().await;
+        let server2 = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(format!("/{REL_PATH}")))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server1)
+            .await;
+        Mock::given(method("GET"))
+            .and(path(format!("/{REL_PATH}")))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server2)
+            .await;
+
+        let cache_dir1 = tempfile::tempdir().unwrap();
+        let cache_dir2 = tempfile::tempdir().unwrap();
+        let downloader = BreakpadSymbolDownloader::new(
+            vec![],
+            vec![
+                (server1.uri(), cache_dir1.path().to_path_buf()),
+                (server2.uri(), cache_dir2.path().to_path_buf()),
+            ],
+            None,
+            Some(Arc::new(Downloader::new_with_max_retries(0))),
+        );
+        let result = downloader.get_file(REL_PATH).await;
+        assert!(matches!(result, Err(DownloadError::StatusError(500))));
     }
 }

--- a/wholesym/src/breakpad.rs
+++ b/wholesym/src/breakpad.rs
@@ -332,6 +332,8 @@ impl ChunkConsumer for BreakpadIndexCreatorChunkConsumer {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use super::*;
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -421,7 +423,7 @@ mod tests {
             vec![],
             vec![(server.uri(), cache_dir.path().to_path_buf())],
             None,
-            None,
+            Some(Arc::new(Downloader::new_with_max_retries(0))),
         );
         let result = downloader.get_file(REL_PATH).await;
         assert!(result.is_some());

--- a/wholesym/src/breakpad.rs
+++ b/wholesym/src/breakpad.rs
@@ -1,6 +1,8 @@
+use std::collections::HashMap;
 use std::io::Read;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
 
 use samply_symbols::{BreakpadIndex, BreakpadIndexCreator, BreakpadParseError, OwnedBreakpadIndex};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -54,6 +56,8 @@ impl BreakpadSymbolDownloader {
             breakpad_symindex_cache_dir,
             observer: None,
             downloader: downloader.unwrap_or_default(),
+            negative_cache_ttl: None,
+            negative_cache: Mutex::new(HashMap::new()),
         };
         Self {
             inner: Arc::new(inner),
@@ -68,6 +72,17 @@ impl BreakpadSymbolDownloader {
     /// See the [`DownloaderObserver`] trait for more information.
     pub fn set_observer(&mut self, observer: Option<Arc<dyn DownloaderObserver>>) {
         Arc::get_mut(&mut self.inner).unwrap().observer = observer;
+    }
+
+    /// Set the TTL for the in-memory negative cache.
+    ///
+    /// When set, `get_file` will remember paths for which all servers returned 404, and
+    /// return `Ok(None)` immediately for subsequent requests within the TTL, without
+    /// contacting the servers again. Transient errors are never cached.
+    ///
+    /// By default no negative caching is performed.
+    pub fn set_negative_cache_ttl(&mut self, ttl: Duration) {
+        Arc::get_mut(&mut self.inner).unwrap().negative_cache_ttl = Some(ttl);
     }
 
     /// Download (if needed) and return the local path to the breakpad symbol file at `rel_path`.
@@ -107,6 +122,8 @@ struct BreakpadSymbolDownloaderInner {
     breakpad_symindex_cache_dir: Option<PathBuf>,
     observer: Option<Arc<dyn DownloaderObserver>>,
     downloader: Arc<Downloader>,
+    negative_cache_ttl: Option<Duration>,
+    negative_cache: Mutex<HashMap<String, Instant>>,
 }
 
 impl BreakpadSymbolDownloaderInner {
@@ -134,6 +151,15 @@ impl BreakpadSymbolDownloaderInner {
             return Ok(Some(path));
         }
 
+        if let Some(ttl) = self.negative_cache_ttl {
+            let cached_at = self.negative_cache.lock().unwrap().get(rel_path).copied();
+            if let Some(cached_at) = cached_at {
+                if cached_at.elapsed() < ttl {
+                    return Ok(None);
+                }
+            }
+        }
+
         let mut transient_error: Option<DownloadError> = None;
         for (server_base_url, cache_dir) in &self.breakpad_servers {
             match self
@@ -148,7 +174,15 @@ impl BreakpadSymbolDownloaderInner {
 
         match transient_error {
             Some(e) => Err(e),
-            None => Ok(None),
+            None => {
+                if self.negative_cache_ttl.is_some() {
+                    self.negative_cache
+                        .lock()
+                        .unwrap()
+                        .insert(rel_path.to_owned(), Instant::now());
+                }
+                Ok(None)
+            }
         }
     }
 
@@ -553,5 +587,58 @@ mod tests {
         );
         let result = downloader.get_file(REL_PATH).await;
         assert!(matches!(result, Err(DownloadError::StatusError(500))));
+    }
+
+    #[tokio::test]
+    async fn negative_cache_suppresses_second_request_after_404() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(format!("/{REL_PATH}")))
+            .respond_with(ResponseTemplate::new(404))
+            .expect(1) // must be called exactly once despite two get_file calls
+            .mount(&server)
+            .await;
+
+        let cache_dir = tempfile::tempdir().unwrap();
+        let mut downloader = BreakpadSymbolDownloader::new(
+            vec![],
+            vec![(server.uri(), cache_dir.path().to_path_buf())],
+            None,
+            Some(Arc::new(Downloader::new_with_max_retries(0))),
+        );
+        downloader.set_negative_cache_ttl(Duration::from_secs(60));
+
+        assert!(matches!(downloader.get_file(REL_PATH).await, Ok(None)));
+        assert!(matches!(downloader.get_file(REL_PATH).await, Ok(None)));
+        // wiremock will fail the test if the server was called more than once
+    }
+
+    #[tokio::test]
+    async fn negative_cache_does_not_suppress_request_after_transient_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(format!("/{REL_PATH}")))
+            .respond_with(ResponseTemplate::new(503))
+            .expect(2) // must be called both times
+            .mount(&server)
+            .await;
+
+        let cache_dir = tempfile::tempdir().unwrap();
+        let mut downloader = BreakpadSymbolDownloader::new(
+            vec![],
+            vec![(server.uri(), cache_dir.path().to_path_buf())],
+            None,
+            Some(Arc::new(Downloader::new_with_max_retries(0))),
+        );
+        downloader.set_negative_cache_ttl(Duration::from_secs(60));
+
+        assert!(matches!(
+            downloader.get_file(REL_PATH).await,
+            Err(DownloadError::StatusError(503))
+        ));
+        assert!(matches!(
+            downloader.get_file(REL_PATH).await,
+            Err(DownloadError::StatusError(503))
+        ));
     }
 }

--- a/wholesym/src/breakpad.rs
+++ b/wholesym/src/breakpad.rs
@@ -329,3 +329,163 @@ impl ChunkConsumer for BreakpadIndexCreatorChunkConsumer {
         self.0.finish()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    // Minimal valid breakpad sym file.
+    const TESTPROJ_SYM: &[u8] = b"MODULE Linux x86_64 D48F191186D67E69DF025AD71FB91E1F0 testproj\nFILE 0 /home/user/main.rs\nFUNC 5380 44 0 testproj::main\n5380 9 1 0\n";
+    const REL_PATH: &str = "testproj/D48F191186D67E69DF025AD71FB91E1F0/testproj.sym";
+
+    #[tokio::test]
+    async fn get_file_no_download_finds_local_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let sym_path = dir.path().join(REL_PATH);
+        std::fs::create_dir_all(sym_path.parent().unwrap()).unwrap();
+        std::fs::write(&sym_path, TESTPROJ_SYM).unwrap();
+
+        let downloader =
+            BreakpadSymbolDownloader::new(vec![dir.path().to_path_buf()], vec![], None, None);
+        let result = downloader.get_file_no_download(REL_PATH).await;
+        assert_eq!(result, Some(sym_path));
+    }
+
+    #[tokio::test]
+    async fn get_file_no_download_returns_none_when_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let downloader =
+            BreakpadSymbolDownloader::new(vec![dir.path().to_path_buf()], vec![], None, None);
+        let result = downloader.get_file_no_download(REL_PATH).await;
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn ensure_symindex_creates_valid_symindex() {
+        let sym_dir = tempfile::tempdir().unwrap();
+        let symindex_dir = tempfile::tempdir().unwrap();
+        let sym_path = sym_dir.path().join(REL_PATH);
+        std::fs::create_dir_all(sym_path.parent().unwrap()).unwrap();
+        std::fs::write(&sym_path, TESTPROJ_SYM).unwrap();
+
+        let downloader = BreakpadSymbolDownloader::new(
+            vec![sym_dir.path().to_path_buf()],
+            vec![],
+            Some(symindex_dir.path().to_path_buf()),
+            None,
+        );
+        let symindex_path = downloader
+            .ensure_symindex(&sym_path, REL_PATH)
+            .await
+            .unwrap();
+        assert!(symindex_path.exists());
+    }
+
+    #[tokio::test]
+    async fn ensure_symindex_errors_on_malformed_sym_file() {
+        let sym_dir = tempfile::tempdir().unwrap();
+        let symindex_dir = tempfile::tempdir().unwrap();
+        let sym_path = sym_dir.path().join(REL_PATH);
+        std::fs::create_dir_all(sym_path.parent().unwrap()).unwrap();
+        std::fs::write(&sym_path, b"this is junk").unwrap();
+
+        let downloader = BreakpadSymbolDownloader::new(
+            vec![sym_dir.path().to_path_buf()],
+            vec![],
+            Some(symindex_dir.path().to_path_buf()),
+            None,
+        );
+        let err = downloader
+            .ensure_symindex(&sym_path, REL_PATH)
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, SymindexGenerationError::BreakpadParsing(_)),
+            "{err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn get_file_downloads_from_server() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(format!("/{REL_PATH}")))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(TESTPROJ_SYM))
+            .mount(&server)
+            .await;
+
+        let cache_dir = tempfile::tempdir().unwrap();
+        let downloader = BreakpadSymbolDownloader::new(
+            vec![],
+            vec![(server.uri(), cache_dir.path().to_path_buf())],
+            None,
+            None,
+        );
+        let result = downloader.get_file(REL_PATH).await;
+        assert!(result.is_some());
+        assert!(result.unwrap().exists());
+    }
+
+    #[tokio::test]
+    async fn get_file_falls_back_to_second_server_on_404() {
+        let server1 = MockServer::start().await;
+        let server2 = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(format!("/{REL_PATH}")))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server1)
+            .await;
+        Mock::given(method("GET"))
+            .and(path(format!("/{REL_PATH}")))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(TESTPROJ_SYM))
+            .mount(&server2)
+            .await;
+
+        let cache_dir1 = tempfile::tempdir().unwrap();
+        let cache_dir2 = tempfile::tempdir().unwrap();
+        let downloader = BreakpadSymbolDownloader::new(
+            vec![],
+            vec![
+                (server1.uri(), cache_dir1.path().to_path_buf()),
+                (server2.uri(), cache_dir2.path().to_path_buf()),
+            ],
+            None,
+            None,
+        );
+        let result = downloader.get_file(REL_PATH).await;
+        assert!(result.is_some());
+        assert!(result.unwrap().exists());
+    }
+
+    #[tokio::test]
+    async fn get_file_returns_none_when_all_servers_404() {
+        let server1 = MockServer::start().await;
+        let server2 = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(format!("/{REL_PATH}")))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server1)
+            .await;
+        Mock::given(method("GET"))
+            .and(path(format!("/{REL_PATH}")))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server2)
+            .await;
+
+        let cache_dir1 = tempfile::tempdir().unwrap();
+        let cache_dir2 = tempfile::tempdir().unwrap();
+        let downloader = BreakpadSymbolDownloader::new(
+            vec![],
+            vec![
+                (server1.uri(), cache_dir1.path().to_path_buf()),
+                (server2.uri(), cache_dir2.path().to_path_buf()),
+            ],
+            None,
+            None,
+        );
+        let result = downloader.get_file(REL_PATH).await;
+        assert!(result.is_none());
+    }
+}

--- a/wholesym/src/config.rs
+++ b/wholesym/src/config.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
+use std::time::Duration;
 
 use symsrv::{parse_nt_symbol_path, NtSymbolPathEntry};
 
@@ -14,6 +15,7 @@ pub struct SymbolManagerConfig {
     pub(crate) breakpad_directories_readonly: Vec<PathBuf>,
     pub(crate) breakpad_servers: Vec<(String, PathBuf)>,
     pub(crate) breakpad_symindex_cache_dir: Option<PathBuf>,
+    pub(crate) breakpad_negative_cache_ttl: Option<Duration>,
     pub(crate) windows_servers: Vec<(String, PathBuf)>,
     pub(crate) use_debuginfod: bool,
     pub(crate) use_spotlight: bool,
@@ -112,6 +114,19 @@ impl SymbolManagerConfig {
     /// reading and writing.
     pub fn breakpad_symindex_cache_dir(mut self, dir: impl Into<PathBuf>) -> Self {
         self.breakpad_symindex_cache_dir = Some(dir.into());
+        self
+    }
+
+    /// Set the TTL for the in-memory negative cache for breakpad symbol server lookups.
+    ///
+    /// When set, paths for which all servers returned 404 are remembered in memory, and
+    /// subsequent requests for the same path within the TTL return "not found" immediately
+    /// without contacting the servers. Paths that failed with transient errors (5xx, 429,
+    /// network failures) are never cached.
+    ///
+    /// By default no negative caching is performed.
+    pub fn breakpad_negative_cache_ttl(mut self, ttl: Duration) -> Self {
+        self.breakpad_negative_cache_ttl = Some(ttl);
         self
     }
 

--- a/wholesym/src/config.rs
+++ b/wholesym/src/config.rs
@@ -23,6 +23,7 @@ pub struct SymbolManagerConfig {
     pub(crate) debuginfod_servers: Vec<(String, PathBuf)>,
     pub(crate) extra_symbol_directories: Vec<PathBuf>,
     pub(crate) simpleperf_binary_cache_directories: Vec<PathBuf>,
+    pub(crate) user_agent: Option<String>,
 }
 
 impl SymbolManagerConfig {
@@ -197,6 +198,14 @@ impl SymbolManagerConfig {
     /// The simpleperf scripts pull files from the Android device into this directory.
     pub fn simpleperf_binary_cache_dir(mut self, dir: impl Into<PathBuf>) -> Self {
         self.simpleperf_binary_cache_directories.push(dir.into());
+        self
+    }
+
+    /// Set the `User-Agent` header sent with all HTTP download requests.
+    ///
+    /// If not set, reqwest's default `User-Agent` is used.
+    pub fn user_agent(mut self, user_agent: impl Into<String>) -> Self {
+        self.user_agent = Some(user_agent.into());
         self
     }
 }

--- a/wholesym/src/downloader.rs
+++ b/wholesym/src/downloader.rs
@@ -4,6 +4,10 @@ use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use reqwest_middleware::ClientWithMiddleware;
+use reqwest_retry::policies::ExponentialBackoff;
+use reqwest_retry::RetryTransientMiddleware;
+
 use crate::download::{response_to_uncompressed_stream_with_progress, UncompressedStream};
 use crate::file_creation::{create_file_cleanly, CleanFileCreationError};
 use crate::{async_double_buffer, DownloadError};
@@ -175,7 +179,7 @@ impl ChunkConsumer for NoopChunkConsumer {
 }
 
 pub struct Downloader {
-    reqwest_client: Result<reqwest::Client, reqwest::Error>,
+    reqwest_client: Result<ClientWithMiddleware, reqwest::Error>,
 }
 
 impl Default for Downloader {
@@ -186,6 +190,13 @@ impl Default for Downloader {
 
 impl Downloader {
     pub fn new() -> Self {
+        Self::new_with_max_retries(5)
+    }
+
+    /// Create a `Downloader` that retries transient failures (5xx, 429, connection
+    /// errors) up to `max_retries` additional times with exponential backoff.
+    /// Pass `0` to disable retries — useful in tests.
+    pub fn new_with_max_retries(max_retries: u32) -> Self {
         let builder = reqwest::Client::builder();
 
         // Turn off HTTP 2, in order to work around https://github.com/seanmonstar/reqwest/issues/1761 .
@@ -199,7 +210,12 @@ impl Downloader {
 
         // Create the client.
         // TODO: Add timeouts, user agent, maybe other settings
-        let reqwest_client = builder.build();
+        let reqwest_client = builder.build().map(|client| {
+            let retry_policy = ExponentialBackoff::builder().build_with_max_retries(max_retries);
+            reqwest_middleware::ClientBuilder::new(client)
+                .with(RetryTransientMiddleware::new_with_policy(retry_policy))
+                .build()
+        });
 
         Self { reqwest_client }
     }
@@ -227,10 +243,18 @@ impl Downloader {
         let request_builder = request_builder.header("Accept-Encoding", "gzip");
 
         // Send the request and wait for the headers.
-        let response_result = request_builder.send().await;
-
-        // Check the HTTP status code.
-        let response_result = response_result.and_then(|response| response.error_for_status());
+        // The retry middleware handles transient failures (5xx, 429, connection errors)
+        // transparently before returning here.
+        let response_result: Result<reqwest::Response, reqwest::Error> =
+            match request_builder.send().await {
+                Ok(response) => response.error_for_status(),
+                Err(reqwest_middleware::Error::Reqwest(e)) => Err(e),
+                Err(reqwest_middleware::Error::Middleware(e)) => {
+                    let s = e.to_string();
+                    reporter.download_failed(DownloadError::Other(s.clone().into()));
+                    return Err(DownloadError::Other(s.into()));
+                }
+            };
 
         let response = match response_result {
             Ok(response) => response,
@@ -550,6 +574,10 @@ mod tests {
     use wiremock::matchers::method;
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
+    // Use max_retries=0 in tests that expect errors so that retry backoff
+    // delays don't slow them down. Tests that expect success are unaffected
+    // since the first attempt succeeds immediately.
+
     #[tokio::test]
     async fn download_200_returns_bytes() {
         let server = MockServer::start().await;
@@ -558,7 +586,7 @@ mod tests {
             .mount(&server)
             .await;
 
-        let downloader = Downloader::new();
+        let downloader = Downloader::new_with_max_retries(0);
         let pending = downloader
             .initiate_download(&server.uri(), None)
             .await
@@ -575,7 +603,7 @@ mod tests {
             .mount(&server)
             .await;
 
-        let downloader = Downloader::new();
+        let downloader = Downloader::new_with_max_retries(0);
         let result = downloader.initiate_download(&server.uri(), None).await;
         assert!(matches!(result, Err(DownloadError::StatusError(404))));
     }
@@ -588,8 +616,52 @@ mod tests {
             .mount(&server)
             .await;
 
-        let downloader = Downloader::new();
+        let downloader = Downloader::new_with_max_retries(0);
         let result = downloader.initiate_download(&server.uri(), None).await;
         assert!(matches!(result, Err(DownloadError::StatusError(500))));
+    }
+
+    #[tokio::test]
+    async fn download_500_retried_then_succeeds() {
+        let server = MockServer::start().await;
+        // First two requests return 500; third returns 200.
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(500))
+            .up_to_n_times(2)
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(b"ok".as_ref()))
+            .mount(&server)
+            .await;
+
+        // max_retries=2 means up to 3 total attempts — enough to get past the two 500s.
+        // Use a very short min backoff to keep the test fast.
+        let retry_policy = ExponentialBackoff::builder()
+            .retry_bounds(
+                std::time::Duration::from_millis(1),
+                std::time::Duration::from_millis(10),
+            )
+            .build_with_max_retries(2);
+        let client = reqwest::Client::builder()
+            .http1_only()
+            .no_gzip()
+            .no_brotli()
+            .no_deflate()
+            .build()
+            .unwrap();
+        let middleware_client = reqwest_middleware::ClientBuilder::new(client)
+            .with(RetryTransientMiddleware::new_with_policy(retry_policy))
+            .build();
+        let downloader = Downloader {
+            reqwest_client: Ok(middleware_client),
+        };
+
+        let pending = downloader
+            .initiate_download(&server.uri(), None)
+            .await
+            .unwrap();
+        let bytes = pending.download_to_memory().await.unwrap();
+        assert_eq!(bytes, b"ok");
     }
 }

--- a/wholesym/src/downloader.rs
+++ b/wholesym/src/downloader.rs
@@ -543,3 +543,53 @@ where
         uncompressed_size_in_bytes,
     ))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wiremock::matchers::method;
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    #[tokio::test]
+    async fn download_200_returns_bytes() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(b"abcde".as_ref()))
+            .mount(&server)
+            .await;
+
+        let downloader = Downloader::new();
+        let pending = downloader
+            .initiate_download(&server.uri(), None)
+            .await
+            .unwrap();
+        let bytes = pending.download_to_memory().await.unwrap();
+        assert_eq!(bytes, b"abcde");
+    }
+
+    #[tokio::test]
+    async fn download_404_returns_status_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+
+        let downloader = Downloader::new();
+        let result = downloader.initiate_download(&server.uri(), None).await;
+        assert!(matches!(result, Err(DownloadError::StatusError(404))));
+    }
+
+    #[tokio::test]
+    async fn download_500_returns_status_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+
+        let downloader = Downloader::new();
+        let result = downloader.initiate_download(&server.uri(), None).await;
+        assert!(matches!(result, Err(DownloadError::StatusError(500))));
+    }
+}

--- a/wholesym/src/downloader.rs
+++ b/wholesym/src/downloader.rs
@@ -190,13 +190,24 @@ impl Default for Downloader {
 
 impl Downloader {
     pub fn new() -> Self {
-        Self::new_with_max_retries(5)
+        Self::new_internal(5, None)
+    }
+
+    /// Create a `Downloader` with the given `User-Agent` header string and the default
+    /// retry policy (5 retries with exponential backoff).
+    pub fn new_with_user_agent(user_agent: &str) -> Self {
+        Self::new_internal(5, Some(user_agent))
     }
 
     /// Create a `Downloader` that retries transient failures (5xx, 429, connection
     /// errors) up to `max_retries` additional times with exponential backoff.
     /// Pass `0` to disable retries — useful in tests.
-    pub fn new_with_max_retries(max_retries: u32) -> Self {
+    #[cfg(test)]
+    pub(crate) fn new_with_max_retries(max_retries: u32) -> Self {
+        Self::new_internal(max_retries, None)
+    }
+
+    fn new_internal(max_retries: u32, user_agent: Option<&str>) -> Self {
         let builder = reqwest::Client::builder();
 
         // Turn off HTTP 2, in order to work around https://github.com/seanmonstar/reqwest/issues/1761 .
@@ -208,8 +219,12 @@ impl Downloader {
         // Instead, we do the streaming decompression manually, see download.rs.
         let builder = builder.no_gzip().no_brotli().no_deflate();
 
-        // Create the client.
-        // TODO: Add timeouts, user agent, maybe other settings
+        let builder = match user_agent {
+            Some(ua) => builder.user_agent(ua),
+            None => builder,
+        };
+
+        // TODO: Add timeouts
         let reqwest_client = builder.build().map(|client| {
             let retry_policy = ExponentialBackoff::builder().build_with_max_retries(max_retries);
             reqwest_middleware::ClientBuilder::new(client)

--- a/wholesym/src/helper.rs
+++ b/wholesym/src/helper.rs
@@ -293,6 +293,9 @@ impl Helper {
             Some(downloader.clone()),
         );
         breakpad_downloader.set_observer(Some(observer.clone()));
+        if let Some(ttl) = config.breakpad_negative_cache_ttl {
+            breakpad_downloader.set_negative_cache_ttl(ttl);
+        }
         Self {
             downloader,
             symsrv_downloader,

--- a/wholesym/src/helper.rs
+++ b/wholesym/src/helper.rs
@@ -576,11 +576,12 @@ impl FileAndPathHelper for Helper {
         }
 
         if let (Some(debug_name), Some(debug_id)) = (&info.debug_name, info.debug_id) {
+            let safe_debug_name = sanitize_breakpad_path_component(debug_name);
             let rel_path = format!(
                 "{}/{}/{}.sym",
-                debug_name,
+                safe_debug_name,
                 debug_id.breakpad(),
-                debug_name.trim_end_matches(".pdb")
+                safe_debug_name.trim_end_matches(".pdb")
             );
 
             // Search breakpad symbol directories.
@@ -1294,3 +1295,83 @@ impl DownloaderObserver for HelperDownloaderObserver {
 // I think it's ok if the logging here doesn't answer all those questions. Instead, the
 // questions can be answered by information in the response JSON... or I guess by something
 // that's stored on the SymbolMap.
+
+/// Sanitize a debug name so it is safe to use as a single directory component in a
+/// cache file path.
+///
+/// `debug_name` comes from profiled binaries and, in reliost, from untrusted
+/// user-submitted profiles. Without sanitization, a crafted name could escape the
+/// cache directory (path traversal).
+///
+/// Rules:
+/// - Any character outside `[A-Za-z0-9._-]` is replaced with `_`.  This removes
+///   directory separators (`/`, `\`) and other special characters.
+/// - The strings `.` and `..` are replaced with `_` to prevent single-component
+///   traversal after the character substitution above.
+/// - An empty result is replaced with `_`.
+fn sanitize_breakpad_path_component(name: &str) -> String {
+    let sanitized: String = name
+        .chars()
+        .map(|c| {
+            if c.is_alphanumeric() || matches!(c, '.' | '-' | '_') {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    if sanitized.is_empty() || sanitized == "." || sanitized == ".." {
+        return "_".to_string();
+    }
+    sanitized
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sanitize_normal_names_unchanged() {
+        assert_eq!(sanitize_breakpad_path_component("xul.pdb"), "xul.pdb");
+        assert_eq!(sanitize_breakpad_path_component("libxul.so"), "libxul.so");
+        assert_eq!(sanitize_breakpad_path_component("testproj"), "testproj");
+        assert_eq!(
+            sanitize_breakpad_path_component("libSystem.B.dylib"),
+            "libSystem.B.dylib"
+        );
+    }
+
+    #[test]
+    fn sanitize_replaces_slashes() {
+        assert_eq!(
+            sanitize_breakpad_path_component("../../etc/passwd.pdb"),
+            ".._.._etc_passwd.pdb"
+        );
+        assert_eq!(
+            sanitize_breakpad_path_component("/etc/passwd.pdb"),
+            "_etc_passwd.pdb"
+        );
+        assert_eq!(
+            sanitize_breakpad_path_component("\\windows\\ntdll.pdb"),
+            "_windows_ntdll.pdb"
+        );
+    }
+
+    #[test]
+    fn sanitize_replaces_dotdot_component() {
+        assert_eq!(sanitize_breakpad_path_component(".."), "_");
+        assert_eq!(sanitize_breakpad_path_component("."), "_");
+    }
+
+    #[test]
+    fn sanitize_replaces_empty() {
+        assert_eq!(sanitize_breakpad_path_component(""), "_");
+    }
+
+    #[test]
+    fn sanitize_replaces_other_bad_chars() {
+        assert_eq!(sanitize_breakpad_path_component("foo()*$bar"), "foo____bar");
+        assert_eq!(sanitize_breakpad_path_component("foo bar"), "foo_bar");
+        assert_eq!(sanitize_breakpad_path_component("foo\x00bar"), "foo_bar");
+    }
+}

--- a/wholesym/src/helper.rs
+++ b/wholesym/src/helper.rs
@@ -265,7 +265,10 @@ struct KnownLibs {
 impl Helper {
     pub fn with_config(config: SymbolManagerConfig) -> Self {
         let observer = Arc::new(HelperDownloaderObserver::new());
-        let downloader = Arc::new(Downloader::new());
+        let downloader = Arc::new(match config.user_agent.as_deref() {
+            Some(ua) => Downloader::new_with_user_agent(ua),
+            None => Downloader::new(),
+        });
         let symsrv_downloader = match config.effective_nt_symbol_path() {
             Some(nt_symbol_path) => {
                 let mut downloader = SymsrvDownloader::new(nt_symbol_path);

--- a/wholesym/src/helper.rs
+++ b/wholesym/src/helper.rs
@@ -400,6 +400,7 @@ impl Helper {
                 .breakpad_downloader
                 .get_file(&path)
                 .await
+                .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?
                 .ok_or("Not found on breakpad symbol server")?,
             WholesymFileLocation::BreakpadSymindexFile(rel_path) => {
                 let sym_path = self

--- a/wholesym/src/lib.rs
+++ b/wholesym/src/lib.rs
@@ -164,3 +164,8 @@ pub use samply_symbols::{
 pub use symbol_manager::{SymbolFileOrigin, SymbolManager, SymbolMap};
 pub use symbol_manager_observer::SymbolManagerObserver;
 pub use verbose_symbol_manager_observer::VerboseSymbolManagerObserver;
+
+#[cfg(feature = "api")]
+pub use samply_api::{ModuleLoadOutcome, ModuleStat, SymbolicateStats};
+#[cfg(feature = "api")]
+pub use symbol_manager::QueryApiJsonResult;

--- a/wholesym/src/symbol_manager.rs
+++ b/wholesym/src/symbol_manager.rs
@@ -316,6 +316,13 @@ impl QueryApiJsonResult {
     pub fn http_status(&self) -> u16 {
         self.0.http_status()
     }
+
+    /// Returns observability statistics for `/symbolicate/v5` requests.
+    ///
+    /// Returns `None` for `/asm/v1`, `/source/v1`, and error responses.
+    pub fn symbolicate_stats(&self) -> Option<&samply_api::SymbolicateStats> {
+        self.0.symbolicate_stats()
+    }
 }
 
 #[cfg(feature = "api")]

--- a/wholesym/src/symbol_manager.rs
+++ b/wholesym/src/symbol_manager.rs
@@ -311,6 +311,14 @@ impl SymbolManager {
 pub struct QueryApiJsonResult(samply_api::QueryApiJsonResult<Helper>);
 
 #[cfg(feature = "api")]
+impl QueryApiJsonResult {
+    /// Returns the HTTP status code that best describes this result.
+    pub fn http_status(&self) -> u16 {
+        self.0.http_status()
+    }
+}
+
+#[cfg(feature = "api")]
 impl serde::Serialize for QueryApiJsonResult {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where


### PR DESCRIPTION
This implements some of the things we were missing to make [reliost](https://github.com/mstange/reliost) a fully-fledged replacement for [eliot](https://github.com/mozilla-services/eliot).