### PR TITLE
Enable support for profiles created with Simpleperf's on-the-fly compression (-z)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1489,6 +1489,7 @@ dependencies = [
  "prost",
  "prost-derive",
  "thiserror 2.0.18",
+ "zstd-safe",
 ]
 
 [[package]]
@@ -4333,3 +4334,22 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/samply/Cargo.toml
+++ b/samply/Cargo.toml
@@ -15,7 +15,7 @@ fxprof-processed-profile = { version = "0.8", path = "../fxprof-processed-profil
 # framehop = { path = "../../framehop" }
 framehop = "0.16"
 # linux-perf-data = { path = "../../linux-perf-data", default-features = false }
-linux-perf-data = { version = "0.13", default-features = false }
+linux-perf-data = { version = "0.13" }
 
 tokio = { version = "1.39", features = ["rt", "rt-multi-thread", "macros"] }
 tokio-util = "0.7.11"


### PR DESCRIPTION
Allow Samply to process Simpleperf profiles created with the `-z` compression option.