### PR TITLE
Switch back from aws-lc to ring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,28 +164,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "aws-lc-rs"
-version = "1.16.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
-dependencies = [
- "aws-lc-sys",
- "zeroize",
-]
-
-[[package]]
-name = "aws-lc-sys"
-version = "0.40.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
-dependencies = [
- "cc",
- "cmake",
- "dunce",
- "fs_extra",
-]
-
-[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -397,15 +375,6 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
-
-[[package]]
-name = "cmake"
-version = "0.1.58"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
-dependencies = [
- "cc",
-]
 
 [[package]]
 name = "colorchoice"
@@ -638,12 +607,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dunce"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
-
-[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -805,12 +768,6 @@ dependencies = [
  "rustix 1.1.4",
  "windows-sys 0.59.0",
 ]
-
-[[package]]
-name = "fs_extra"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "funty"
@@ -2036,7 +1993,6 @@ version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
- "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -2308,7 +2264,6 @@ dependencies = [
  "log",
  "percent-encoding",
  "pin-project-lite",
- "quinn",
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
@@ -2464,7 +2419,6 @@ version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
- "aws-lc-rs",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -2528,7 +2482,6 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
- "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -3560,6 +3513,7 @@ dependencies = [
  "reqwest 0.13.2",
  "reqwest-middleware",
  "reqwest-retry",
+ "rustls",
  "samply-api",
  "samply-debugid",
  "samply-symbols",

--- a/wholesym/Cargo.toml
+++ b/wholesym/Cargo.toml
@@ -31,12 +31,13 @@ uuid = "1"
 reqwest-middleware = "0.5"
 reqwest-retry = "0.9"
 reqwest = { version = "0.13", default-features = false, features = [
-    "rustls",
+    "rustls-no-provider",
     "stream",
     "gzip",
     "brotli",
     "deflate"
 ] }
+rustls = { version = "0.23", default-features = false, features = ["ring"] } # So that reqwest uses rustls with ring
 bytes = "1.10"
 memmap2 = "0.9.9"
 tokio = { version = "1.38", features = ["fs", "macros"] }

--- a/wholesym/src/downloader.rs
+++ b/wholesym/src/downloader.rs
@@ -188,6 +188,20 @@ impl Default for Downloader {
     }
 }
 
+/// Install rustls's `ring` crypto provider as the process-wide default.
+///
+/// We use reqwest's `rustls-no-provider` feature, so a provider must be
+/// installed before building any `reqwest::Client`. `install_default` only
+/// succeeds for the first caller, but if some other code in the process
+/// already installed a provider that's fine — we just want one to exist.
+fn ensure_crypto_provider_installed() {
+    use std::sync::Once;
+    static INSTALL: Once = Once::new();
+    INSTALL.call_once(|| {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+    });
+}
+
 impl Downloader {
     pub fn new() -> Self {
         Self::new_internal(5, None)
@@ -208,6 +222,8 @@ impl Downloader {
     }
 
     fn new_internal(max_retries: u32, user_agent: Option<&str>) -> Self {
+        ensure_crypto_provider_installed();
+
         let builder = reqwest::Client::builder();
 
         // Turn off HTTP 2, in order to work around https://github.com/seanmonstar/reqwest/issues/1761 .
@@ -658,6 +674,7 @@ mod tests {
                 std::time::Duration::from_millis(10),
             )
             .build_with_max_retries(2);
+        ensure_crypto_provider_installed();
         let client = reqwest::Client::builder()
             .http1_only()
             .no_gzip()


### PR DESCRIPTION
The update to reqwest 0.13 in #801 changed the rustls provider from ring to aws-lc. This PR makes us use ring again.

We're already pulling in ring via symsrv's reqwest 0.12 dependency.