### PR TITLE
Read dyld subcache names from the cache header

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2663,6 +2663,7 @@ dependencies = [
  "samply-object",
  "scala-native-demangle",
  "srcsrv",
+ "tempfile",
  "thiserror 2.0.18",
  "uuid",
  "yoke",

--- a/samply-symbols/Cargo.toml
+++ b/samply-symbols/Cargo.toml
@@ -62,3 +62,4 @@ crc32fast = "1.4.2"
 [dev-dependencies]
 memmap2 = "0.9.9"
 anyhow = "1"
+tempfile = "3"

--- a/samply-symbols/src/macho.rs
+++ b/samply-symbols/src/macho.rs
@@ -575,16 +575,9 @@ fn read_uleb128(mut bytes: &[u8]) -> Option<(u64, &[u8])> {
     None
 }
 
-/// State machine for loading a dyld shared cache and its numeric/`.symbols`
-/// subcaches.
+/// State machine for loading a dyld shared cache and its subcaches.
 pub struct DyldCacheLoad<FT: FileTypes> {
     state: DyldCacheLoadState<FT>,
-}
-
-#[derive(Clone, Copy, PartialEq, Eq)]
-enum SuffixAttempt {
-    Plain,
-    ZeroPadded,
 }
 
 enum DyldCacheLoadState<FT: FileTypes> {
@@ -594,22 +587,14 @@ enum DyldCacheLoadState<FT: FileTypes> {
         dylib_path: String,
         pending: FT::FL,
     },
-    /// Awaiting the bytes for `.{N}` or `.{NN}` numeric subcache.
-    AwaitingNumericSubcache {
+    /// Awaiting a subcache file listed in the root cache header.
+    AwaitingSubcache {
         root: FileContentsWrapper<FT::F>,
         dyld_cache_path: FT::FL,
         dylib_path: String,
         collected: Vec<FileContentsWrapper<FT::F>>,
-        index: usize,
-        attempt: SuffixAttempt,
-        pending: FT::FL,
-    },
-    /// Awaiting the optional `.symbols` subcache.
-    AwaitingSymbolsSubcache {
-        root: FileContentsWrapper<FT::F>,
-        dyld_cache_path: FT::FL,
-        dylib_path: String,
-        collected: Vec<FileContentsWrapper<FT::F>>,
+        suffixes: Vec<String>,
+        next: usize,
         pending: FT::FL,
     },
     Done(Result<DyldCacheFileData<FT::F>, Error>),
@@ -641,69 +626,27 @@ impl<FT: FileTypes> DyldCacheLoad<FT> {
         dyld_cache_path: FT::FL,
         dylib_path: String,
         collected: Vec<FileContentsWrapper<FT::F>>,
-        index: usize,
-        mut attempt: SuffixAttempt,
+        suffixes: Vec<String>,
+        next: usize,
     ) {
-        loop {
-            let suffix = match attempt {
-                SuffixAttempt::Plain => format!(".{index}"),
-                SuffixAttempt::ZeroPadded => format!(".{index:02}"),
-            };
-            match dyld_cache_path.location_for_dyld_subcache(&suffix) {
-                Some(pending) => {
-                    self.state = DyldCacheLoadState::AwaitingNumericSubcache {
-                        root,
-                        dyld_cache_path,
-                        dylib_path,
-                        collected,
-                        index,
-                        attempt,
-                        pending,
-                    };
-                    return;
-                }
-                None => match attempt {
-                    SuffixAttempt::Plain => {
-                        attempt = SuffixAttempt::ZeroPadded;
-                    }
-                    SuffixAttempt::ZeroPadded => {
-                        self.advance_to_symbols_or_finalize(
-                            root,
-                            dyld_cache_path,
-                            dylib_path,
-                            collected,
-                        );
-                        return;
-                    }
-                },
-            }
-        }
-    }
-
-    fn advance_to_symbols_or_finalize(
-        &mut self,
-        root: FileContentsWrapper<FT::F>,
-        dyld_cache_path: FT::FL,
-        dylib_path: String,
-        collected: Vec<FileContentsWrapper<FT::F>>,
-    ) {
-        match dyld_cache_path.location_for_dyld_subcache(".symbols") {
-            Some(pending) => {
-                self.state = DyldCacheLoadState::AwaitingSymbolsSubcache {
-                    root,
-                    dyld_cache_path,
-                    dylib_path,
-                    collected,
-                    pending,
-                };
-            }
-            None => {
-                self.state = DyldCacheLoadState::Done(Ok(DyldCacheFileData::new(
-                    root, collected, dylib_path,
-                )));
-                let _ = dyld_cache_path;
-            }
-        }
+        let Some(suffix) = suffixes.get(next) else {
+            self.state =
+                DyldCacheLoadState::Done(Ok(DyldCacheFileData::new(root, collected, dylib_path)));
+            return;
+        };
+        let Some(pending) = dyld_cache_path.location_for_dyld_subcache(suffix) else {
+            self.state = DyldCacheLoadState::Done(Err(Error::FileLocationRefusedSubcacheLocation));
+            return;
+        };
+        self.state = DyldCacheLoadState::AwaitingSubcache {
+            root,
+            dyld_cache_path,
+            dylib_path,
+            collected,
+            suffixes,
+            next,
+            pending,
+        };
     }
 }
 
@@ -714,10 +657,9 @@ impl<FT: FileTypes> NeedsFiles<FT> for DyldCacheLoad<FT> {
                 location: pending,
                 required: true,
             },
-            DyldCacheLoadState::AwaitingNumericSubcache { pending, .. }
-            | DyldCacheLoadState::AwaitingSymbolsSubcache { pending, .. } => LoadStep::NeedFile {
+            DyldCacheLoadState::AwaitingSubcache { pending, .. } => LoadStep::NeedFile {
                 location: pending,
-                required: false,
+                required: true,
             },
             DyldCacheLoadState::Done(_) => LoadStep::Done,
             DyldCacheLoadState::Poisoned => unreachable!("invalid DyldCacheLoad state"),
@@ -734,28 +676,37 @@ impl<FT: FileTypes> NeedsFiles<FT> for DyldCacheLoad<FT> {
             } => match result {
                 Ok(file) => {
                     let root = FileContentsWrapper::new(file);
-                    self.advance_to_next_subcache(
-                        root,
-                        dyld_cache_path,
-                        dylib_path,
-                        Vec::new(),
-                        1,
-                        SuffixAttempt::Plain,
-                    );
+                    match object::read::macho::DyldCache::<Endianness, _>::subcache_suffixes(&root)
+                    {
+                        Ok(suffixes) => {
+                            self.advance_to_next_subcache(
+                                root,
+                                dyld_cache_path,
+                                dylib_path,
+                                Vec::new(),
+                                suffixes,
+                                0,
+                            );
+                        }
+                        Err(e) => {
+                            self.state =
+                                DyldCacheLoadState::Done(Err(Error::DyldCacheParseError(e)));
+                        }
+                    }
                 }
                 Err(e) => {
                     self.state =
                         DyldCacheLoadState::Done(Err(Error::OpenFile(pending.to_string(), e)));
                 }
             },
-            DyldCacheLoadState::AwaitingNumericSubcache {
+            DyldCacheLoadState::AwaitingSubcache {
                 root,
                 dyld_cache_path,
                 dylib_path,
                 mut collected,
-                index,
-                attempt,
-                pending: _pending,
+                suffixes,
+                next,
+                pending,
             } => match result {
                 Ok(file) => {
                     collected.push(FileContentsWrapper::new(file));
@@ -764,46 +715,15 @@ impl<FT: FileTypes> NeedsFiles<FT> for DyldCacheLoad<FT> {
                         dyld_cache_path,
                         dylib_path,
                         collected,
-                        index + 1,
-                        SuffixAttempt::Plain,
+                        suffixes,
+                        next + 1,
                     );
                 }
-                Err(_) => match attempt {
-                    SuffixAttempt::Plain => {
-                        self.advance_to_next_subcache(
-                            root,
-                            dyld_cache_path,
-                            dylib_path,
-                            collected,
-                            index,
-                            SuffixAttempt::ZeroPadded,
-                        );
-                    }
-                    SuffixAttempt::ZeroPadded => {
-                        self.advance_to_symbols_or_finalize(
-                            root,
-                            dyld_cache_path,
-                            dylib_path,
-                            collected,
-                        );
-                    }
-                },
-            },
-            DyldCacheLoadState::AwaitingSymbolsSubcache {
-                root,
-                dyld_cache_path,
-                dylib_path,
-                mut collected,
-                pending: _pending,
-            } => {
-                if let Ok(file) = result {
-                    collected.push(FileContentsWrapper::new(file));
+                Err(e) => {
+                    self.state =
+                        DyldCacheLoadState::Done(Err(Error::OpenFile(pending.to_string(), e)));
                 }
-                self.state = DyldCacheLoadState::Done(Ok(DyldCacheFileData::new(
-                    root, collected, dylib_path,
-                )));
-                let _ = dyld_cache_path; // intentionally dropped
-            }
+            },
             DyldCacheLoadState::Done(_) | DyldCacheLoadState::Poisoned => {
                 panic!("DyldCacheLoad::provide called when not awaiting a file")
             }

--- a/samply-symbols/tests/integration_tests/main.rs
+++ b/samply-symbols/tests/integration_tests/main.rs
@@ -2,10 +2,12 @@ use std::fs::File;
 use std::io::{BufWriter, Read, Write};
 use std::path::{Path, PathBuf};
 
+use object::macho::{DyldSubCacheEntryV1, DyldSubCacheEntryV2};
+use object::Endianness;
 use samply_symbols::debugid::DebugId;
 use samply_symbols::{
-    CompactSymbolTable, Error, FileLoadResult, FileLocation, FileTypes, LoadSymbolMap,
-    LookupAddress, MultiArchDisambiguator, SymbolMap, SymbolMapLoadStep,
+    CompactSymbolTable, DyldCacheLoad, Error, FileLoadResult, FileLocation, FileTypes, LoadStep,
+    LoadSymbolMap, LookupAddress, MultiArchDisambiguator, NeedsFiles, SymbolMap, SymbolMapLoadStep,
 };
 
 fn drive_symbol_map_load(sm: &mut LoadSymbolMap<TestFileTypes>) {
@@ -552,4 +554,155 @@ fn compare_snapshot() {
     let expected = std::str::from_utf8(&expected).unwrap();
 
     assert_eq!(output, expected);
+}
+
+fn synth_dyld_cache_root(
+    v2_suffixes: Option<&[&str]>,
+    v1_count: usize,
+    with_symbols_file: bool,
+) -> Vec<u8> {
+    use std::mem::size_of;
+
+    const SUBCACHE_ARRAY_OFFSET: usize = 0x800;
+    const MAPPING_OFFSET_FIELD: usize = 0x10;
+    const SUBCACHE_ARRAY_OFFSET_FIELD: usize = 0x188;
+    const SUBCACHE_ARRAY_COUNT_FIELD: usize = 0x18c;
+    const SYMBOL_FILE_UUID_FIELD: usize = 0x190;
+    const V2_FILE_SUFFIX_FIELD: usize = 0x18;
+
+    // The header size in mapping_offset determines the subcache entry version.
+    let (mapping_offset, entry_size, entry_count) = match v2_suffixes {
+        Some(suffixes) => (
+            0x1d0u32,
+            size_of::<DyldSubCacheEntryV2<Endianness>>(),
+            suffixes.len(),
+        ),
+        None => (
+            0x1c8u32,
+            size_of::<DyldSubCacheEntryV1<Endianness>>(),
+            v1_count,
+        ),
+    };
+
+    let mut data = vec![0u8; SUBCACHE_ARRAY_OFFSET + entry_count * entry_size];
+    let put_u32 = |data: &mut [u8], offset: usize, value: u32| {
+        data[offset..offset + 4].copy_from_slice(&value.to_le_bytes())
+    };
+    data[..16].copy_from_slice(b"dyld_v1  arm64e\0");
+    put_u32(&mut data, MAPPING_OFFSET_FIELD, mapping_offset);
+    put_u32(
+        &mut data,
+        SUBCACHE_ARRAY_OFFSET_FIELD,
+        SUBCACHE_ARRAY_OFFSET as u32,
+    );
+    put_u32(&mut data, SUBCACHE_ARRAY_COUNT_FIELD, entry_count as u32);
+    if with_symbols_file {
+        data[SYMBOL_FILE_UUID_FIELD..SYMBOL_FILE_UUID_FIELD + 16].copy_from_slice(&[0xab; 16]);
+    }
+    if let Some(suffixes) = v2_suffixes {
+        for (index, suffix) in suffixes.iter().enumerate() {
+            let offset = SUBCACHE_ARRAY_OFFSET + index * entry_size + V2_FILE_SUFFIX_FIELD;
+            data[offset..offset + suffix.len()].copy_from_slice(suffix.as_bytes());
+        }
+    }
+    data
+}
+
+fn drive_dyld_cache_load(root_path: &Path) -> (Vec<String>, Result<(), Error>) {
+    let mut load = DyldCacheLoad::<TestFileTypes>::new(
+        FileLocationType(root_path.to_owned()),
+        "/usr/lib/system/libsystem_c.dylib".to_string(),
+    );
+    let mut requested = Vec::new();
+    while let LoadStep::NeedFile { location, .. } = load.poll() {
+        let location = location.clone();
+        requested.push(
+            location
+                .0
+                .file_name()
+                .unwrap()
+                .to_string_lossy()
+                .into_owned(),
+        );
+        let result = load_file(location);
+        load.provide(result);
+    }
+    (requested, load.finish().map(|_| ()))
+}
+
+#[test]
+fn dyld_cache_load_uses_header_listed_subcache_names() {
+    let dir = tempfile::tempdir().unwrap();
+    let suffixes = [".01", ".02.dylddata", ".03.dyldreadonly"];
+    let root = dir.path().join("dyld_shared_cache_arm64e");
+    std::fs::write(&root, synth_dyld_cache_root(Some(&suffixes), 0, true)).unwrap();
+    for suffix in suffixes.iter().copied().chain([".symbols"]) {
+        std::fs::write(
+            dir.path().join(format!("dyld_shared_cache_arm64e{suffix}")),
+            b"subcache",
+        )
+        .unwrap();
+    }
+
+    let (requested, result) = drive_dyld_cache_load(&root);
+    assert_eq!(
+        requested,
+        [
+            "dyld_shared_cache_arm64e",
+            "dyld_shared_cache_arm64e.01",
+            "dyld_shared_cache_arm64e.02.dylddata",
+            "dyld_shared_cache_arm64e.03.dyldreadonly",
+            "dyld_shared_cache_arm64e.symbols",
+        ]
+    );
+    result.unwrap();
+}
+
+#[test]
+fn dyld_cache_load_v1_numeric_subcache_names() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().join("dyld_shared_cache_arm64e");
+    std::fs::write(&root, synth_dyld_cache_root(None, 2, false)).unwrap();
+    for suffix in [".1", ".2"] {
+        std::fs::write(
+            dir.path().join(format!("dyld_shared_cache_arm64e{suffix}")),
+            b"subcache",
+        )
+        .unwrap();
+    }
+
+    let (requested, result) = drive_dyld_cache_load(&root);
+    assert_eq!(
+        requested,
+        [
+            "dyld_shared_cache_arm64e",
+            "dyld_shared_cache_arm64e.1",
+            "dyld_shared_cache_arm64e.2",
+        ]
+    );
+    result.unwrap();
+}
+
+#[test]
+fn dyld_cache_load_missing_listed_subcache_is_an_error_naming_the_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().join("dyld_shared_cache_arm64e");
+    std::fs::write(
+        &root,
+        synth_dyld_cache_root(Some(&[".01", ".02.dylddata"]), 0, false),
+    )
+    .unwrap();
+    std::fs::write(dir.path().join("dyld_shared_cache_arm64e.01"), b"subcache").unwrap();
+
+    let (requested, result) = drive_dyld_cache_load(&root);
+    assert!(requested
+        .last()
+        .unwrap()
+        .ends_with("dyld_shared_cache_arm64e.02.dylddata"));
+    match result {
+        Err(Error::OpenFile(path, _)) => {
+            assert!(path.ends_with(".02.dylddata"), "unexpected path: {path}")
+        }
+        other => panic!("expected OpenFile error for the missing subcache, got {other:?}"),
+    }
 }


### PR DESCRIPTION
macOS 26 uses suffixes such as `.02.dylddata` and
`.03.dyldreadonly`, which cannot be inferred from the subcache index. The
old probing loop stopped after finding `.01`, causing dyld cache parsing
to fail with an incorrect subcache count.

Use `DyldCache::subcache_suffixes` to load the names recorded in the
header. This also handles the numeric V1 format and the optional
`.symbols` cache. Treat every listed subcache as required and report the
specific file when loading fails.

Add regression tests for V1 and V2 cache layouts and missing subcaches.

Fixes: https://github.com/mstange/samply/issues/839
