### PR TITLE
Emit processed profile format version 70.

### DIFF
--- a/fxprof-processed-profile/src/frame_table.rs
+++ b/fxprof-processed-profile/src/frame_table.rs
@@ -72,6 +72,7 @@ impl FrameInterner {
         let mut line_col = Vec::with_capacity(len);
         let mut column_col = Vec::with_capacity(len);
         let mut address_col = Vec::with_capacity(len);
+        let mut lib_col = Vec::with_capacity(len);
         let mut native_symbol_col = Vec::with_capacity(len);
         let mut inline_depth_col = Vec::with_capacity(len);
 
@@ -93,16 +94,18 @@ impl FrameInterner {
             match frame.variant {
                 InternalFrameVariant::Label => {
                     address_col.push(-1);
+                    lib_col.push(-1);
                     native_symbol_col.push(None);
                     inline_depth_col.push(0);
                 }
                 InternalFrameVariant::Native(NativeFrameData {
+                    lib,
                     native_symbol,
                     relative_address,
                     inline_depth,
-                    ..
                 }) => {
                     address_col.push(relative_address as i32);
+                    lib_col.push(lib.as_i32());
                     native_symbol_col.push(native_symbol);
                     inline_depth_col.push(inline_depth.min(u8::MAX as u16) as u8);
                 }
@@ -116,6 +119,7 @@ impl FrameInterner {
             line_col,
             column_col,
             address_col,
+            lib_col,
             native_symbol_col,
             inline_depth_col,
         };
@@ -136,6 +140,7 @@ pub struct FrameTable {
     line_col: Vec<Option<u32>>,
     column_col: Vec<Option<u32>>,
     address_col: Vec<i32>, // relative address, `-1` if None
+    lib_col: Vec<i32>,     // GlobalLibIndex, `-1` if None
     native_symbol_col: Vec<Option<NativeSymbolIndex>>,
     inline_depth_col: Vec<u8>,
 }
@@ -171,6 +176,8 @@ impl FrameTable {
             w.optional_number_array(&self.column_col)?;
             w.name("address")?;
             w.i32_array(&self.address_col)?;
+            w.name("lib")?;
+            w.i32_array(&self.lib_col)?;
             w.name("nativeSymbol")?;
             w.array(|w| {
                 for n in &self.native_symbol_col {

--- a/fxprof-processed-profile/src/global_lib_table.rs
+++ b/fxprof-processed-profile/src/global_lib_table.rs
@@ -123,6 +123,10 @@ impl GlobalLibIndex {
         self.1
     }
 
+    pub(crate) fn as_i32(self) -> i32 {
+        self.0 as i32
+    }
+
     pub(crate) fn write_json<W: Write>(self, w: &mut Writer<W>) -> std::io::Result<()> {
         w.number_value(self.0 as u32)
     }

--- a/fxprof-processed-profile/src/markers/serialization.rs
+++ b/fxprof-processed-profile/src/markers/serialization.rs
@@ -43,6 +43,9 @@ pub(super) fn write_schema_display<W: Write>(
         if locations.contains(MarkerLocations::TIMELINE_FILEIO) {
             w.string_value("timeline-fileio")?;
         }
+        if locations.contains(MarkerLocations::TIMELINE_NETWORK) {
+            w.string_value("timeline-network")?;
+        }
         Ok(())
     })
 }

--- a/fxprof-processed-profile/src/markers/types.rs
+++ b/fxprof-processed-profile/src/markers/types.rs
@@ -94,6 +94,8 @@ bitflags! {
         const TIMELINE_IPC = 1 << 4;
         /// This adds markers to the FileIO timeline area in the header.
         const TIMELINE_FILEIO = 1 << 5;
+        /// This adds markers to the Network track.
+        const TIMELINE_NETWORK = 1 << 6;
     }
 }
 

--- a/fxprof-processed-profile/src/profile.rs
+++ b/fxprof-processed-profile/src/profile.rs
@@ -1506,7 +1506,7 @@ impl Profile {
             w.name("interval")?;
             w.fp(self.interval.as_secs_f64() * 1000.0)?;
             w.name("preprocessedProfileVersion")?;
-            w.number_value(68u32)?;
+            w.number_value(70u32)?;
             w.name("processType")?;
             w.number_value(0u32)?;
             w.name("product")?;

--- a/fxprof-processed-profile/src/resource_table.rs
+++ b/fxprof-processed-profile/src/resource_table.rs
@@ -7,18 +7,15 @@ use crate::writer::Writer;
 
 #[derive(Debug, Clone, Default)]
 pub struct ResourceTable {
-    resource_libs: Vec<GlobalLibIndex>,
     resource_names: Vec<StringHandle>,
     lib_to_resource: FastHashMap<GlobalLibIndex, ResourceIndex>,
 }
 
 impl ResourceTable {
     pub fn resource_for_lib(&mut self, lib_index: GlobalLibIndex) -> ResourceIndex {
-        let resource_libs = &mut self.resource_libs;
         let resource_names = &mut self.resource_names;
         *self.lib_to_resource.entry(lib_index).or_insert_with(|| {
-            let resource = ResourceIndex(resource_libs.len() as u32);
-            resource_libs.push(lib_index);
+            let resource = ResourceIndex(resource_names.len() as u32);
             resource_names.push(lib_index.name_string_index());
             resource
         })
@@ -26,17 +23,10 @@ impl ResourceTable {
 
     pub(crate) fn write_json<W: Write>(&self, w: &mut Writer<W>) -> std::io::Result<()> {
         const RESOURCE_TYPE_LIB: u32 = 1;
-        let len = self.resource_libs.len();
+        let len = self.resource_names.len();
         w.object(|w| {
             w.name("length")?;
             w.number_value(len)?;
-            w.name("lib")?;
-            w.array(|w| {
-                for lib in &self.resource_libs {
-                    lib.write_json(w)?;
-                }
-                Ok(())
-            })?;
             w.name("name")?;
             w.array(|w| {
                 for name in &self.resource_names {

--- a/fxprof-processed-profile/tests/integration_tests/snapshots/integration_tests__flow_marker_fields.snap
+++ b/fxprof-processed-profile/tests/integration_tests/snapshots/integration_tests__flow_marker_fields.snap
@@ -47,7 +47,7 @@ expression: profile_as_json_value(&profile)
       }
     ],
     "pausedRanges": [],
-    "preprocessedProfileVersion": 68,
+    "preprocessedProfileVersion": 70,
     "processType": 0,
     "product": "test",
     "sampleUnits": {
@@ -72,6 +72,7 @@ expression: profile_as_json_value(&profile)
       "inlineDepth": [],
       "innerWindowID": [],
       "length": 0,
+      "lib": [],
       "line": [],
       "nativeSymbol": [],
       "originalLocation": [],
@@ -98,7 +99,6 @@ expression: profile_as_json_value(&profile)
     "resourceTable": {
       "host": [],
       "length": 0,
-      "lib": [],
       "name": [],
       "type": []
     },

--- a/fxprof-processed-profile/tests/integration_tests/snapshots/integration_tests__profile_counters_with_sorted_processes.snap
+++ b/fxprof-processed-profile/tests/integration_tests/snapshots/integration_tests__profile_counters_with_sorted_processes.snap
@@ -144,7 +144,7 @@ expression: profile_as_json_value(&profile)
     "interval": 1,
     "markerSchema": [],
     "pausedRanges": [],
-    "preprocessedProfileVersion": 68,
+    "preprocessedProfileVersion": 70,
     "processType": 0,
     "product": "test",
     "sampleUnits": {
@@ -169,6 +169,7 @@ expression: profile_as_json_value(&profile)
       "inlineDepth": [],
       "innerWindowID": [],
       "length": 0,
+      "lib": [],
       "line": [],
       "nativeSymbol": [],
       "originalLocation": [],
@@ -195,7 +196,6 @@ expression: profile_as_json_value(&profile)
     "resourceTable": {
       "host": [],
       "length": 0,
-      "lib": [],
       "name": [],
       "type": []
     },

--- a/fxprof-processed-profile/tests/integration_tests/snapshots/integration_tests__profile_with_js.snap
+++ b/fxprof-processed-profile/tests/integration_tests/snapshots/integration_tests__profile_with_js.snap
@@ -33,7 +33,7 @@ expression: profile_as_json_value(&profile)
     "interval": 1,
     "markerSchema": [],
     "pausedRanges": [],
-    "preprocessedProfileVersion": 68,
+    "preprocessedProfileVersion": 70,
     "processType": 0,
     "product": "test with js",
     "sampleUnits": {
@@ -76,6 +76,10 @@ expression: profile_as_json_value(&profile)
         0
       ],
       "length": 2,
+      "lib": [
+        -1,
+        -1
+      ],
       "line": [
         null,
         null
@@ -138,7 +142,6 @@ expression: profile_as_json_value(&profile)
     "resourceTable": {
       "host": [],
       "length": 0,
-      "lib": [],
       "name": [],
       "type": []
     },

--- a/fxprof-processed-profile/tests/integration_tests/snapshots/integration_tests__profile_without_js.snap
+++ b/fxprof-processed-profile/tests/integration_tests/snapshots/integration_tests__profile_without_js.snap
@@ -170,7 +170,7 @@ expression: profile_as_json_value(&profile)
     ],
     "oscpu": "macOS 14.4",
     "pausedRanges": [],
-    "preprocessedProfileVersion": 68,
+    "preprocessedProfileVersion": 70,
     "processType": 0,
     "product": "test",
     "sampleUnits": {
@@ -297,6 +297,24 @@ expression: profile_as_json_value(&profile)
         0
       ],
       "length": 16,
+      "lib": [
+        -1,
+        0,
+        0,
+        0,
+        0,
+        0,
+        1,
+        1,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        1
+      ],
       "line": [
         null,
         null,
@@ -546,10 +564,6 @@ expression: profile_as_json_value(&profile)
         null
       ],
       "length": 2,
-      "lib": [
-        0,
-        1
-      ],
       "name": [
         1,
         7


### PR DESCRIPTION
See [CHANGELOG-formats.md](https://github.com/firefox-devtools/profiler/blob/main/docs-developer/CHANGELOG-formats.md#version-70):
- v69 adds schema display location `timeline-network`
- v70 lets frames specify a lib per frame and multiple frames from different libs to use the same func