### PR TITLE
fix(mac): capture sample timestamp while thread is suspended

### DIFF
--- a/samply/src/mac/proc_maps.rs
+++ b/samply/src/mac/proc_maps.rs
@@ -535,14 +535,17 @@ impl<'a> StackwalkerRef<'a> {
 /// `frames` must be empty initially.
 ///
 /// On return, `frames` will have the stack frames from callee-most to root-most.
+///
+/// Returns the monotonic timestamp captured while the thread is still suspended,
+/// so the sample time reflects the moment the stack was actually sampled.
 pub fn get_backtrace(
     stackwalker: StackwalkerRef,
     memory: &mut ForeignMemory,
     thread_act: mach_port_t,
     frames: &mut Vec<FrameAddress>,
     fold_recursive_prefix: bool,
-) -> Result<(), SamplingError> {
-    with_suspended_thread(thread_act, || {
+) -> Result<u64, SamplingError> {
+    let sample_time_mono = with_suspended_thread(thread_act, || {
         let (pc, regs) = get_unwinding_registers(thread_act).map_err(|err| match err {
             KernelError::InvalidArgument
             | KernelError::MachSendInvalidDest
@@ -552,7 +555,7 @@ pub fn get_backtrace(
             err => SamplingError::Ignorable("thread_get_state in get_unwinding_registers", err),
         })?;
         do_stackwalk(stackwalker, pc, regs, memory, frames);
-        Ok(())
+        Ok(super::time::get_monotonic_timestamp())
     })
     .unwrap_or_else(|err| match err {
         KernelError::InvalidArgument
@@ -574,7 +577,7 @@ pub fn get_backtrace(
         }
     }
 
-    Ok(())
+    Ok(sample_time_mono)
 }
 
 /// `frames` must be empty initially.

--- a/samply/src/mac/thread_profiler.rs
+++ b/samply/src/mac/thread_profiler.rs
@@ -4,7 +4,6 @@ use framehop::FrameAddress;
 use fxprof_processed_profile::{CpuDelta, Profile, StringHandle, ThreadHandle, Timestamp};
 use mach2::mach_types::thread_act_t;
 use mach2::port::mach_port_t;
-use time::get_monotonic_timestamp;
 
 use super::error::SamplingError;
 use super::kernel_error::{self, IntoResult, KernelError};
@@ -15,7 +14,6 @@ use super::thread_info::{
     thread_info_t, time_value, THREAD_BASIC_INFO, THREAD_BASIC_INFO_COUNT, THREAD_EXTENDED_INFO,
     THREAD_EXTENDED_INFO_COUNT, THREAD_IDENTIFIER_INFO, THREAD_IDENTIFIER_INFO_COUNT,
 };
-use crate::mac::time;
 use crate::shared::recycling::ThreadRecycler;
 use crate::shared::types::{StackFrame, StackMode};
 use crate::shared::unresolved_samples::{UnresolvedSamples, UnresolvedStacks};
@@ -137,17 +135,13 @@ impl ThreadProfiler {
 
         if !cpu_delta.is_zero() || self.tick_count == 0 {
             stack_scratch_buffer.clear();
-            get_backtrace(
+            let sample_time_mono = get_backtrace(
                 stackwalker,
                 &mut self.stack_memory,
                 self.thread_act,
                 stack_scratch_buffer,
                 fold_recursive_prefix,
             )?;
-            // make sure to use the time immediately after the stack is sampled so that any
-            // jitdump records emitted in the interval between samply starting to sample
-            // all tasks and actually stopping the thread are properly used
-            let sample_time_mono = get_monotonic_timestamp();
 
             let frames = stack_scratch_buffer.iter().rev().map(|f| match f {
                 FrameAddress::InstructionPointer(address) => {


### PR DESCRIPTION
The monotonic timestamp was read after `get_backtrace` had already resumed the target thread, letting it run briefly before the timestamp was taken and producing a small forward offset.

This can cause issues when trying to align/extract frames based on the markers.