### PR TITLE
Improve how ETW JIT frames are stored in the profile

### DIFF
--- a/samply/src/linux_shared/converter.rs
+++ b/samply/src/linux_shared/converter.rs
@@ -9,8 +9,8 @@ use framehop::{ExplicitModuleSectionInfo, FrameAddress, Module, Unwinder};
 use fxprof_processed_profile::{
     Category, CategoryColor, CategoryHandle, CpuDelta, FrameFlags, LibraryHandle, LibraryInfo,
     Marker, MarkerField, MarkerTiming, PlatformSpecificReferenceTimestamp, Profile,
-    ReferenceTimestamp, SamplingInterval, Schema, StringHandle, SubcategoryHandle, SymbolTable,
-    ThreadHandle,
+    ReferenceTimestamp, SamplingInterval, Schema, SourceLocation, StringHandle, SubcategoryHandle,
+    SymbolTable, ThreadHandle,
 };
 use linux_perf_data::linux_perf_event_reader::TaskWasPreempted;
 use linux_perf_data::simpleperf_dso_type::{DSO_DEX_FILE, DSO_KERNEL, DSO_KERNEL_MODULE};
@@ -224,9 +224,6 @@ where
 
     pub fn finish(mut self) -> Profile {
         let mut profile = self.profile;
-        self.simpleperf
-            .jit_app_cache_library
-            .finish_and_set_symbol_table(&mut profile);
         self.processes.finish(
             &mut profile,
             &self.unresolved_stacks,
@@ -1283,13 +1280,17 @@ where
             .get_simpleperf_jit_function_name(&path, address)
             .unwrap_or_else(|| (format!("jit_fun_{address:x}"), mapping_size as u32));
 
-        let process = self.processes.get_by_pid(e.pid, &mut self.profile);
         let synthetic_lib = &mut self.simpleperf.jit_app_cache_library;
-        let info = LibMappingInfo::new_java_mapping(
-            synthetic_lib.lib_handle(),
-            Some(synthetic_lib.default_category()),
-        );
-        process.add_jit_function(timestamp_raw, synthetic_lib, name, address, len, info);
+        let (lib_handle, default_category) =
+            (synthetic_lib.lib_handle(), synthetic_lib.default_category());
+        // We have no source information for these.
+        let symbol =
+            synthetic_lib.add_function(&name, len, SourceLocation::default(), &mut self.profile);
+        let info = LibMappingInfo::new_java_mapping(lib_handle, Some(default_category))
+            .with_jit_symbol(symbol);
+
+        let process = self.processes.get_by_pid(e.pid, &mut self.profile);
+        process.add_jit_function(timestamp_raw, symbol.symbol_address, address, len, info);
     }
 
     fn get_simpleperf_jit_function_name(

--- a/samply/src/linux_shared/process.rs
+++ b/samply/src/linux_shared/process.rs
@@ -314,7 +314,7 @@ where
         }
 
         let (category, js_frame) =
-            jit_category_manager.classify_jit_symbol(symbol_name.unwrap_or(""), profile);
+            jit_category_manager.classify_jit_symbol(symbol_name.unwrap_or(""), None, profile);
         self.lib_mapping_ops.push(
             timestamp,
             LibMappingOp::Add(LibMappingAdd {

--- a/samply/src/linux_shared/process.rs
+++ b/samply/src/linux_shared/process.rs
@@ -17,7 +17,6 @@ use crate::shared::marker_file::get_markers;
 use crate::shared::perf_map::try_load_perf_map;
 use crate::shared::process_sample_data::{MarkerSpanOnThread, ProcessSampleData};
 use crate::shared::recycling::{ProcessRecyclingData, ThreadRecycler};
-use crate::shared::synthetic_jit_library::SyntheticJitLibrary;
 use crate::shared::timestamp_converter::TimestampConverter;
 use crate::shared::unresolved_samples::UnresolvedSamples;
 
@@ -330,20 +329,17 @@ where
     pub fn add_jit_function(
         &mut self,
         timestamp_raw: u64,
-        jit_lib: &mut SyntheticJitLibrary,
-        name: String,
+        relative_address_at_start: u32,
         start_avma: u64,
         size: u32,
         info: LibMappingInfo,
     ) {
-        let relative_address = jit_lib.add_function(name, size);
-
         self.jit_app_cache_mapping_ops.push(
             timestamp_raw,
             LibMappingOp::Add(LibMappingAdd {
                 start_avma,
                 end_avma: start_avma + u64::from(size),
-                relative_address_at_start: relative_address,
+                relative_address_at_start,
                 info,
             }),
         );

--- a/samply/src/shared/jit_category_manager.rs
+++ b/samply/src/shared/jit_category_manager.rs
@@ -13,8 +13,14 @@ pub enum JsFrame {
 
 #[derive(Debug, Clone, Copy)]
 pub enum JsName {
-    SelfHosted(#[allow(dead_code)] StringHandle),
-    NonSelfHosted(StringHandle),
+    /// A function used in the implementation of built-in JS APIs such as
+    /// filter / map / RegExp.test etc. In SpiderMonkey these are "self-hosted"
+    /// JS functions; in V8 they're precompiled "builtins" that don't show up as
+    /// JS functions at all. We don't surface these as JS frames, so we don't
+    /// bother interning the name.
+    Builtin,
+    /// A JS function that is not shipped as part of a JS engine.
+    NonBuiltin(StringHandle),
 }
 
 #[derive(Debug, Clone)]
@@ -330,24 +336,21 @@ impl JitCategoryManager {
                 if after.is_empty() {
                     // Nothing is following the closing square bracket, in particular no filename.
                     // Example: "forEach[Call (StrictMode)]"
-                    // This is likely a self-hosted function.
-                    return JsName::SelfHosted(profile.handle_for_string(before));
+                    // This is likely a builtin function.
+                    return JsName::Builtin;
                 }
-                return JsName::NonSelfHosted(
-                    profile.handle_for_string(&format!("{before}{after}")),
-                );
+                return JsName::NonBuiltin(profile.handle_for_string(&format!("{before}{after}")));
             }
         }
 
-        let s = profile.handle_for_string(func_name);
-        match func_name.contains("(self-hosted:")
+        if func_name.contains("(self-hosted:")
             || func_name.contains(" self-hosted:")
             || func_name.ends_with("valueIsFalsey")
             || func_name.ends_with("valueIsTruthy")
         {
-            true => JsName::SelfHosted(s),
-            false => JsName::NonSelfHosted(s),
+            return JsName::Builtin;
         }
+        JsName::NonBuiltin(profile.handle_for_string(func_name))
     }
 }
 
@@ -393,7 +396,7 @@ mod test {
             &mut profile,
         );
         match js_name {
-            Some(JsFrame::RegularInAdditionToNativeFrame(JsName::NonSelfHosted(s))) => {
+            Some(JsFrame::RegularInAdditionToNativeFrame(JsName::NonBuiltin(s))) => {
                 assert_eq!(profile.get_string(s), "AccessibleButton (main.js:3560:25)")
             }
             _ => panic!(),

--- a/samply/src/shared/jit_category_manager.rs
+++ b/samply/src/shared/jit_category_manager.rs
@@ -1,10 +1,16 @@
 use fxprof_processed_profile::{
-    Category, CategoryColor, CategoryHandle, Profile, StringHandle, SubcategoryHandle,
+    Category, CategoryColor, CategoryHandle, Profile, SourceLocation, StringHandle,
+    SubcategoryHandle,
 };
 
 /// The script URL that SpiderMonkey reports for its built-in ("self-hosted")
 /// functions.
 const SELF_HOSTED_SCRIPT_URL: &str = "self-hosted";
+
+/// Convert a line / column number to `None` if it's the "unknown" sentinel 0.
+fn nonzero(line_or_col: u32) -> Option<u32> {
+    (line_or_col != 0).then_some(line_or_col)
+}
 
 /// The script a JIT'ed JS function was defined in, for data sources which report
 /// it out-of-band instead of baking it into the symbol name.
@@ -12,6 +18,26 @@ const SELF_HOSTED_SCRIPT_URL: &str = "self-hosted";
 pub struct JsScriptSource<'a> {
     /// The script URL, e.g. `https://example.com/app.js`.
     pub url: &'a str,
+    /// The 1-based line at which the function starts, or 0 if unknown.
+    pub function_start_line: u32,
+    /// The 1-based column at which the function starts, or 0 if unknown.
+    pub function_start_col: u32,
+}
+
+impl JsScriptSource<'_> {
+    /// The source location for a frame of this function, i.e. the script plus the
+    /// position the function starts at.
+    pub fn source_location(&self, profile: &mut Profile) -> SourceLocation {
+        SourceLocation {
+            file_path: Some(profile.handle_for_string(self.url)),
+            // We only know where the function starts, not which line inside it is
+            // executing in this frame.
+            line: None,
+            col: None,
+            function_start_line: nonzero(self.function_start_line),
+            function_start_col: nonzero(self.function_start_col),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -32,7 +58,14 @@ pub enum JsName {
     /// bother interning the name.
     Builtin,
     /// A JS function that is not shipped as part of a JS engine.
-    NonBuiltin(StringHandle),
+    NonBuiltin {
+        name: StringHandle,
+        /// Where the function was defined. Only populated for data sources which
+        /// report the script separately; for the JS engines that bake the script
+        /// location into the symbol name it stays empty, because there the
+        /// location is already part of `name`.
+        source_location: SourceLocation,
+    },
 }
 
 #[derive(Debug, Clone)]
@@ -343,11 +376,15 @@ impl JitCategoryManager {
     ) -> JsName {
         if let Some(script_source) = script_source {
             // The data source told us which script this function came from, so we
-            // don't have to guess.
+            // don't have to guess, and we can store the script as a real source
+            // location rather than appending it to the name.
             if script_source.url == SELF_HOSTED_SCRIPT_URL {
                 return JsName::Builtin;
             }
-            return JsName::NonBuiltin(profile.handle_for_string(func_name));
+            return JsName::NonBuiltin {
+                name: profile.handle_for_string(func_name),
+                source_location: script_source.source_location(profile),
+            };
         }
 
         if let Some((before, after)) = func_name
@@ -363,7 +400,10 @@ impl JitCategoryManager {
                     // This is likely a builtin function.
                     return JsName::Builtin;
                 }
-                return JsName::NonBuiltin(profile.handle_for_string(&format!("{before}{after}")));
+                return JsName::NonBuiltin {
+                    name: profile.handle_for_string(&format!("{before}{after}")),
+                    source_location: SourceLocation::default(),
+                };
             }
         }
 
@@ -375,7 +415,10 @@ impl JitCategoryManager {
         {
             return JsName::Builtin;
         }
-        JsName::NonBuiltin(profile.handle_for_string(func_name))
+        JsName::NonBuiltin {
+            name: profile.handle_for_string(func_name),
+            source_location: SourceLocation::default(),
+        }
     }
 }
 
@@ -416,6 +459,17 @@ mod test {
         )
     }
 
+    /// Unwrap a regular JS function frame into its name and source location.
+    fn unwrap_non_builtin(js_frame: Option<JsFrame>) -> (StringHandle, SourceLocation) {
+        match js_frame {
+            Some(JsFrame::RegularInAdditionToNativeFrame(JsName::NonBuiltin {
+                name,
+                source_location,
+            })) => (name, source_location),
+            other => panic!("expected a non-builtin JS function, got {other:?}"),
+        }
+    }
+
     #[test]
     fn test() {
         let mut manager = JitCategoryManager::new();
@@ -425,12 +479,14 @@ mod test {
             None,
             &mut profile,
         );
-        match js_name {
-            Some(JsFrame::RegularInAdditionToNativeFrame(JsName::NonBuiltin(s))) => {
-                assert_eq!(profile.get_string(s), "AccessibleButton (main.js:3560:25)")
-            }
-            _ => panic!(),
-        }
+        let (name, source_location) = unwrap_non_builtin(js_name);
+        assert_eq!(
+            profile.get_string(name),
+            "AccessibleButton (main.js:3560:25)"
+        );
+        // SpiderMonkey baked the location into the name, so there's nothing to
+        // put into the source location.
+        assert_eq!(source_location, SourceLocation::default());
     }
 
     /// SpiderMonkey bakes the script location into the symbol name when it isn't
@@ -454,14 +510,87 @@ mod test {
         let mut manager = JitCategoryManager::new();
         let mut profile = new_profile();
         let (_category, js_name) = manager.classify_jit_symbol(
-            "Ion: filter self-hosted:1234:5",
-            Some(JsScriptSource { url: "self-hosted" }),
+            "Ion: filter",
+            Some(JsScriptSource {
+                url: "self-hosted",
+                function_start_line: 1234,
+                function_start_col: 5,
+            }),
             &mut profile,
         );
         assert!(matches!(
             js_name,
             Some(JsFrame::RegularInAdditionToNativeFrame(JsName::Builtin))
         ));
+    }
+
+    /// A separately-reported script goes into the source location, and the name is
+    /// left alone.
+    #[test]
+    fn test_script_source_becomes_source_location() {
+        let mut manager = JitCategoryManager::new();
+        let mut profile = new_profile();
+        let (_category, js_name) = manager.classify_jit_symbol(
+            "Ion: doWork",
+            Some(JsScriptSource {
+                url: "https://example.com/app.js",
+                function_start_line: 12,
+                function_start_col: 3,
+            }),
+            &mut profile,
+        );
+        let (name, source_location) = unwrap_non_builtin(js_name);
+        assert_eq!(profile.get_string(name), "doWork");
+        assert_eq!(
+            source_location.file_path.map(|p| profile.get_string(p)),
+            Some("https://example.com/app.js")
+        );
+        assert_eq!(source_location.function_start_line, Some(12));
+        assert_eq!(source_location.function_start_col, Some(3));
+        // We know where the function starts, not which line is executing.
+        assert_eq!(source_location.line, None);
+        assert_eq!(source_location.col, None);
+    }
+
+    /// ETW reports line 0 when it doesn't know the position.
+    #[test]
+    fn test_script_source_without_position() {
+        let mut manager = JitCategoryManager::new();
+        let mut profile = new_profile();
+        let (_category, js_name) = manager.classify_jit_symbol(
+            "Ion: doWork",
+            Some(JsScriptSource {
+                url: "https://example.com/app.js",
+                function_start_line: 0,
+                function_start_col: 0,
+            }),
+            &mut profile,
+        );
+        let (_name, source_location) = unwrap_non_builtin(js_name);
+        assert!(source_location.file_path.is_some());
+        assert_eq!(source_location.function_start_line, None);
+        assert_eq!(source_location.function_start_col, None);
+    }
+
+    #[test]
+    fn test_source_location() {
+        let mut profile = new_profile();
+        let script_source = JsScriptSource {
+            url: "https://example.com/app.js",
+            function_start_line: 12,
+            function_start_col: 3,
+        };
+
+        let source_location = script_source.source_location(&mut profile);
+        assert_eq!(
+            source_location.file_path.map(|p| profile.get_string(p)),
+            Some("https://example.com/app.js")
+        );
+        assert_eq!(source_location.function_start_line, Some(12));
+        assert_eq!(source_location.function_start_col, Some(3));
+        // We know where the function starts, not which line is executing.
+        assert_eq!(source_location.line, None);
+        assert_eq!(source_location.col, None);
     }
 
     /// A regular script is never treated as builtin, even if the function name
@@ -471,18 +600,15 @@ mod test {
         let mut manager = JitCategoryManager::new();
         let mut profile = new_profile();
         let (_category, js_name) = manager.classify_jit_symbol(
-            "Ion: valueIsTruthy https://example.com/app.js:12:3",
+            "Ion: valueIsTruthy",
             Some(JsScriptSource {
                 url: "https://example.com/app.js",
+                function_start_line: 12,
+                function_start_col: 3,
             }),
             &mut profile,
         );
-        match js_name {
-            Some(JsFrame::RegularInAdditionToNativeFrame(JsName::NonBuiltin(s))) => assert_eq!(
-                profile.get_string(s),
-                "valueIsTruthy https://example.com/app.js:12:3"
-            ),
-            _ => panic!(),
-        }
+        let (name, _source_location) = unwrap_non_builtin(js_name);
+        assert_eq!(profile.get_string(name), "valueIsTruthy");
     }
 }

--- a/samply/src/shared/jit_category_manager.rs
+++ b/samply/src/shared/jit_category_manager.rs
@@ -341,6 +341,7 @@ impl JitCategoryManager {
 
         let s = profile.handle_for_string(func_name);
         match func_name.contains("(self-hosted:")
+            || func_name.contains(" self-hosted:")
             || func_name.ends_with("valueIsFalsey")
             || func_name.ends_with("valueIsTruthy")
         {

--- a/samply/src/shared/jit_category_manager.rs
+++ b/samply/src/shared/jit_category_manager.rs
@@ -264,17 +264,6 @@ impl JitCategoryManager {
             return (category.into(), None);
         }
 
-        if let Some(ion_ic_rest) = name.strip_prefix("IonIC: ") {
-            let category = self.ion_ic_category.get(profile);
-            if let Some((_ic_type, js_func)) = ion_ic_rest.split_once(" : ") {
-                let js_func = JsFrame::RegularInAdditionToNativeFrame(Self::handle_for_js_name(
-                    profile, js_func,
-                ));
-                return (category.into(), Some(js_func));
-            }
-            return (category.into(), None);
-        }
-
         for (&(prefix, _category, is_js), lazy_category_handle) in
             Self::CATEGORIES.iter().zip(self.categories.iter_mut())
         {

--- a/samply/src/shared/jit_category_manager.rs
+++ b/samply/src/shared/jit_category_manager.rs
@@ -2,6 +2,18 @@ use fxprof_processed_profile::{
     Category, CategoryColor, CategoryHandle, Profile, StringHandle, SubcategoryHandle,
 };
 
+/// The script URL that SpiderMonkey reports for its built-in ("self-hosted")
+/// functions.
+const SELF_HOSTED_SCRIPT_URL: &str = "self-hosted";
+
+/// The script a JIT'ed JS function was defined in, for data sources which report
+/// it out-of-band instead of baking it into the symbol name.
+#[derive(Debug, Clone, Copy)]
+pub struct JsScriptSource<'a> {
+    /// The script URL, e.g. `https://example.com/app.js`.
+    pub url: &'a str,
+}
+
 #[derive(Debug, Clone, Copy)]
 pub enum JsFrame {
     #[allow(dead_code)]
@@ -230,11 +242,16 @@ impl JitCategoryManager {
 
     /// Get the category and JS function name for a function from JIT code.
     ///
+    /// `script_source` is the script this function was defined in - pass `None`
+    /// if unavailable. (E.g. ETW has it separately from the name, jitdump has it
+    /// in the debug info (if present) but also puts it in the name.)
+    ///
     /// The category is only created in the profile once a function with that
     /// category is encountered.
     pub fn classify_jit_symbol(
         &mut self,
         name: &str,
+        script_source: Option<JsScriptSource<'_>>,
         profile: &mut Profile,
     ) -> (SubcategoryHandle, Option<JsFrame>) {
         if name == "BaselineInterpreter" || name.starts_with("BlinterpOp: ") {
@@ -245,8 +262,11 @@ impl JitCategoryManager {
         }
 
         if let Some(js_func) = name.strip_prefix("BaselineInterpreter: ") {
-            let js_func =
-                JsFrame::BaselineInterpreterStub(Self::handle_for_js_name(profile, js_func));
+            let js_func = JsFrame::BaselineInterpreterStub(Self::handle_for_js_name(
+                profile,
+                js_func,
+                script_source,
+            ));
             return (
                 self.baseline_interpreter_category.get(profile).into(),
                 Some(js_func),
@@ -257,7 +277,9 @@ impl JitCategoryManager {
             let category = self.ion_ic_category.get(profile);
             if let Some((_ic_type, js_func)) = ion_ic_rest.split_once(" : ") {
                 let js_func = JsFrame::RegularInAdditionToNativeFrame(Self::handle_for_js_name(
-                    profile, js_func,
+                    profile,
+                    js_func,
+                    script_source,
                 ));
                 return (category.into(), Some(js_func));
             }
@@ -272,7 +294,7 @@ impl JitCategoryManager {
 
                 let js_name = if is_js {
                     Some(JsFrame::RegularInAdditionToNativeFrame(
-                        Self::handle_for_js_name(profile, name_without_prefix),
+                        Self::handle_for_js_name(profile, name_without_prefix, script_source),
                     ))
                 } else {
                     None
@@ -300,7 +322,7 @@ impl JitCategoryManager {
                     let new_name = format!("{v8_wasm_name} (WASM:{func_index})");
                     let category = category.get(profile);
                     let js_func = JsFrame::RegularInAdditionToNativeFrame(
-                        Self::handle_for_js_name(profile, &new_name),
+                        Self::handle_for_js_name(profile, &new_name, script_source),
                     );
                     return (category.into(), Some(js_func));
                 }
@@ -314,7 +336,20 @@ impl JitCategoryManager {
         (category.into(), None)
     }
 
-    fn handle_for_js_name(profile: &mut Profile, func_name: &str) -> JsName {
+    fn handle_for_js_name(
+        profile: &mut Profile,
+        func_name: &str,
+        script_source: Option<JsScriptSource<'_>>,
+    ) -> JsName {
+        if let Some(script_source) = script_source {
+            // The data source told us which script this function came from, so we
+            // don't have to guess.
+            if script_source.url == SELF_HOSTED_SCRIPT_URL {
+                return JsName::Builtin;
+            }
+            return JsName::NonBuiltin(profile.handle_for_string(func_name));
+        }
+
         if let Some((before, after)) = func_name
             .split_once("[Call")
             .or_else(|| func_name.split_once("[Construct"))
@@ -332,8 +367,9 @@ impl JitCategoryManager {
             }
         }
 
+        // SpiderMonkey bakes the script location into the symbol name, so the
+        // built-in script shows up as e.g. "filter (self-hosted:1234:5)".
         if func_name.contains("(self-hosted:")
-            || func_name.contains(" self-hosted:")
             || func_name.ends_with("valueIsFalsey")
             || func_name.ends_with("valueIsTruthy")
         {
@@ -372,22 +408,80 @@ mod test {
 
     use super::*;
 
-    #[test]
-    fn test() {
-        let mut manager = JitCategoryManager::new();
-        let mut profile = Profile::new(
+    fn new_profile() -> Profile {
+        Profile::new(
             "",
             ReferenceTimestamp::from_millis_since_unix_epoch(0.0),
             SamplingInterval::from_millis(1),
-        );
+        )
+    }
+
+    #[test]
+    fn test() {
+        let mut manager = JitCategoryManager::new();
+        let mut profile = new_profile();
         let (_category, js_name) = manager.classify_jit_symbol(
             "IonIC: SetElem : AccessibleButton (main.js:3560:25)",
+            None,
             &mut profile,
         );
         match js_name {
             Some(JsFrame::RegularInAdditionToNativeFrame(JsName::NonBuiltin(s))) => {
                 assert_eq!(profile.get_string(s), "AccessibleButton (main.js:3560:25)")
             }
+            _ => panic!(),
+        }
+    }
+
+    /// SpiderMonkey bakes the script location into the symbol name when it isn't
+    /// reported separately, so we have to recognize it there.
+    #[test]
+    fn test_builtin_from_name() {
+        let mut manager = JitCategoryManager::new();
+        let mut profile = new_profile();
+        let (_category, js_name) =
+            manager.classify_jit_symbol("Ion: filter (self-hosted:1234:5)", None, &mut profile);
+        assert!(matches!(
+            js_name,
+            Some(JsFrame::RegularInAdditionToNativeFrame(JsName::Builtin))
+        ));
+    }
+
+    /// The Windows ETW path reports the script URL separately, so we don't have to
+    /// guess from the name.
+    #[test]
+    fn test_builtin_from_script_source() {
+        let mut manager = JitCategoryManager::new();
+        let mut profile = new_profile();
+        let (_category, js_name) = manager.classify_jit_symbol(
+            "Ion: filter self-hosted:1234:5",
+            Some(JsScriptSource { url: "self-hosted" }),
+            &mut profile,
+        );
+        assert!(matches!(
+            js_name,
+            Some(JsFrame::RegularInAdditionToNativeFrame(JsName::Builtin))
+        ));
+    }
+
+    /// A regular script is never treated as builtin, even if the function name
+    /// happens to look like one of SpiderMonkey's built-ins.
+    #[test]
+    fn test_regular_script_source_wins_over_name() {
+        let mut manager = JitCategoryManager::new();
+        let mut profile = new_profile();
+        let (_category, js_name) = manager.classify_jit_symbol(
+            "Ion: valueIsTruthy https://example.com/app.js:12:3",
+            Some(JsScriptSource {
+                url: "https://example.com/app.js",
+            }),
+            &mut profile,
+        );
+        match js_name {
+            Some(JsFrame::RegularInAdditionToNativeFrame(JsName::NonBuiltin(s))) => assert_eq!(
+                profile.get_string(s),
+                "valueIsTruthy https://example.com/app.js:12:3"
+            ),
             _ => panic!(),
         }
     }

--- a/samply/src/shared/jitdump_manager.rs
+++ b/samply/src/shared/jitdump_manager.rs
@@ -214,7 +214,7 @@ impl SingleJitDumpProcessor {
                         };
 
                     let (category, js_frame) =
-                        jit_category_manager.classify_jit_symbol(symbol_name, profile);
+                        jit_category_manager.classify_jit_symbol(symbol_name, None, profile);
                     self.lib_mapping_ops.push(
                         raw_jitdump_record.timestamp,
                         LibMappingOp::Add(LibMappingAdd {

--- a/samply/src/shared/lib_mappings.rs
+++ b/samply/src/shared/lib_mappings.rs
@@ -1,6 +1,8 @@
 use std::iter::Peekable;
 
-use fxprof_processed_profile::{LibMappings, LibraryHandle, SubcategoryHandle};
+use fxprof_processed_profile::{
+    LibMappings, LibraryHandle, SourceLocation, StringHandle, SubcategoryHandle,
+};
 
 use super::jit_category_manager::JsFrame;
 
@@ -10,6 +12,26 @@ pub struct LibMappingInfo {
     pub category: Option<SubcategoryHandle>,
     pub js_frame: Option<JsFrame>,
     pub art_info: Option<AndroidArtInfo>,
+    pub symbol: Option<JitSymbolInfo>,
+}
+
+/// The native symbol for a function in a synthetic JIT library.
+///
+/// JIT code has no symbol file to symbolicate against, so we know the symbol at
+/// the time we see the function, and we put it on the frame directly rather than
+/// going through a lib symbol table.
+#[derive(Debug, Clone, Copy)]
+pub struct JitSymbolInfo {
+    pub lib_handle: LibraryHandle,
+    pub name: StringHandle,
+    /// The symbol's start address, relative to the synthetic JIT library.
+    pub symbol_address: u32,
+    pub symbol_size: Option<u32>,
+    /// Source information for the native frames of this function.
+    ///
+    /// A prepended JS label frame carries its own, richer source location; this
+    /// one is just for the native frame.
+    pub source_location: SourceLocation,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -29,6 +51,7 @@ impl LibMappingInfo {
             category: None,
             js_frame: None,
             art_info: None,
+            symbol: None,
         }
     }
 
@@ -39,6 +62,7 @@ impl LibMappingInfo {
             category: Some(category),
             js_frame: None,
             art_info: None,
+            symbol: None,
         }
     }
 
@@ -52,6 +76,7 @@ impl LibMappingInfo {
             category: Some(category),
             js_frame,
             art_info: None,
+            symbol: None,
         }
     }
 
@@ -61,6 +86,7 @@ impl LibMappingInfo {
             category: None,
             js_frame: None,
             art_info: Some(AndroidArtInfo::LibArt),
+            symbol: None,
         }
     }
 
@@ -73,7 +99,15 @@ impl LibMappingInfo {
             category,
             js_frame: None,
             art_info: Some(AndroidArtInfo::JavaFrame),
+            symbol: None,
         }
+    }
+
+    /// Attach the native symbol for a function in a synthetic JIT library, so
+    /// that its frames don't need a lib symbol table to get their name.
+    pub fn with_jit_symbol(mut self, symbol: JitSymbolInfo) -> Self {
+        self.symbol = Some(symbol);
+        self
     }
 }
 

--- a/samply/src/shared/perf_map.rs
+++ b/samply/src/shared/perf_map.rs
@@ -94,7 +94,8 @@ pub fn try_load_perf_map(
             (lib_handle, relative_address)
         };
 
-        let (category, js_frame) = jit_category_manager.classify_jit_symbol(symbol_name, profile);
+        let (category, js_frame) =
+            jit_category_manager.classify_jit_symbol(symbol_name, None, profile);
 
         // Add this function to the JIT lib mappings so that it can be consulted for
         // category information, JS function prepending, and to translate the absolute

--- a/samply/src/shared/stack_converter.rs
+++ b/samply/src/shared/stack_converter.rs
@@ -276,12 +276,20 @@ impl<I: Iterator<Item = SecondPassFrameInfo>> ConvertedStackIterD<I> {
             }
             None => profile.handle_for_frame_with_address(location, category, frame_flags),
         };
-        if let Some(JsName::NonBuiltin(js_name)) = extra_js_name {
+        if let Some(JsName::NonBuiltin {
+            name,
+            source_location,
+        }) = extra_js_name
+        {
             // Prepend a JS frame.
             // We don't treat builtin functions as JS (e.g. filter/map/push), which
             // SpiderMonkey calls "self-hosted" functions.
-            let prepended_js_frame =
-                profile.handle_for_frame_with_label(js_name, category, FrameFlags::IS_JS);
+            let prepended_js_frame = profile.handle_for_frame_with_label_and_source_location(
+                name,
+                source_location,
+                category,
+                FrameFlags::IS_JS,
+            );
             let buffered_frame = std::mem::replace(&mut frame_handle, prepended_js_frame);
             self.pending_frame_handle = Some(buffered_frame);
         };

--- a/samply/src/shared/stack_converter.rs
+++ b/samply/src/shared/stack_converter.rs
@@ -2,11 +2,12 @@ use std::collections::VecDeque;
 use std::iter::{Cloned, Rev};
 
 use fxprof_processed_profile::{
-    FrameAddress, FrameFlags, FrameHandle, ProcessHandle, Profile, SubcategoryHandle,
+    FrameAddress, FrameFlags, FrameHandle, FrameSymbolInfo, ProcessHandle, Profile,
+    SubcategoryHandle,
 };
 
 use super::jit_category_manager::{JsFrame, JsName};
-use super::lib_mappings::{AndroidArtInfo, LibMappingsHierarchy};
+use super::lib_mappings::{AndroidArtInfo, JitSymbolInfo, LibMappingsHierarchy};
 use super::types::{StackFrame, StackMode};
 
 #[derive(Debug)]
@@ -28,6 +29,7 @@ struct SecondPassFrameInfo {
     category: SubcategoryHandle,
     js_frame: Option<JsFrame>,
     art_info: Option<AndroidArtInfo>,
+    symbol: Option<JitSymbolInfo>,
 }
 
 struct FirstPassIter<I: Iterator<Item = StackFrame>>(I);
@@ -100,7 +102,7 @@ impl<I: Iterator<Item = FirstPassFrameInfo>> Iterator for SecondPassIter<'_, I> 
             lookup_address,
             from_ip,
         } = self.inner.next()?;
-        let (location, category, js_frame, art_info) = match mode {
+        let (location, category, js_frame, art_info, symbol) = match mode {
             StackMode::User => match self.lib_mappings.convert_address(lookup_address) {
                 Some((relative_lookup_address, info)) => {
                     let location = if from_ip {
@@ -120,6 +122,7 @@ impl<I: Iterator<Item = FirstPassFrameInfo>> Iterator for SecondPassIter<'_, I> 
                         info.category.unwrap_or(self.user_category),
                         info.js_frame,
                         info.art_info,
+                        info.symbol,
                     )
                 }
                 None => {
@@ -128,7 +131,7 @@ impl<I: Iterator<Item = FirstPassFrameInfo>> Iterator for SecondPassIter<'_, I> 
                         true => FrameAddress::InstructionPointer(p, lookup_address),
                         false => FrameAddress::AdjustedReturnAddress(p, lookup_address),
                     };
-                    (location, self.user_category, None, None)
+                    (location, self.user_category, None, None, None)
                 }
             },
             StackMode::Kernel => {
@@ -136,7 +139,7 @@ impl<I: Iterator<Item = FirstPassFrameInfo>> Iterator for SecondPassIter<'_, I> 
                     true => FrameAddress::KernelInstructionPointer(lookup_address),
                     false => FrameAddress::KernelAdjustedReturnAddress(lookup_address),
                 };
-                (location, self.kernel_category, None, None)
+                (location, self.kernel_category, None, None, None)
             }
         };
         Some(SecondPassFrameInfo {
@@ -144,6 +147,7 @@ impl<I: Iterator<Item = FirstPassFrameInfo>> Iterator for SecondPassIter<'_, I> 
             category,
             js_frame,
             art_info,
+            symbol,
         })
     }
 }
@@ -211,6 +215,7 @@ impl<I: Iterator<Item = SecondPassFrameInfo>> ConvertedStackIterD<I> {
             location,
             category,
             js_frame,
+            symbol,
             ..
         } = self.inner.next()?;
 
@@ -245,8 +250,32 @@ impl<I: Iterator<Item = SecondPassFrameInfo>> ConvertedStackIterD<I> {
             None => None,
         };
 
-        let mut frame_handle =
-            profile.handle_for_frame_with_address(location, category, frame_flags);
+        // JIT code has no symbol file, so if we know the function's symbol we put it
+        // on the frame directly. Other libraries get symbolicated later, from their
+        // address.
+        let mut frame_handle = match symbol {
+            Some(symbol) => {
+                let native_symbol = profile.handle_for_native_symbol(
+                    symbol.lib_handle,
+                    symbol.symbol_address,
+                    symbol.symbol_size,
+                    symbol.name,
+                );
+                profile.handle_for_frame_with_address_and_symbol(
+                    location,
+                    FrameSymbolInfo {
+                        // Use the native symbol's name.
+                        name: None,
+                        native_symbol,
+                        source_location: symbol.source_location,
+                    },
+                    0,
+                    category,
+                    frame_flags,
+                )
+            }
+            None => profile.handle_for_frame_with_address(location, category, frame_flags),
+        };
         if let Some(JsName::NonBuiltin(js_name)) = extra_js_name {
             // Prepend a JS frame.
             // We don't treat builtin functions as JS (e.g. filter/map/push), which

--- a/samply/src/shared/stack_converter.rs
+++ b/samply/src/shared/stack_converter.rs
@@ -247,9 +247,10 @@ impl<I: Iterator<Item = SecondPassFrameInfo>> ConvertedStackIterD<I> {
 
         let mut frame_handle =
             profile.handle_for_frame_with_address(location, category, frame_flags);
-        if let Some(JsName::NonSelfHosted(js_name)) = extra_js_name {
+        if let Some(JsName::NonBuiltin(js_name)) = extra_js_name {
             // Prepend a JS frame.
-            // We don't treat Spidermonkey "self-hosted" functions as JS (e.g. filter/map/push).
+            // We don't treat builtin functions as JS (e.g. filter/map/push), which
+            // SpiderMonkey calls "self-hosted" functions.
             let prepended_js_frame =
                 profile.handle_for_frame_with_label(js_name, category, FrameFlags::IS_JS);
             let buffered_frame = std::mem::replace(&mut frame_handle, prepended_js_frame);

--- a/samply/src/shared/synthetic_jit_library.rs
+++ b/samply/src/shared/synthetic_jit_library.rs
@@ -1,10 +1,9 @@
-use std::sync::Arc;
-
 use debugid::DebugId;
 use fxprof_processed_profile::{
-    LibraryHandle, LibraryInfo, Profile, SubcategoryHandle, Symbol, SymbolTable,
+    LibraryHandle, LibraryInfo, Profile, SourceLocation, StringHandle, SubcategoryHandle,
 };
 
+use super::lib_mappings::JitSymbolInfo;
 use super::types::FastHashMap;
 
 #[derive(Debug)]
@@ -12,8 +11,7 @@ pub struct SyntheticJitLibrary {
     lib_handle: LibraryHandle,
     default_category: SubcategoryHandle,
     next_relative_address: u32,
-    symbols: Vec<Symbol>,
-    recycler: Option<FastHashMap<(String, u32), u32>>,
+    recycler: Option<FastHashMap<(StringHandle, u32), u32>>,
 }
 
 impl SyntheticJitLibrary {
@@ -41,37 +39,45 @@ impl SyntheticJitLibrary {
             lib_handle,
             default_category,
             next_relative_address: 0,
-            symbols: Vec::new(),
             recycler,
         }
     }
 
-    /// Returns the relative address of the added function.
-    pub fn add_function(&mut self, name: String, size: u32) -> u32 {
-        if let Some(recycler) = self.recycler.as_mut() {
-            let key = (name, size);
-            if let Some(relative_address) = recycler.get(&key) {
-                return *relative_address;
-            }
-            let relative_address = self.next_relative_address;
-            self.next_relative_address += size;
-            self.symbols.push(Symbol {
-                address: relative_address,
-                size: Some(size),
-                name: key.0.clone(),
-            });
-            recycler.insert(key, relative_address);
-            relative_address
-        } else {
-            let relative_address = self.next_relative_address;
-            self.next_relative_address += size;
-            self.symbols.push(Symbol {
-                address: relative_address,
-                size: Some(size),
-                name,
-            });
-            relative_address
+    /// Add a function to this library and return its native symbol.
+    ///
+    /// `source_location` ends up on the native frames for this function. If a JS
+    /// label frame gets prepended to those frames, that label frame carries its
+    /// own source location instead.
+    pub fn add_function(
+        &mut self,
+        name: &str,
+        size: u32,
+        source_location: SourceLocation,
+        profile: &mut Profile,
+    ) -> JitSymbolInfo {
+        let name = profile.handle_for_string(name);
+        let symbol_address = self.relative_address_for_function(name, size);
+        JitSymbolInfo {
+            lib_handle: self.lib_handle,
+            name,
+            symbol_address,
+            symbol_size: Some(size),
+            source_location,
         }
+    }
+
+    fn relative_address_for_function(&mut self, name: StringHandle, size: u32) -> u32 {
+        if let Some(recycler) = &self.recycler {
+            if let Some(&relative_address) = recycler.get(&(name, size)) {
+                return relative_address;
+            }
+        }
+        let relative_address = self.next_relative_address;
+        self.next_relative_address += size;
+        if let Some(recycler) = &mut self.recycler {
+            recycler.insert((name, size), relative_address);
+        }
+        relative_address
     }
 
     pub fn lib_handle(&self) -> LibraryHandle {
@@ -80,10 +86,5 @@ impl SyntheticJitLibrary {
 
     pub fn default_category(&self) -> SubcategoryHandle {
         self.default_category
-    }
-
-    pub fn finish_and_set_symbol_table(self, profile: &mut Profile) {
-        let symbol_table = Arc::new(SymbolTable::new(self.symbols));
-        profile.set_lib_symbol_table(self.lib_handle, symbol_table);
     }
 }

--- a/samply/src/windows/profile_context.rs
+++ b/samply/src/windows/profile_context.rs
@@ -1728,24 +1728,27 @@ impl ProfileContext {
         // profile data. Or even just leave the name alone - and if there's a source,
         // put that in to the function's source information, otherwise the function just
         // gets no source information.
-        let has_source = if let Some(url) = process.js_sources.get(&source_id) {
+        let script_source = process
+            .js_sources
+            .get(&source_id)
+            .map(|url| JsScriptSource { url });
+        if let Some(script_source) = script_source {
             use std::fmt::Write;
-            write!(&mut method_name, " {url}").unwrap();
+            write!(&mut method_name, " {}", script_source.url).unwrap();
             if line != 0 {
                 write!(&mut method_name, ":{line}:{column}").unwrap();
             }
-            true
-        } else {
-            false
-        };
+        }
 
         // The name prefix gives us the JIT tier / category. Names without a known
         // prefix fall back to the generic JIT category, which is also what
         // self.js_jit_lib defaults to.
-        let (category, mut js_frame) = self
-            .js_category_manager
-            .classify_jit_symbol(&method_name, &mut self.profile);
-        if js_frame.is_none() && has_source {
+        let (category, mut js_frame) = self.js_category_manager.classify_jit_symbol(
+            &method_name,
+            script_source,
+            &mut self.profile,
+        );
+        if js_frame.is_none() && script_source.is_some() {
             // Stock Chrome / Edge emit the bare function name, with no prefix to
             // classify. We classify a method with a script source as a JS function
             // regardless.

--- a/samply/src/windows/profile_context.rs
+++ b/samply/src/windows/profile_context.rs
@@ -6,8 +6,8 @@ use debugid::DebugId;
 use fxprof_processed_profile::{
     Category, CategoryColor, CategoryHandle, CounterDisplayConfig, CounterHandle, CpuDelta,
     FrameFlags, LibraryHandle, LibraryInfo, Marker, MarkerField, MarkerHandle, MarkerLocations,
-    MarkerTiming, ProcessHandle, Profile, SamplingInterval, Schema, StringHandle, ThreadHandle,
-    Timestamp,
+    MarkerTiming, ProcessHandle, Profile, SamplingInterval, Schema, SourceLocation, StringHandle,
+    ThreadHandle, Timestamp,
 };
 use shlex::Shlex;
 use wholesym::PeCodeId;
@@ -337,24 +337,20 @@ impl Process {
         })
     }
 
-    #[allow(clippy::too_many_arguments)]
     pub fn add_jit_function(
         &mut self,
         timestamp_raw: u64,
-        jit_lib: &mut SyntheticJitLibrary,
-        name: String,
+        relative_address_at_start: u32,
         start_avma: u64,
         size: u32,
         info: LibMappingInfo,
     ) {
-        let relative_address = jit_lib.add_function(name, size);
-
         self.jit_lib_mapping_ops.push(
             timestamp_raw,
             LibMappingOp::Add(LibMappingAdd {
                 start_avma,
                 end_avma: start_avma + u64::from(size),
-                relative_address_at_start: relative_address,
+                relative_address_at_start,
                 info,
             }),
         );
@@ -1756,8 +1752,14 @@ impl ProfileContext {
             js_frame = Some(JsFrame::NativeFrameIsJs);
         }
 
-        let lib = &mut self.js_jit_lib;
-        let info = LibMappingInfo::new_jit_function(lib.lib_handle(), category, js_frame);
+        let symbol = self.js_jit_lib.add_function(
+            &method_name,
+            method_size,
+            SourceLocation::default(),
+            &mut self.profile,
+        );
+        let info = LibMappingInfo::new_jit_function(symbol.lib_handle, category, js_frame)
+            .with_jit_symbol(symbol);
 
         if self.profile_creation_props.should_emit_jit_markers {
             let name_handle = self.profile.handle_for_string(&method_name);
@@ -1771,8 +1773,7 @@ impl ProfileContext {
 
         process.add_jit_function(
             timestamp_raw,
-            lib,
-            method_name,
+            symbol.symbol_address,
             method_start_address,
             method_size,
             info,
@@ -1791,13 +1792,20 @@ impl ProfileContext {
             return;
         };
 
-        let lib = &mut self.coreclr_jit_lib;
-        let info = LibMappingInfo::new_jit_function(lib.lib_handle(), lib.default_category(), None);
+        let default_category = self.coreclr_jit_lib.default_category();
+        // CoreCLR doesn't give us any source information.
+        let symbol = self.coreclr_jit_lib.add_function(
+            &method_name,
+            method_size,
+            SourceLocation::default(),
+            &mut self.profile,
+        );
+        let info = LibMappingInfo::new_jit_function(symbol.lib_handle, default_category, None)
+            .with_jit_symbol(symbol);
 
         process.add_jit_function(
             timestamp_raw,
-            lib,
-            method_name,
+            symbol.symbol_address,
             method_start_address,
             method_size,
             info,
@@ -2021,17 +2029,14 @@ impl ProfileContext {
 
     pub fn finish(mut self) -> Profile {
         // Push queued samples into the profile.
-        // We queue them so that we can get symbolicated JIT function names. To get symbolicated JIT function names,
-        // we have to call profile.add_sample after we call profile.set_lib_symbol_table, and we don't have the
-        // complete JIT symbol table before we've seen all JIT symbols.
-        // (This is a rather weak justification. The better justification is that this is consistent with what
-        // samply does on Linux and macOS, where the queued samples also want to respect JIT function names from
-        // a /tmp/perf-1234.map file, and this file may not exist until the profiled process finishes.)
+        // We queue them so that this is consistent with what samply does on Linux and macOS,
+        // where the queued samples want to respect JIT function names from a
+        // /tmp/perf-1234.map file, and this file may not exist until the profiled process
+        // finishes.
+        // (JIT function names used to be another reason: they arrived via a lib symbol table
+        // which wasn't complete until we'd seen all JIT symbols. These days each JIT frame
+        // carries its own native symbol, so that reason is gone.)
         let mut stack_frame_scratch_buf = Vec::new();
-        self.js_jit_lib
-            .finish_and_set_symbol_table(&mut self.profile);
-        self.coreclr_jit_lib
-            .finish_and_set_symbol_table(&mut self.profile);
         let process_sample_datas = self.processes.finish();
 
         let user_category = self.categories.get(KnownCategory::User, &mut self.profile);

--- a/samply/src/windows/profile_context.rs
+++ b/samply/src/windows/profile_context.rs
@@ -18,7 +18,7 @@ use crate::shared::context_switch::{
     ContextSwitchHandler, OffCpuSampleGroup, ThreadContextSwitchData,
 };
 use crate::shared::included_processes::IncludedProcesses;
-use crate::shared::jit_category_manager::{JitCategoryManager, JsFrame};
+use crate::shared::jit_category_manager::{JitCategoryManager, JsFrame, JsScriptSource};
 use crate::shared::jit_function_add_marker::JitFunctionAddMarker;
 use crate::shared::jit_function_recycler::JitFunctionRecycler;
 use crate::shared::lib_mappings::{LibMappingAdd, LibMappingInfo, LibMappingOp, LibMappingOpQueue};
@@ -1700,7 +1700,7 @@ impl ProfileContext {
         &mut self,
         timestamp_raw: u64,
         pid: u32,
-        mut method_name: String,
+        method_name: String,
         method_start_address: u64,
         method_size: u32,
         source_id: u64,
@@ -1711,7 +1711,11 @@ impl ProfileContext {
             return;
         };
 
-        // If we have a script URL, make sure it's appended to the end of the name.
+        // We leave the name alone, and store the script URL and the function's start
+        // line + column as proper source information on the frames. This differs from
+        // the other platforms, where the JS engine bakes the location into the name
+        // and we have no way to separate the two back out.
+        //
         // We need to handle these cases:
         // - `myFun` + sourceID (Chrome)
         // - `RegExp.< src: 'x' flags: ''` with no sourceID (Chrome)
@@ -1719,26 +1723,16 @@ impl ProfileContext {
         // - `Ion: myFun` + sourceID (new Firefox)
         // - `Trampoline: MegamorphicLoadPermissive` with no sourceID (old + new Firefox)
         //
-        // Putting the URL in the name is consistent with what happens on other
-        // platforms, where JS engines put the URL and the function's start line +
-        // column into the name.
-        //
-        // In the future we may want to do the reverse instead: Strip the URL from the
-        // name if present, and store the information in the appropriate place in the
-        // profile data. Or even just leave the name alone - and if there's a source,
-        // put that in to the function's source information, otherwise the function just
-        // gets no source information.
+        // Only the cases with a sourceID get source information; for the others the
+        // location either stays in the name (old Firefox) or doesn't exist at all.
         let script_source = process
             .js_sources
             .get(&source_id)
-            .map(|url| JsScriptSource { url });
-        if let Some(script_source) = script_source {
-            use std::fmt::Write;
-            write!(&mut method_name, " {}", script_source.url).unwrap();
-            if line != 0 {
-                write!(&mut method_name, ":{line}:{column}").unwrap();
-            }
-        }
+            .map(|url| JsScriptSource {
+                url,
+                function_start_line: line,
+                function_start_col: column,
+            });
 
         // The name prefix gives us the JIT tier / category. Names without a known
         // prefix fall back to the generic JIT category, which is also what
@@ -1755,10 +1749,17 @@ impl ProfileContext {
             js_frame = Some(JsFrame::NativeFrameIsJs);
         }
 
+        // The native frame gets the same source location as the JS label frame which
+        // may be prepended to it.
+        let source_location = match script_source {
+            Some(script_source) => script_source.source_location(&mut self.profile),
+            None => SourceLocation::default(),
+        };
+
         let symbol = self.js_jit_lib.add_function(
             &method_name,
             method_size,
-            SourceLocation::default(),
+            source_location,
             &mut self.profile,
         );
         let info = LibMappingInfo::new_jit_function(symbol.lib_handle, category, js_frame)


### PR DESCRIPTION
This makes it so that the source location ends up as an actual source location, rather than appended to the function name.

It also fixes the regression from #860 which caused Spidermonkey self-hosted functions to be marked as JS.