### PR TITLE
Add jslb parsing.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1419,6 +1419,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "json-slabs"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1f6d721e0031466c53b2a005ecfaf4b05fb6a698d78be3220d2e24c36fb513a"
+dependencies = [
+ "thiserror 2.0.18",
+ "zerocopy",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2576,6 +2586,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "indexmap",
+ "json-slabs",
  "lazy_static",
  "libc",
  "linux-perf-data",

--- a/samply/Cargo.toml
+++ b/samply/Cargo.toml
@@ -40,6 +40,7 @@ rand = "0.10"
 nix-base32 = "0.2.0"
 serde_derive = "1.0.137"
 serde = "1.0.204"
+json-slabs = "0.1.0"
 wholesym = { version = "0.8.1", path = "../wholesym", features = ["api"]}
 platform-dirs = "0.3"
 rustc-hash = "2"

--- a/samply/src/profile_json_preparse.rs
+++ b/samply/src/profile_json_preparse.rs
@@ -1,29 +1,42 @@
 use std::collections::HashMap;
 use std::ffi::OsString;
 use std::fs::File;
-use std::io::BufReader;
+use std::io::{self, BufReader, Cursor, Read};
 use std::path::Path;
 use std::str::FromStr;
 
 use debugid::DebugId;
 use flate2::bufread::GzDecoder;
+use json_slabs::{RootJsonReader, MAGIC as JSLB_MAGIC};
 use serde_derive::Deserialize;
 use wholesym::{CodeId, LibraryInfo};
 
 #[derive(Deserialize, Default, Clone, Debug, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
-struct ProfileJsonProcess {
+struct ProfileJsonNode {
     #[serde(default)]
     pub libs: Vec<ProfileJsonLib>,
     #[serde(default)]
     pub threads: Vec<ProfileJsonThread>,
     #[serde(default)]
-    pub processes: Vec<ProfileJsonProcess>,
+    pub processes: Vec<ProfileJsonNode>,
 }
 
 #[derive(Deserialize, Default, Clone, Debug, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 struct ProfileJsonThread {
+    #[serde(default)]
+    pub libs: Vec<ProfileJsonLib>,
+}
+
+/// Minimal skeleton for a JSLB root profile. JSLB is always a "processed"
+/// profile of format version >= 65, which stores all library info at
+/// `profile.libs`, so we only inspect that field. Other fields such as
+/// `threads` or `shared` contain slab placeholders like `{"$s":N}` rather
+/// than sequences, and serde skips them as unknown fields.
+#[derive(Deserialize, Default, Clone, Debug, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+struct ProfileJsonRootLibs {
     #[serde(default)]
     pub libs: Vec<ProfileJsonLib>,
 }
@@ -44,28 +57,66 @@ pub fn parse_libinfo_map_from_profile_file(
     file: File,
     filename: &Path,
 ) -> Result<HashMap<(String, DebugId), LibraryInfo>, std::io::Error> {
-    // Read the profile.json file and parse it as JSON.
-    // Build a map (debugName, breakpadID) -> debugPath from the information
-    // in profile(\.processes\[\d+\])*(\.threads\[\d+\])?\.libs.
+    // Read the profile file and build a map (debugName, breakpadID) -> debugPath.
+    // Supported inputs (any of which may additionally be gzipped):
+    //   * "Gecko" JSON profile — libs at `profile.libs` and per subprocess
+    //     under `profile.processes[i].libs`.
+    //   * "processed" JSON profile of format version < 41 — libs at
+    //     `profile.threads[i].libs`.
+    //   * "processed" JSON profile of format version >= 41 — libs at
+    //     `profile.libs`. See
+    //     https://github.com/firefox-devtools/profiler/blob/e7f99034daccd4b069cb2d309d9541e80d5a4da5/docs-developer/CHANGELOG-formats.md#version-41
+    //   * JSLB (JsonSlabs) container — always a processed profile of format
+    //     version >= 65, so libs are always at `profile.libs`.
     let reader = BufReader::new(file);
-
-    // Handle .gz profiles
     if filename.extension() == Some(&OsString::from("gz")) {
-        let decoder = GzDecoder::new(reader);
-        let reader = BufReader::new(decoder);
-        parse_libinfo_map_from_profile(reader)
+        parse_libinfo_map_from_profile(GzDecoder::new(reader))
     } else {
         parse_libinfo_map_from_profile(reader)
     }
 }
 
