### PR TITLE
Update object dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1763,9 +1763,9 @@ checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "object"
-version = "0.39.1"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e5a6c098c7a3b6547378093f5cc30bc54fd361ce711e05293a5cc589562739b"
+checksum = "dd229a0361b9d0d4396176e02d65897f487eebeab7caa6d443855ee152ca0b9c"
 dependencies = [
  "crc32fast",
  "flate2",
@@ -2534,9 +2534,9 @@ checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "ruzstd"
-version = "0.8.3"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7c1c839d570d835527c9a5e4db7cb2198683a988cb9d7293fc8674e6bd58fc8"
+checksum = "a252f5e20f038fe7b4ea53e073e65398d652c864cc162fc77c56c2f13717b888"
 dependencies = [
  "twox-hash",
 ]

--- a/samply-object/Cargo.toml
+++ b/samply-object/Cargo.toml
@@ -15,7 +15,7 @@ version = "0.8.0"
 [dependencies.object]
 default-features = false
 features = ["read_core"]
-version = "0.39"
+version = "0.40"
 
 [dependencies.uuid]
 default-features = false

--- a/samply-symbols/Cargo.toml
+++ b/samply-symbols/Cargo.toml
@@ -27,7 +27,7 @@ version = "0.33"
 [dependencies.object]
 default-features = false
 features = ["std", "read_core", "archive", "elf", "macho", "pe", "unaligned", "compression"]
-version = "0.39"
+version = "0.40"
 
 [dependencies]
 #pdb-addr2line = { path = "../../pdb-addr2line" }

--- a/samply-symbols/src/binary_image.rs
+++ b/samply-symbols/src/binary_image.rs
@@ -352,7 +352,7 @@ fn object_arch_to_string(arch: object::Architecture) -> Option<&'static str> {
 }
 
 fn elf_machine_arch_to_string(elf_machine_arch: u32) -> Option<&'static str> {
