### PR TITLE
fix: avoid panic on context-switch-out records without a CPU field

### DIFF
--- a/samply/src/linux_shared/converter.rs
+++ b/samply/src/linux_shared/converter.rs
@@ -942,7 +942,7 @@ where
             ContextSwitchRecord::Out { preempted, .. } => {
                 self.context_switch_handler
                     .handle_switch_out(timestamp, &mut thread.context_switch_data);
-                if let (Some(cpus), Some(cpu_index)) = (&mut self.cpus, Some(common.cpu.unwrap())) {
+                if let (Some(cpus), Some(cpu_index)) = (&mut self.cpus, common.cpu) {
                     let combined_thread = cpus.combined_thread_handle();
                     let cpu = cpus.get_mut(cpu_index as usize, &mut self.profile);
                     self.context_switch_handler


### PR DESCRIPTION
The `In` arm of `handle_context_switch` already treats `common.cpu` as optional, but the `Out` arm unwraps it, so importing a perf.data captured with multiple events (e.g. `-e cycles:u,cycles:k --switch-events`) panics at converter.rs:945; this matches the `Out` arm to the `In` arm so a missing CPU is simply skipped. Closes #815.