-fn parse_libinfo_map_from_profile(
-    reader: impl std::io::Read,
+fn parse_libinfo_map_from_profile<R: Read>(
+    mut reader: R,
 ) -> Result<HashMap<(String, DebugId), LibraryInfo>, std::io::Error> {
-    let profile: ProfileJsonProcess = serde_json::from_reader(reader)?;
+    // Peek at the first few bytes to distinguish a JSLB container from raw
+    // JSON, then hand the reader (with the peeked bytes chained back in
+    // front) to serde_json.
+    let mut magic_buf = [0u8; JSLB_MAGIC.len()];
+    let n = read_up_to(&mut reader, &mut magic_buf)?;
+    let is_jslb = n == JSLB_MAGIC.len() && magic_buf == JSLB_MAGIC;
+    let head = Cursor::new(magic_buf).take(n as u64);
+    let combined = head.chain(reader);
+
     let mut libinfo_map = HashMap::new();
-    add_to_libinfo_map_recursive(&profile, &mut libinfo_map);
+    if is_jslb {
+        // JSLB is always a processed profile of format version >= 65, which
+        // stores all library info at `profile.libs`. Per-thread `libs` only
+        // appear in processed profiles below format version 41, which predate
+        // JSLB and are only ever plain JSON — so we don't need to descend
+        // into `threads` or `processes` here.
+        // Buffer *around* RootJsonReader so that its `remaining` cap prevents
+        // the buffered layer from prefetching past the root slab.
+        let profile: ProfileJsonRootLibs =
+            serde_json::from_reader(BufReader::new(RootJsonReader::new(combined)?))?;
+        add_libs_to_libinfo_map(&profile.libs, &mut libinfo_map);
+    } else {
+        let profile: ProfileJsonNode = serde_json::from_reader(combined)?;
+        add_to_libinfo_map_recursive(&profile, &mut libinfo_map);
+    }
     Ok(libinfo_map)
+}
+
+fn read_up_to<R: Read>(reader: &mut R, buf: &mut [u8]) -> io::Result<usize> {
+    let mut n = 0;
+    while n < buf.len() {
+        let m = reader.read(&mut buf[n..])?;
+        if m == 0 {
+            break;
+        }
+        n += m;
+    }
+    Ok(n)
 }
 
 fn add_libs_to_libinfo_map(
@@ -107,7 +158,7 @@ fn libinfo_map_entry_for_lib(lib: &ProfileJsonLib) -> Option<LibraryInfo> {
 }
 
 fn add_to_libinfo_map_recursive(
-    profile: &ProfileJsonProcess,
+    profile: &ProfileJsonNode,
     libinfo_map: &mut HashMap<(String, DebugId), LibraryInfo>,
 ) {
     add_libs_to_libinfo_map(&profile.libs, libinfo_map);
@@ -125,18 +176,17 @@ mod test {
 
     #[test]
     fn deserialize_profile_json() {
-        let p: ProfileJsonProcess = serde_json::from_str("{}").unwrap();
+        let p: ProfileJsonNode = serde_json::from_str("{}").unwrap();
         assert!(p.libs.is_empty());
         assert!(p.threads.is_empty());
         assert!(p.processes.is_empty());
 
-        let p: ProfileJsonProcess = serde_json::from_str("{\"unknown_field\":[1, 2, 3]}").unwrap();
+        let p: ProfileJsonNode = serde_json::from_str("{\"unknown_field\":[1, 2, 3]}").unwrap();
         assert!(p.libs.is_empty());
         assert!(p.threads.is_empty());
         assert!(p.processes.is_empty());
 
-        let p: ProfileJsonProcess =
-            serde_json::from_str("{\"threads\":[{\"libs\":[{}]}]}").unwrap();
+        let p: ProfileJsonNode = serde_json::from_str("{\"threads\":[{\"libs\":[{}]}]}").unwrap();
         assert!(p.libs.is_empty());
         assert_eq!(p.threads.len(), 1);
         assert_eq!(p.threads[0].libs.len(), 1);


### PR DESCRIPTION
This makes `samply load profile.jslb.gz` work, i.e. profiles using the [JsonSlabs (JSLB) container format](https://github.com/mstange/json-slabs) which has been supported in the profiler.firefox.com front-end for a month or two now.

We require .libs to be in the "root JSON slab" of the file, i.e. no placeholder hops away from the root object.

The plan is that, eventually, even gigantic profile files will only have a very small "JSON slab" / "skeleton JSON", and most of the profile data will be in typed array slabs. For `samply load <profile>`, we only need to read the lists of libraries so that the local symbol server can use them for symbolication, and this list will then always be near the front of the file in the self-contained skeleton JSON. So `samply load` will only need to look at a small prefix of the file (and for `profile.jslb.gz`, it'll only need to uncompress that prefix), and the rest of the file can be ignored by `samply load`.

At the moment we're still a ways away from that because the profile format still requires most arrays to be present as regular JSON number arrays. I'm working on lifting those restrictions in the front-end, with new profile versions.