-    let s = match elf_machine_arch as u16 {
+    let s = match object::elf::Machine(elf_machine_arch as u16) {
         object::elf::EM_ARM => "arm",
         object::elf::EM_AARCH64 => "arm64",
         object::elf::EM_386 => "x86",

--- a/samply-symbols/src/macho.rs
+++ b/samply-symbols/src/macho.rs
@@ -2,7 +2,7 @@ use std::marker::PhantomData;
 
 use debugid::DebugId;
 use macho_unwind_info::UnwindInfo;
-use object::macho::{self, LinkeditDataCommand, MachHeader32, MachHeader64};
+use object::macho::{self, CpuSubtype, CpuType, LinkeditDataCommand, MachHeader32, MachHeader64};
 use object::read::macho::{
     FatArch, LoadCommandIterator, MachHeader, MachOFatFile32, MachOFatFile64,
 };
@@ -28,9 +28,9 @@ use crate::symbol_map_object::{
 /// Converts a cpu type/subtype pair into the architecture name.
 ///
 /// For example, this converts `CPU_TYPE_ARM64, CPU_SUBTYPE_ARM64E` to `Some("arm64e")`.
-fn macho_arch_name_for_cpu_type(cputype: u32, cpusubtype: u32) -> Option<&'static str> {
+fn macho_arch_name_for_cpu_type(cputype: CpuType, cpusubtype: CpuSubtype) -> Option<&'static str> {
     use object::macho::*;
-    let s = match (cputype, cpusubtype) {
+    let s = match (cputype, cpusubtype.id()) {
         (CPU_TYPE_X86, _) => "i386",
         (CPU_TYPE_X86_64, CPU_SUBTYPE_X86_64_H) => "x86_64h",
         (CPU_TYPE_X86_64, _) => "x86_64",
@@ -122,8 +122,8 @@ pub fn get_fat_archive_members_impl<FC: FileContents, FA: FatArch>(
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct FatArchiveMember {
     pub offset_and_size: (u64, u64),
-    pub cputype: u32,
-    pub cpusubtype: u32,
+    pub cputype: CpuType,
+    pub cpusubtype: CpuSubtype,
     pub arch: Option<String>,
     pub uuid: Option<Uuid>,
 }

--- a/samply-symbols/src/symbol_map_object.rs
+++ b/samply-symbols/src/symbol_map_object.rs
@@ -37,7 +37,7 @@ enum FullSymbolListEntry<'a, Symbol> {
     /// A synthesized symbol for the entry point of the object.
     SynthesizedEntryPoint,
     Symbol(Symbol),
-    Export(object::Export<'a>),
+    Export(Cow<'a, [u8]>),
     PltStub(String),
     EndAddress,
 }
@@ -53,7 +53,7 @@ impl<'a, Symbol: object::ObjectSymbol<'a>> std::fmt::Debug for FullSymbolListEnt
                 .finish(),
             Self::Export(arg0) => f
                 .debug_tuple("Export")
-                .field(&std::str::from_utf8(arg0.name()).unwrap())
+                .field(&std::str::from_utf8(arg0).unwrap())
                 .finish(),
             Self::PltStub(arg0) => f.debug_tuple("PltStub").field(arg0).finish(),
             Self::EndAddress => write!(f, "EndAddress"),
@@ -70,7 +70,7 @@ impl<'a, Symbol: object::ObjectSymbol<'a>> FullSymbolListEntry<'a, Symbol> {
             FullSymbolListEntry::Symbol(symbol) => {
                 String::from_utf8_lossy(symbol.name_bytes().ok()?)
             }
-            FullSymbolListEntry::Export(export) => String::from_utf8_lossy(export.name()),
+            FullSymbolListEntry::Export(name) => String::from_utf8_lossy(name),
             FullSymbolListEntry::PltStub(name) => Cow::Borrowed(name.as_str()),
         };
         Some(name)
@@ -149,13 +149,13 @@ fn relative_address_u32(address: u64, base_address: u64) -> Option<u32> {
 fn is_executable_section<'data, S: ObjectSection<'data>>(section: &S) -> bool {
     match (section.kind(), section.flags()) {
         (SectionKind::Text, _) => true,
-        (_, SectionFlags::MachO { flags })
-            if flags & object::macho::S_ATTR_PURE_INSTRUCTIONS != 0 =>
+        (_, SectionFlags::MachO { flags, .. })
+            if flags.contains(object::macho::S_ATTR_PURE_INSTRUCTIONS) =>
         {
             true
         }
-        (SectionKind::UninitializedData, SectionFlags::Elf { sh_flags })
-            if sh_flags & u64::from(object::elf::SHF_EXECINSTR) != 0 =>
+        (SectionKind::UninitializedData, SectionFlags::Elf { sh_flags, .. })
+            if sh_flags.contains(object::elf::SHF_EXECINSTR) =>
         {
             true
         }
@@ -308,12 +308,18 @@ impl<'a, Symbol: object::ObjectSymbol<'a> + 'a> SymbolList<'a, Symbol> {
 
         // 3. Exports (only used by exe / dll objects)
         if let Ok(exports) = object_file.exports() {
-            for export in exports {
-                entries.push((
-                    (export.address() - base_address) as u32,
-                    FullSymbolListEntry::Export(export),
-                ));
-            }
+            entries.extend(exports.map_while(Result::ok).filter_map(|export| {
+                let object::ExportTarget::Address { address } = export.target() else {
+                    return None;
+                };
+                let object::NameOrOrdinal::Name(name) = export.into_name() else {
+                    return None;
+                };
+                Some((
+                    u32::try_from(address.checked_sub(base_address)?).ok()?,
+                    FullSymbolListEntry::Export(name),
+                ))
+            }));
         }
 
         // 4. Placeholder symbols based on function start addresses

--- a/samply/Cargo.toml
+++ b/samply/Cargo.toml
@@ -112,4 +112,4 @@ features =  ["Win32",
 [dependencies.object]
 default-features = false
 features = ["std", "read_core", "elf", "pe", "unaligned", "write"]
-version = "0.39"
+version = "0.40"

--- a/samply/src/linux_shared/object_rewriter.rs
+++ b/samply/src/linux_shared/object_rewriter.rs
@@ -1,7 +1,7 @@
 use std::error::Error;
 
 use object::read::elf::{FileHeader, SectionHeader};
-use object::{elf, Endianness, U16, U32, U64};
+use object::{elf, Endianness};
 
 /// Returns a `Vec<u8>` with ELF data of an equivalent image with no program
 /// headers and fixed section offsets.
@@ -64,7 +64,7 @@ pub fn drop_phdr<Elf: FileHeader<Endian = Endianness>>(
     let section_offsets: Vec<usize> = in_sections
         .iter()
         .map(|s: &Elf::SectionHeader| {
-            if s.sh_type(endian) & elf::SHT_NOBITS == 0 {
+            if s.sh_type(endian) != elf::SHT_NOBITS {
                 let addralign = s.sh_addralign(endian).into() as usize;
                 if addralign != 0 {
                     reserved_len = align(reserved_len, addralign);
@@ -85,70 +85,26 @@ pub fn drop_phdr<Elf: FileHeader<Endian = Endianness>>(
     out_data.reserve(reserved_len);
 
     // We're done reserving, start writing.
+    let encoder = object::write::elf::Encoder::new(endian, is_64, in_header.e_machine(endian));
 
     // Write the ELF header.
     {
         // We copy all information from the original header, except the header size + version,
         // the section table offset, and the program header information (set to offset 0 + num 0).
-        // This code would be simpler if the elf::FileHeader trait had setters, and not just getters.
-        let e_ident = *in_header.e_ident();
-        let e_type = in_header.e_type(endian);
-        let e_machine = in_header.e_machine(endian);
-        let e_version = elf::EV_CURRENT.into();
-        let e_entry = in_header.e_entry(endian).into();
-        let e_phoff = 0; // No program headers
-        let e_shoff = section_table_offset as u64; // Adjusted section table offset
-        let e_flags = in_header.e_flags(endian);
-        let e_ehsize = in_header.e_ehsize(endian);
-        let e_phentsize = in_header.e_phentsize(endian);
-        let e_phnum = 0; // No program headers
-        let e_shentsize = std::mem::size_of::<Elf::SectionHeader>() as u16;
-        let e_shnum = in_header.e_shnum(endian);
-        let e_shstrndx = in_header.e_shstrndx(endian);
-        if is_64 {
-            let out_header = elf::FileHeader64 {
-                e_ident,
-                e_type: U16::new(endian, e_type),
-                e_machine: U16::new(endian, e_machine),
-                e_version: U32::new(endian, e_version),
-                e_entry: U64::new(endian, e_entry),
-                e_phoff: U64::new(endian, e_phoff),
-                e_shoff: U64::new(endian, e_shoff),
-                e_flags: U32::new(endian, e_flags),
-                e_ehsize: U16::new(endian, e_ehsize),
-                e_phentsize: U16::new(endian, e_phentsize),
-                e_phnum: U16::new(endian, e_phnum),
-                e_shentsize: U16::new(endian, e_shentsize),
-                e_shnum: U16::new(endian, e_shnum),
-                e_shstrndx: U16::new(endian, e_shstrndx),
-            };
-            out_data.write_pod(&out_header);
-        } else {
-            let out_header = elf::FileHeader32 {
-                e_ident,
-                e_type: U16::new(endian, e_type),
-                e_machine: U16::new(endian, e_machine),
-                e_version: U32::new(endian, e_version),
-                e_entry: U32::new(endian, e_entry as u32),
-                e_phoff: U32::new(endian, e_phoff as u32),
-                e_shoff: U32::new(endian, e_shoff as u32),
-                e_flags: U32::new(endian, e_flags),
-                e_ehsize: U16::new(endian, e_ehsize),
-                e_phentsize: U16::new(endian, e_phentsize),
-                e_phnum: U16::new(endian, e_phnum),
-                e_shentsize: U16::new(endian, e_shentsize),
-                e_shnum: U16::new(endian, e_shnum),
-                e_shstrndx: U16::new(endian, e_shstrndx),
-            };
-            out_data.write_pod(&out_header);
-        }
+        let out_header = object::write::elf::FileHeader::from_raw(endian, in_header);
+        let mut out_layout =
+            object::write::elf::FileHeaderLayout::from_raw(endian, in_header, in_data)?;
+        out_layout.e_phoff = 0; // No program headers
+        out_layout.segment_num = 0; // No program headers
+        out_layout.e_shoff = section_table_offset as u64; // Adjusted section table offset
+        encoder.file_header(&mut out_data, &out_header, &out_layout)?;
     }
 
     // Do not write any program headers.
 
     // Write the section data.
     for (section, offset) in in_sections.iter().zip(section_offsets.iter()) {
-        if section.sh_type(endian) & elf::SHT_NOBITS == 0 {
+        if section.sh_type(endian) != elf::SHT_NOBITS {
             write_align(&mut out_data, section.sh_addralign(endian).into() as usize);
             debug_assert_eq!(out_data.len(), *offset);
             out_data.write_bytes(section.data(endian, in_data)?);
@@ -160,53 +116,16 @@ pub fn drop_phdr<Elf: FileHeader<Endian = Endianness>>(
     debug_assert_eq!(out_data.len(), section_table_offset);
     for (in_section, offset) in in_sections.iter().zip(section_offsets.iter()) {
         // We copy all information from the original section except the offset.
-        // This would be simpler if the elf::SectionHeader trait had setters, and not just getters.
-        let sh_name = in_section.sh_name(endian);
-        let sh_type = in_section.sh_type(endian);
-        let sh_flags = in_section.sh_flags(endian).into();
-        let sh_addr = in_section.sh_addr(endian).into();
+        let mut out_section = object::write::elf::SectionHeader::from_raw(endian, in_section);
 
         // Fix section offset
-        let sh_offset = if sh_type == elf::SHT_NULL {
+        out_section.sh_offset = if out_section.sh_type == elf::SHT_NULL {
             0
         } else {
             *offset as u64
         };
 
-        let sh_size = in_section.sh_size(endian).into();
-        let sh_link = in_section.sh_link(endian);
-        let sh_info = in_section.sh_info(endian);
-        let sh_addralign = in_section.sh_addralign(endian).into();
-        let sh_entsize = in_section.sh_entsize(endian).into();
-        if is_64 {
-            let out_section = elf::SectionHeader64 {
-                sh_name: U32::new(endian, sh_name),
-                sh_type: U32::new(endian, sh_type),
-                sh_flags: U64::new(endian, sh_flags),
-                sh_addr: U64::new(endian, sh_addr),
-                sh_offset: U64::new(endian, sh_offset),
-                sh_size: U64::new(endian, sh_size),
-                sh_link: U32::new(endian, sh_link),
-                sh_info: U32::new(endian, sh_info),
-                sh_addralign: U64::new(endian, sh_addralign),
-                sh_entsize: U64::new(endian, sh_entsize),
-            };
-            out_data.write_pod(&out_section);
-        } else {
-            let out_section = elf::SectionHeader32 {
-                sh_name: U32::new(endian, sh_name),
-                sh_type: U32::new(endian, sh_type),
-                sh_flags: U32::new(endian, sh_flags as u32),
-                sh_addr: U32::new(endian, sh_addr as u32),
-                sh_offset: U32::new(endian, sh_offset as u32),
-                sh_size: U32::new(endian, sh_size as u32),
-                sh_link: U32::new(endian, sh_link),
-                sh_info: U32::new(endian, sh_info),
-                sh_addralign: U32::new(endian, sh_addralign as u32),
-                sh_entsize: U32::new(endian, sh_entsize as u32),
-            };
-            out_data.write_pod(&out_section);
-        }
+        encoder.section_header(&mut out_data, &out_section);
     }
 
     // We're done.

--- a/samply/src/mac/proc_maps.rs
+++ b/samply/src/mac/proc_maps.rs
@@ -32,7 +32,7 @@ use mach2::{structs::arm_thread_state64_t, thread_status::ARM_THREAD_STATE64};
 #[cfg(target_arch = "x86_64")]
 use mach2::{structs::x86_thread_state64_t, thread_status::x86_THREAD_STATE64};
 use object::macho::{
-    MachHeader64, SegmentCommand64, CPU_SUBTYPE_ARM64E, CPU_SUBTYPE_ARM64_ALL, CPU_SUBTYPE_MASK,
+    CpuSubtype, CpuType, MachHeader64, SegmentCommand64, CPU_SUBTYPE_ARM64E, CPU_SUBTYPE_ARM64_ALL,
     CPU_SUBTYPE_X86_64_ALL, CPU_SUBTYPE_X86_64_H, CPU_TYPE_ARM64, CPU_TYPE_X86_64, MH_EXECUTE,
 };
 use object::read::macho::{MachHeader, Section, Segment};
@@ -257,8 +257,8 @@ fn enumerate_dyld_images(
     Ok(vec)
 }
 
-fn get_arch_string(cputype: u32, cpusubtype: u32) -> Option<&'static str> {
-    let s = match (cputype, cpusubtype & !CPU_SUBTYPE_MASK) {
+fn get_arch_string(cputype: CpuType, cpusubtype: CpuSubtype) -> Option<&'static str> {
+    let s = match (cputype, cpusubtype.id()) {
         (CPU_TYPE_X86_64, CPU_SUBTYPE_X86_64_ALL) => "x86_64",
         (CPU_TYPE_X86_64, CPU_SUBTYPE_X86_64_H) => "x86_64h",
         (CPU_TYPE_ARM64, CPU_SUBTYPE_ARM64_ALL) => "arm64",


### PR DESCRIPTION
Things to note:

- `macho_arch_name_for_cpu_type` now ignores the capability bits of the subtype, which matters for arm64e.

- `Object::exports` now obtains exports from more places. For example, for Mach-O it can obtain them from LC_DYLD_EXPORTS_TRIE, LC_DYLD_INFO, or LC_DYSYMTAB (in order of preference).

- The SHT_NOBITS change in `drop_phdr` is a bug fix, but I'm not sure if this was ever hit in practice.

- Changed `drop_phdr` to use `object::write::elf::Encoder` which allows it to be more concise.

---
The only testing I've done is `cargo test`; I'm creating the PR because this `object` release had lots of breaking changes.